### PR TITLE
Add extended roll command for accumulating successes

### DIFF
--- a/game/templates/game/scene/commands.html
+++ b/game/templates/game/scene/commands.html
@@ -41,6 +41,12 @@
                                 <td data-label="Explanation" style="padding: 16px; text-align: left; vertical-align: middle;">Runs the /roll command num_rolls times. Can be used at the end of a post.<br><strong>Warning</strong>: this will roll until botching or finished and increases difficulty on failures automatically.</td>
                             </tr>
                             <tr>
+                                <td data-label="Command" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/extended</code></td>
+                                <td data-label="Example" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/extended 5 target 10 difficulty 7 True</code></td>
+                                <td data-label="Syntax" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/extended &lt;num_dice&gt; target &lt;target_successes&gt; difficulty &lt;diff&gt; &lt;specialty&gt;</code></td>
+                                <td data-label="Explanation" style="padding: 16px; text-align: left; vertical-align: middle;">Extended roll that accumulates successes until reaching the target number. Keeps rolling until target is reached or a botch occurs. Shows each roll and cumulative total. Difficulty and specialty are optional (default: 6 and False).</td>
+                            </tr>
+                            <tr>
                                 <td data-label="Command" style="padding: 16px; text-align: center; vertical-align: middle;"><code>Tags</code></td>
                                 <td data-label="Example" style="padding: 16px; text-align: center; vertical-align: middle;"><code>&lt;b&gt&lt;/b&gt etc</code></td>
                                 <td data-label="Syntax" style="padding: 16px; text-align: center; vertical-align: middle;"><code>As HTML</code></td>


### PR DESCRIPTION
Implements /extended command for Posts and Scenes that performs dice rolls
until a target number of total successes is reached. This is useful for
complex tasks that require multiple rolls to complete.

Features:
- Syntax: /extended <dice> target <successes> [difficulty <diff>] [specialty]
- Tracks cumulative successes across multiple rolls
- Stops on target reached or botch (negative successes)
- Shows each roll with running total for transparency
- Includes max_rolls safety limit (default 100)
- Comprehensive test coverage for function and command parsing

Resolves #703