### PR TITLE
Add automatic removal of retired/deceased characters from organizations

### DIFF
--- a/characters/models/core/character.py
+++ b/characters/models/core/character.py
@@ -32,6 +32,76 @@ class Character(CharacterModel):
         verbose_name = "Character"
         verbose_name_plural = "Characters"
 
+    def save(self, *args, **kwargs):
+        # Check if this is an existing character whose status is changing to Ret or Dec
+        if self.pk:
+            try:
+                old_instance = Character.objects.get(pk=self.pk)
+                old_status = old_instance.status
+                new_status = self.status
+                # If status is changing to Retired or Deceased, remove from organizations
+                if old_status not in ["Ret", "Dec"] and new_status in ["Ret", "Dec"]:
+                    # Call parent save first to ensure we're working with saved state
+                    super().save(*args, **kwargs)
+                    self.remove_from_organizations()
+                    return
+            except Character.DoesNotExist:
+                pass
+        super().save(*args, **kwargs)
+
+    def remove_from_organizations(self):
+        """Remove this character from all organizational structures when retired or deceased."""
+        # Import here to avoid circular imports
+        from characters.models.core.group import Group
+
+        # Remove from Group memberships
+        for group in Group.objects.filter(members=self):
+            group.members.remove(self)
+
+        # Remove from Group leadership positions
+        for group in Group.objects.filter(leader=self):
+            group.leader = None
+            group.save()
+
+        # Handle Human-specific relationships (Chantry)
+        # Check if this character is a Human (or subclass) for Chantry relations
+        if hasattr(self, "member_of"):
+            # Remove from Chantry memberships
+            for chantry in self.member_of.all():
+                chantry.members.remove(self)
+
+        if hasattr(self, "chantry_leader_at"):
+            # Remove from Chantry leadership
+            for chantry in self.chantry_leader_at.all():
+                chantry.leaders.remove(self)
+
+        if hasattr(self, "ambassador_from"):
+            # Remove from ambassador positions
+            for chantry in self.ambassador_from.all():
+                chantry.ambassador = None
+                chantry.save()
+
+        if hasattr(self, "tends_node_at"):
+            # Remove from node tender positions
+            for chantry in self.tends_node_at.all():
+                chantry.node_tender = None
+                chantry.save()
+
+        if hasattr(self, "investigator_at"):
+            # Remove from investigator roles
+            for chantry in self.investigator_at.all():
+                chantry.investigator.remove(self)
+
+        if hasattr(self, "guardian_of"):
+            # Remove from guardian roles
+            for chantry in self.guardian_of.all():
+                chantry.guardian.remove(self)
+
+        if hasattr(self, "teacher_at"):
+            # Remove from teacher roles
+            for chantry in self.teacher_at.all():
+                chantry.teacher.remove(self)
+
     def get_type(self):
         if "human" in self.type:
             return "Human"

--- a/characters/views/core/character.py
+++ b/characters/views/core/character.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from characters.models.core import Character
 from core.views.approved_user_mixin import SpecialUserMixin
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.views.generic import CreateView, DetailView, UpdateView
 from game.models import Scene
 
@@ -19,6 +21,17 @@ class CharacterDetailView(SpecialUserMixin, DetailView):
             self.object, self.request.user
         )
         return context
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        # Handle retirement and death status changes
+        if "retire" in request.POST:
+            self.object.status = "Ret"
+            self.object.save()
+        if "decease" in request.POST:
+            self.object.status = "Dec"
+            self.object.save()
+        return redirect(reverse("characters:character", kwargs={"pk": self.object.pk}))
 
 
 class CharacterCreateView(CreateView):

--- a/locations/tests/mage/chantry.py
+++ b/locations/tests/mage/chantry.py
@@ -276,3 +276,151 @@ class TestChantryUpdateView(TestCase):
         self.chantry.refresh_from_db()
         self.assertEqual(self.chantry.name, "Chantry Updated")
         self.assertEqual(self.chantry.description, "Test Chantry")
+
+
+class TestCharacterRetirementChantryRemoval(TestCase):
+    """Test that retiring or marking a character as deceased removes them from chantries."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="User1", password="12345")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.player,
+            status="App",  # Approved status
+        )
+        self.chantry = Chantry.objects.create(name="Test Chantry")
+
+    def test_character_removed_from_chantry_members_on_retirement(self):
+        """Test that retiring a character removes them from chantry membership."""
+        self.chantry.members.add(self.character)
+        self.assertIn(self.character, self.chantry.members.all())
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from chantry
+        self.assertNotIn(self.character, self.chantry.members.all())
+
+    def test_character_removed_from_chantry_leaders_on_retirement(self):
+        """Test that retiring a character removes them from chantry leadership."""
+        self.chantry.leaders.add(self.character)
+        self.assertIn(self.character, self.chantry.leaders.all())
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from leadership
+        self.assertNotIn(self.character, self.chantry.leaders.all())
+
+    def test_character_removed_from_ambassador_on_retirement(self):
+        """Test that retiring a character removes them from ambassador position."""
+        self.chantry.ambassador = self.character
+        self.chantry.save()
+        self.assertEqual(self.chantry.ambassador, self.character)
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from ambassador position
+        self.assertIsNone(self.chantry.ambassador)
+
+    def test_character_removed_from_node_tender_on_retirement(self):
+        """Test that retiring a character removes them from node tender position."""
+        self.chantry.node_tender = self.character
+        self.chantry.save()
+        self.assertEqual(self.chantry.node_tender, self.character)
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from node tender position
+        self.assertIsNone(self.chantry.node_tender)
+
+    def test_character_removed_from_investigator_on_retirement(self):
+        """Test that retiring a character removes them from investigator role."""
+        self.chantry.investigator.add(self.character)
+        self.assertIn(self.character, self.chantry.investigator.all())
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from investigator role
+        self.assertNotIn(self.character, self.chantry.investigator.all())
+
+    def test_character_removed_from_guardian_on_retirement(self):
+        """Test that retiring a character removes them from guardian role."""
+        self.chantry.guardian.add(self.character)
+        self.assertIn(self.character, self.chantry.guardian.all())
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from guardian role
+        self.assertNotIn(self.character, self.chantry.guardian.all())
+
+    def test_character_removed_from_teacher_on_retirement(self):
+        """Test that retiring a character removes them from teacher role."""
+        self.chantry.teacher.add(self.character)
+        self.assertIn(self.character, self.chantry.teacher.all())
+
+        # Retire the character
+        self.character.status = "Ret"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from teacher role
+        self.assertNotIn(self.character, self.chantry.teacher.all())
+
+    def test_character_removed_from_all_chantry_roles_on_death(self):
+        """Test that marking a character as deceased removes them from all chantry roles."""
+        # Add character to all possible roles
+        self.chantry.members.add(self.character)
+        self.chantry.leaders.add(self.character)
+        self.chantry.ambassador = self.character
+        self.chantry.node_tender = self.character
+        self.chantry.investigator.add(self.character)
+        self.chantry.guardian.add(self.character)
+        self.chantry.teacher.add(self.character)
+        self.chantry.save()
+
+        # Mark character as deceased
+        self.character.status = "Dec"
+        self.character.save()
+
+        # Refresh from database
+        self.chantry.refresh_from_db()
+
+        # Character should be removed from all roles
+        self.assertNotIn(self.character, self.chantry.members.all())
+        self.assertNotIn(self.character, self.chantry.leaders.all())
+        self.assertIsNone(self.chantry.ambassador)
+        self.assertIsNone(self.chantry.node_tender)
+        self.assertNotIn(self.character, self.chantry.investigator.all())
+        self.assertNotIn(self.character, self.chantry.guardian.all())
+        self.assertNotIn(self.character, self.chantry.teacher.all())


### PR DESCRIPTION
When a character's status changes to "Ret" (Retired) or "Dec" (Deceased),
they are now automatically removed from all organizational structures:

- Group memberships and leadership positions
- Chantry memberships, leadership, and special roles (ambassador, node
  tender, investigator, guardian, teacher)

This ensures data consistency by preventing retired or deceased characters
from remaining in active organizational rosters.

Changes:
- Override Character.save() to detect status changes to Ret/Dec
- Add Character.remove_from_organizations() method for cleanup logic
- Add POST handler to CharacterDetailView for retire/decease buttons
- Add comprehensive tests for Group and Chantry removal

Resolves #841