### PR TITLE
Add filtering by statistic type and specific stat to specialties list

### DIFF
--- a/characters/templates/characters/core/specialty/list.html
+++ b/characters/templates/characters/core/specialty/list.html
@@ -4,14 +4,84 @@
 {% endblock title %}
 {% block content %}
     {% load field %}
-    <div class="centertext container">
-        <div class="row border">
-            <h3 class="col-sm border">Specialties</h3>
-        </div>
-        {% for obj in object_list %}
-            <div class="row border">
-                <a class="col-sm border" href="{{ obj.get_absolute_url }}">{{ obj.name }}</a>
+    <div class="container">
+        <div class="tg-card header-card mb-4">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title">Specialties</h1>
             </div>
-        {% endfor %}
+        </div>
+
+        <!-- Filter Controls -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-body">
+                <h6 class="mb-3">Filter Specialties</h6>
+                <form method="get" class="row g-3">
+                    <div class="col-md-4">
+                        <label for="stat_type" class="form-label" style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Statistic Type</label>
+                        <select name="stat_type" id="stat_type" class="form-select">
+                            <option value="">All Types</option>
+                            {% for value, label in stat_types %}
+                                <option value="{{ value }}" {% if current_stat_type == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-4">
+                        <label for="stat" class="form-label" style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Specific Statistic</label>
+                        <select name="stat" id="stat" class="form-select">
+                            <option value="">All Statistics</option>
+                            {% for value, label in stat_choices %}
+                                <option value="{{ value }}" {% if current_stat == value %}selected{% endif %}>{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-4 d-flex align-items-end">
+                        <button type="submit" class="btn btn-primary me-2">Apply Filters</button>
+                        <a href="{% url 'characters:list:specialty' %}" class="btn btn-secondary">Clear</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <!-- Results Count -->
+        {% if current_stat_type or current_stat %}
+            <div class="mb-3">
+                <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                    <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Results:</span>
+                    <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object_list|length }} specialties found</span>
+                </div>
+            </div>
+        {% endif %}
+
+        <!-- Specialties List -->
+        <div class="tg-card">
+            <div class="tg-card-body">
+                {% if object_list %}
+                    <div class="tg-table">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Specialty Name</th>
+                                    <th>Statistic</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for obj in object_list %}
+                                    <tr>
+                                        <td>
+                                            <a href="{{ obj.get_absolute_url }}">{{ obj.name }}</a>
+                                        </td>
+                                        <td>
+                                            <span class="tg-badge badge-pill">{{ obj.stat }}</span>
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <p class="text-muted mb-0">No specialties found matching the selected filters.</p>
+                {% endif %}
+            </div>
+        </div>
     </div>
 {% endblock content %}

--- a/characters/views/core/specialty.py
+++ b/characters/views/core/specialty.py
@@ -1,4 +1,8 @@
 from characters.models.core import Specialty
+from characters.models.core.statistic import Statistic
+from characters.models.core.ability_block import Ability
+from characters.models.core.attribute_block import Attribute
+from characters.models.core.background_block import Background
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 
@@ -23,3 +27,59 @@ class SpecialtyListView(ListView):
     model = Specialty
     ordering = ["name"]
     template_name = "characters/core/specialty/list.html"
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        # Filter by stat type (Ability, Attribute, Background)
+        stat_type = self.request.GET.get("stat_type", "")
+        if stat_type:
+            # Get all property_names for the selected stat type
+            if stat_type == "ability":
+                stat_property_names = list(Ability.objects.values_list("property_name", flat=True))
+            elif stat_type == "attribute":
+                stat_property_names = list(Attribute.objects.values_list("property_name", flat=True))
+            elif stat_type == "background":
+                stat_property_names = list(Background.objects.values_list("property_name", flat=True))
+            else:
+                stat_property_names = []
+
+            if stat_property_names:
+                queryset = queryset.filter(stat__in=stat_property_names)
+
+        # Filter by specific statistic
+        specific_stat = self.request.GET.get("stat", "")
+        if specific_stat:
+            queryset = queryset.filter(stat=specific_stat)
+
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # Get all stat types for the filter dropdown
+        context["stat_types"] = [
+            ("ability", "Ability"),
+            ("attribute", "Attribute"),
+            ("background", "Background"),
+        ]
+
+        # Get all unique stats from specialties for the specific stat filter
+        all_stats = Specialty.objects.values_list("stat", flat=True).distinct().order_by("stat")
+
+        # Map stat property_names to their display names
+        stat_choices = []
+        for stat_prop in all_stats:
+            stat_obj = Statistic.objects.filter(property_name=stat_prop).first()
+            if stat_obj:
+                stat_choices.append((stat_prop, stat_obj.name))
+            else:
+                stat_choices.append((stat_prop, stat_prop.replace("_", " ").title()))
+
+        context["stat_choices"] = sorted(stat_choices, key=lambda x: x[1])
+
+        # Preserve current filter selections
+        context["current_stat_type"] = self.request.GET.get("stat_type", "")
+        context["current_stat"] = self.request.GET.get("stat", "")
+
+        return context


### PR DESCRIPTION
Enhance the specialties list view to allow users to filter by statistic
type (Ability, Attribute, Background) and by specific statistic. Also
updates the template to use tg-card styling conventions and displays
results in a proper table format with filter controls.