### PR TITLE
Add password reset email infrastructure

### DIFF
--- a/accounts/templates/registration/password_reset_email.html
+++ b/accounts/templates/registration/password_reset_email.html
@@ -1,0 +1,100 @@
+{% autoescape off %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            background-color: #1a1a1a;
+            color: #fff;
+            padding: 20px;
+            text-align: center;
+            border-radius: 6px 6px 0 0;
+        }
+        .content {
+            background-color: #f9f9f9;
+            padding: 30px;
+            border: 1px solid #ddd;
+            border-top: none;
+            border-radius: 0 0 6px 6px;
+        }
+        .button {
+            display: inline-block;
+            background-color: #6c757d;
+            color: #fff;
+            text-decoration: none;
+            padding: 12px 30px;
+            border-radius: 4px;
+            font-weight: 600;
+            margin: 20px 0;
+        }
+        .info {
+            background-color: #e3f2fd;
+            padding: 15px;
+            border-radius: 4px;
+            margin: 15px 0;
+        }
+        .warning {
+            font-size: 0.9em;
+            color: #666;
+            margin-top: 20px;
+        }
+        .footer {
+            text-align: center;
+            font-size: 0.85em;
+            color: #888;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #ddd;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1 style="margin: 0;">{{ site_name }}</h1>
+    </div>
+    <div class="content">
+        <p>Hello,</p>
+
+        <p>You're receiving this email because you requested a password reset for your user account at {{ site_name }}.</p>
+
+        <div class="info">
+            <strong>Username:</strong> {{ user.get_username }}
+        </div>
+
+        <p>Please click the button below to reset your password:</p>
+
+        <p style="text-align: center;">
+            <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}" class="button">
+                Reset Your Password
+            </a>
+        </p>
+
+        <p>Or copy and paste this link into your browser:</p>
+        <p style="word-break: break-all; background-color: #fff; padding: 10px; border: 1px solid #ddd; border-radius: 4px;">
+            {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+        </p>
+
+        <div class="warning">
+            <p><strong>Security Notice:</strong></p>
+            <ul>
+                <li>This link will expire after use or after a period of time for security reasons.</li>
+                <li>If you didn't request this password reset, you can safely ignore this email.</li>
+                <li>Your password won't be changed until you access the link above and create a new one.</li>
+            </ul>
+        </div>
+    </div>
+    <div class="footer">
+        <p>This is an automated message from {{ site_name }}. Please do not reply to this email.</p>
+    </div>
+</body>
+</html>
+{% endautoescape %}

--- a/accounts/templates/registration/password_reset_email.txt
+++ b/accounts/templates/registration/password_reset_email.txt
@@ -1,0 +1,22 @@
+{% autoescape off %}
+Password Reset Request
+======================
+
+Hello,
+
+You're receiving this email because you requested a password reset for your user account at {{ site_name }}.
+
+Username: {{ user.get_username }}
+
+Please go to the following page to reset your password:
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+Security Notice:
+- This link will expire after use or after a period of time for security reasons.
+- If you didn't request this password reset, you can safely ignore this email.
+- Your password won't be changed until you access the link above and create a new one.
+
+Thanks,
+The {{ site_name }} team
+{% endautoescape %}

--- a/accounts/templates/registration/password_reset_subject.txt
+++ b/accounts/templates/registration/password_reset_subject.txt
@@ -1,0 +1,3 @@
+{% autoescape off %}
+Password Reset for {{ site_name }}
+{% endautoescape %}

--- a/tg/settings.py
+++ b/tg/settings.py
@@ -141,7 +141,54 @@ STATICFILES_DIRS = [BASE_DIR / "staticfiles"]
 
 LOGIN_REDIRECT_URL = "user"
 LOGOUT_REDIRECT_URL = "home"
-# EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# Email Configuration
+# ====================
+# Currently using console backend for development.
+# When ready for production, configure one of the following:
+#
+# Option 1: SMTP (Gmail, SendGrid, etc.)
+# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+# EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp.gmail.com")
+# EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "587"))
+# EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True") == "True"
+# EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+# EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+#
+# Option 2: Amazon SES
+# EMAIL_BACKEND = "django_ses.SESBackend"
+# AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
+# AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+# AWS_SES_REGION_NAME = os.environ.get("AWS_SES_REGION_NAME", "us-east-1")
+# AWS_SES_REGION_ENDPOINT = f"email.{AWS_SES_REGION_NAME}.amazonaws.com"
+#
+# Option 3: Mailgun
+# EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
+# ANYMAIL = {
+#     "MAILGUN_API_KEY": os.environ.get("MAILGUN_API_KEY", ""),
+#     "MAILGUN_SENDER_DOMAIN": os.environ.get("MAILGUN_SENDER_DOMAIN", ""),
+# }
+
+# Development: Console backend (prints emails to console)
+EMAIL_BACKEND = os.environ.get(
+    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+)
+
+# Production email settings (configure via environment variables)
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "25"))
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "False") == "True"
+EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "False") == "True"
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+EMAIL_TIMEOUT = int(os.environ.get("EMAIL_TIMEOUT", "30"))
+
+# Default sender for password resets and other system emails
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "noreply@tellurian-games.com")
+SERVER_EMAIL = os.environ.get("SERVER_EMAIL", DEFAULT_FROM_EMAIL)
+
+# Password reset token expiration (in seconds, default 3 days = 259200)
+PASSWORD_RESET_TIMEOUT = int(os.environ.get("PASSWORD_RESET_TIMEOUT", "259200"))
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field


### PR DESCRIPTION
Add email templates for password reset functionality and configure
email backend settings with environment variable support. The system
defaults to console backend for development and can be configured for
production with SMTP, SES, or Mailgun by setting environment variables.

resolves #5