### PR TITLE
Add a new command

### DIFF
--- a/game/templates/game/scene/commands.html
+++ b/game/templates/game/scene/commands.html
@@ -35,6 +35,12 @@
                                 <td data-label="Explanation" style="padding: 16px; text-align: left; vertical-align: middle;">Mostly self explanatory, noting that &lt;specialty&gt; is True or False. Specialty and difficulty can be left off and default to False and "difficulty 6." Can be used at the end of a post.</td>
                             </tr>
                             <tr>
+                                <td data-label="Command" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/stat</code></td>
+                                <td data-label="Example" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/stat Dexterity + Firearms difficulty 6</code></td>
+                                <td data-label="Syntax" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/stat &lt;stat&gt; + &lt;stat&gt; [+ ...] difficulty &lt;diff&gt; &lt;specialty&gt;</code></td>
+                                <td data-label="Explanation" style="padding: 16px; text-align: left; vertical-align: middle;">Rolls dice based on character statistics. Can combine 1-3 stats (e.g., "Dexterity + Firearms" or "Strength + Brawl + 2"). Displays the dice pool and individual stat values. Difficulty and specialty are optional (default: 6 and False). Can be used at the end of a post.</td>
+                            </tr>
+                            <tr>
                                 <td data-label="Command" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/rolls</code></td>
                                 <td data-label="Example" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/rolls 3 rolls @ 5 difficulty 6 True</code></td>
                                 <td data-label="Syntax" style="padding: 16px; text-align: center; vertical-align: middle;"><code>/roll &lt;num_rolls&gt; rolls @ &lt;num_dice&gt; difficulty &lt;diff&gt; &lt;specialty&gt;</code></td>


### PR DESCRIPTION
Closes #622

- Add /stat command to roll dice based on character statistics
- Supports 1-3 stats with + syntax (e.g., "Dexterity + Firearms")
- Supports numeric modifiers (e.g., "Strength + Brawl + 2")
- Displays individual stat values and total dice pool
- Supports difficulty and specialty options like /roll
- Update commands documentation with /stat usage
- Add comprehensive test coverage for new command