### PR TITLE
Filter meritflaws by spendable costs

### DIFF
--- a/characters/templates/characters/changeling/ctdhuman/freebies_form.html
+++ b/characters/templates/characters/changeling/ctdhuman/freebies_form.html
@@ -131,7 +131,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/mage/companion/companion_freebies_form.html
+++ b/characters/templates/characters/mage/companion/companion_freebies_form.html
@@ -137,7 +137,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/mage/mage/freebies_form.html
+++ b/characters/templates/characters/mage/mage/freebies_form.html
@@ -181,7 +181,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/mage/mage/mage_xp_form.html
+++ b/characters/templates/characters/mage/mage/mage_xp_form.html
@@ -351,7 +351,9 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}},
+                        'xp': 'true'
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/mage/mtahuman/freebies_form.html
+++ b/characters/templates/characters/mage/mtahuman/freebies_form.html
@@ -131,7 +131,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/mage/sorcerer/sorcerer_freebies_form.html
+++ b/characters/templates/characters/mage/sorcerer/sorcerer_freebies_form.html
@@ -169,7 +169,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/vampire/vtmhuman/freebies_form.html
+++ b/characters/templates/characters/vampire/vtmhuman/freebies_form.html
@@ -131,7 +131,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/werewolf/kinfolk/freebies_form.html
+++ b/characters/templates/characters/werewolf/kinfolk/freebies_form.html
@@ -131,7 +131,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/werewolf/wtahuman/freebies_form.html
+++ b/characters/templates/characters/werewolf/wtahuman/freebies_form.html
@@ -131,7 +131,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);

--- a/characters/templates/characters/wraith/wtohuman/freebies_form.html
+++ b/characters/templates/characters/wraith/wtohuman/freebies_form.html
@@ -131,7 +131,8 @@
                 $.ajax({
                     url: '{% url 'characters:ajax:load_values' %}',
                     data: {
-                        'example': this.value
+                        'example': this.value,
+                        'object': {{object.id}}
                     },
                     success: function (data) {
                         $("#id_value").html(data);


### PR DESCRIPTION
Implements filtering to only show merit/flaws with selectable costs and only display valid cost options on both freebie and XP expenditure pages.

Changes:
- Updated meritflaw_options() to filter merit/flaws by affordable ratings
  - Flaws: Check against -7 total flaw limit
  - Merits: Check against available freebies
- Enhanced load_values() to filter rating values based on affordability
  - For freebies: Shows ratings where cost <= available freebies
  - For XP: Shows ratings where 3 × |new - current| <= available XP
- Updated XPForm to filter merit/flaws by character type and affordability
  - Added proper character type filtering (like freebie spending)
  - Only shows merit/flaws with at least one affordable rating change
- Modified all freebie form templates to pass character object ID to AJAX
- Modified mage XP form template to pass character object and XP flag

Closes #654