### PR TITLE
Add tenet bonus/penalty display for Mage Practices

### DIFF
--- a/characters/templates/characters/mage/mage/mage_focus_block_display.html
+++ b/characters/templates/characters/mage/mage/mage_focus_block_display.html
@@ -43,6 +43,11 @@
                                 <div class="px-3 py-2">
                                     <a href="{{ pr.practice.get_absolute_url }}" style="font-weight: 600; font-size: 0.875rem; color: var(--theme-text-secondary); margin-right: 8px;">{{ pr.practice }}:</a>
                                     <span class="dots" style="font-weight: 700; color: var(--theme-text-primary);">{{ pr.rating|dots }}</span>
+                                    {% if pr.get_tenet_bonus != 0 %}
+                                        <span style="font-weight: 600; font-size: 0.75rem; margin-left: 8px; {% if pr.get_tenet_bonus > 0 %}color: #28a745;{% else %}color: #dc3545;{% endif %}">
+                                            ({% if pr.get_tenet_bonus > 0 %}+{% endif %}{{ pr.get_tenet_bonus }})
+                                        </span>
+                                    {% endif %}
                                 </div>
                             {% endfor %}
                         </div>


### PR DESCRIPTION
Display the net tenet bonus or penalty for each Practice in the Mage
focus block. The bonus is calculated as:
- +1 if the practice is ONLY associated to tenets
- -1 if the practice is ONLY limited by tenets
- 0 otherwise (both, or neither)

Changes:
- Added get_tenet_bonus() method to PracticeRating model
- Updated mage_focus_block_display.html to show bonus/penalty
- Added comprehensive tests for tenet bonus calculation

Resolves #719