### PR TITLE
Move Enhancement validation logic from view to form

### DIFF
--- a/characters/views/mage/background_views.py
+++ b/characters/views/mage/background_views.py
@@ -61,31 +61,32 @@ class MtAEnhancementView(SpecialUserMixin, FormView):
     def form_valid(self, form):
         context = self.get_context_data()
         obj = context["object"]
-        # Check Data Valid
-        if form.save(char=obj):
-            if (
-                BackgroundRating.objects.filter(
-                    char=obj,
-                    bg=Background.objects.get(property_name="enhancement"),
-                    complete=False,
-                ).count()
-                == 0
-            ):
-                obj.creation_status += 1
-                obj.save()
-                for step in self.potential_skip:
-                    if (
-                        BackgroundRating.objects.filter(
-                            bg=Background.objects.get(property_name=step),
-                            char=obj,
-                            complete=False,
-                        ).count()
-                        == 0
-                    ):
-                        obj.creation_status += 1
-                    else:
-                        obj.save()
-                        break
-                obj.save()
-            return HttpResponseRedirect(obj.get_absolute_url())
-        return super().form_invalid(form)
+        # Save the form data
+        form.save(char=obj)
+
+        # Check if there are more enhancements to complete
+        if (
+            BackgroundRating.objects.filter(
+                char=obj,
+                bg=Background.objects.get(property_name="enhancement"),
+                complete=False,
+            ).count()
+            == 0
+        ):
+            obj.creation_status += 1
+            obj.save()
+            for step in self.potential_skip:
+                if (
+                    BackgroundRating.objects.filter(
+                        bg=Background.objects.get(property_name=step),
+                        char=obj,
+                        complete=False,
+                    ).count()
+                    == 0
+                ):
+                    obj.creation_status += 1
+                else:
+                    obj.save()
+                    break
+            obj.save()
+        return HttpResponseRedirect(obj.get_absolute_url())


### PR DESCRIPTION
Resolves #677

- Add comprehensive clean() method to EnhancementForm with type-specific validation
- Validate enhancement style and type are selected
- Validate attribute count, device selection, and new device fields
- Move effect cost validation (cost <= 2 * rank) from save() to clean()
- Fix typos: new_device_winder_type -> new_device_wonder_type
- Remove validation return values from save() method
- Update MtAEnhancementView to use standard Django form validation flow

This follows Django best practices by keeping validation in the form's clean()
methods and business logic in save(), with the view relying on Django's
built-in form validation.