### PR TITLE
Add house selection to HouseFaction form

### DIFF
--- a/characters/forms/changeling/__init__.py
+++ b/characters/forms/changeling/__init__.py
@@ -1,2 +1,3 @@
 from .changeling import ChangelingCreationForm
 from .ctdhuman import CtDHumanCreationForm
+from .house_faction import HouseFactionForm

--- a/characters/forms/changeling/house_faction.py
+++ b/characters/forms/changeling/house_faction.py
@@ -1,0 +1,38 @@
+from characters.models.changeling.house import House
+from characters.models.changeling.house_faction import HouseFaction
+from django import forms
+
+
+class HouseFactionForm(forms.ModelForm):
+    houses = forms.ModelMultipleChoiceField(
+        queryset=House.objects.all(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        help_text="Select which houses this faction belongs to",
+    )
+
+    class Meta:
+        model = HouseFaction
+        fields = ["name", "description", "houses"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            # If editing an existing faction, set the initial houses
+            self.fields["houses"].initial = House.objects.filter(
+                factions=self.instance
+            )
+
+    def save(self, commit=True):
+        instance = super().save(commit=commit)
+        if commit:
+            # Update the House objects to reference this faction
+            # First, remove this faction from all houses
+            for house in House.objects.filter(factions=instance):
+                house.factions.remove(instance)
+
+            # Then add it to the selected houses
+            for house in self.cleaned_data["houses"]:
+                house.factions.add(instance)
+
+        return instance

--- a/characters/models/changeling/house_faction.py
+++ b/characters/models/changeling/house_faction.py
@@ -1,4 +1,5 @@
 from core.models import Model
+from django.urls import reverse
 
 
 class HouseFaction(Model):
@@ -7,3 +8,16 @@ class HouseFaction(Model):
     class Meta:
         verbose_name = "House Faction"
         verbose_name_plural = "House Factions"
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("characters:changeling:create:house_faction")
+
+    def get_absolute_url(self):
+        return reverse("characters:changeling:house_faction", kwargs={"pk": self.pk})
+
+    def get_update_url(self):
+        return reverse("characters:changeling:update:house_faction", kwargs={"pk": self.pk})
+
+    def get_heading(self):
+        return "ctd_heading"

--- a/characters/templates/characters/changeling/house_faction/detail.html
+++ b/characters/templates/characters/changeling/house_faction/detail.html
@@ -1,0 +1,8 @@
+{% extends "core/object.html" %}
+{% block status_row %}
+    <div class="col-md-6 mb-3">{% include "characters/changeling/house_faction/display_includes/details.html" %}</div>
+    {{ block.super }}
+{% endblock status_row %}
+{% block contents %}
+    {# No additional content needed as details are shown in status_row #}
+{% endblock contents %}

--- a/characters/templates/characters/changeling/house_faction/display_includes/details.html
+++ b/characters/templates/characters/changeling/house_faction/display_includes/details.html
@@ -1,0 +1,26 @@
+{% load dots %}
+<div class="card h-100">
+    <div class="card-header bg-light py-2">
+        <h5 class="mb-0 ctd_heading">House Faction Details</h5>
+    </div>
+    <div class="card-body py-3">
+        <div class="row">
+            <div class="col-md-12 mb-3">
+                <h6 class="text-primary mb-3" style="font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; font-size: 0.875rem;">
+                    <i class="fas fa-home mr-2"></i>Houses
+                </h6>
+                {% if object.house_set.exists %}
+                    <ul class="list-unstyled mb-0">
+                        {% for house in object.house_set.all %}
+                            <li class="mb-2 p-3 border-left border-primary" style="border-left-width: 3px !important; background-color: rgba(0, 123, 255, 0.05); line-height: 1.6;">
+                                <a href="{{ house.get_absolute_url }}">{{ house.name }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-muted mb-0">No houses belong to this faction</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/characters/templates/characters/changeling/house_faction/form.html
+++ b/characters/templates/characters/changeling/house_faction/form.html
@@ -1,0 +1,19 @@
+{% extends "core/form.html" %}
+{% block creation_title %}
+    Create House Faction
+{% endblock creation_title %}
+{% block contents %}
+    {% load dots %}
+    <div class="row">
+        <div class="col-sm">Name</div>
+        <div class="col-sm">{{ form.name }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Description</div>
+        <div class="col-sm">{{ form.description }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Houses</div>
+        <div class="col-sm">{{ form.houses }}</div>
+    </div>
+{% endblock contents %}

--- a/characters/templates/characters/changeling/house_faction/list.html
+++ b/characters/templates/characters/changeling/house_faction/list.html
@@ -1,0 +1,17 @@
+{% extends "core/base.html" %}
+{% block title %}
+    House Factions
+{% endblock title %}
+{% block content %}
+    {% load field %}
+    <div class="centertext container">
+        <div class="row border">
+            <h3 class="col-sm border">House Factions</h3>
+        </div>
+        {% for obj in object_list %}
+            <div class="row border">
+                <a class="col-sm border" href="{{ obj.get_absolute_url }}">{{ obj.name }}</a>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/characters/tests/changeling/house_faction.py
+++ b/characters/tests/changeling/house_faction.py
@@ -1,0 +1,99 @@
+from characters.models.changeling.house import House
+from characters.models.changeling.house_faction import HouseFaction
+from django.test import TestCase
+
+
+class TestHouseFactionDetailView(TestCase):
+    def setUp(self) -> None:
+        self.faction = HouseFaction.objects.create(name="Test Faction")
+        self.url = self.faction.get_absolute_url()
+
+    def test_house_faction_detail_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_house_faction_detail_view_templates(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(
+            response, "characters/changeling/house_faction/detail.html"
+        )
+
+
+class TestHouseFactionCreateView(TestCase):
+    def setUp(self):
+        self.house1 = House.objects.create(name="House 1")
+        self.house2 = House.objects.create(name="House 2")
+        self.valid_data = {
+            "name": "Faction",
+            "description": "Test",
+            "houses": [self.house1.id, self.house2.id],
+        }
+        self.url = HouseFaction.get_creation_url()
+
+    def test_create_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(
+            response, "characters/changeling/house_faction/form.html"
+        )
+
+    def test_create_view_successful_post(self):
+        response = self.client.post(self.url, data=self.valid_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(HouseFaction.objects.count(), 1)
+        faction = HouseFaction.objects.first()
+        self.assertEqual(faction.name, "Faction")
+        # Check that the houses are associated with the faction
+        self.house1.refresh_from_db()
+        self.house2.refresh_from_db()
+        self.assertIn(faction, self.house1.factions.all())
+        self.assertIn(faction, self.house2.factions.all())
+
+
+class TestHouseFactionUpdateView(TestCase):
+    def setUp(self):
+        self.faction = HouseFaction.objects.create(
+            name="Test Faction",
+            description="Test description",
+        )
+        self.house1 = House.objects.create(name="House 1")
+        self.house2 = House.objects.create(name="House 2")
+        self.house3 = House.objects.create(name="House 3")
+        # Initially associate house1 with the faction
+        self.house1.factions.add(self.faction)
+
+        self.valid_data = {
+            "name": "Faction Updated",
+            "description": "Test",
+            "houses": [self.house2.id, self.house3.id],
+        }
+        self.url = self.faction.get_update_url()
+
+    def test_update_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(
+            response, "characters/changeling/house_faction/form.html"
+        )
+
+    def test_update_view_successful_post(self):
+        response = self.client.post(self.url, data=self.valid_data)
+        self.assertEqual(response.status_code, 302)
+        self.faction.refresh_from_db()
+        self.assertEqual(self.faction.name, "Faction Updated")
+        self.assertEqual(self.faction.description, "Test")
+        # Check that the houses are updated correctly
+        self.house1.refresh_from_db()
+        self.house2.refresh_from_db()
+        self.house3.refresh_from_db()
+        # house1 should no longer have this faction
+        self.assertNotIn(self.faction, self.house1.factions.all())
+        # house2 and house3 should have this faction
+        self.assertIn(self.faction, self.house2.factions.all())
+        self.assertIn(self.faction, self.house3.factions.all())

--- a/characters/urls/changeling/create.py
+++ b/characters/urls/changeling/create.py
@@ -1,6 +1,7 @@
 from characters.views.changeling.changeling import ChangelingBasicsView
 from characters.views.changeling.ctdhuman import CtDHumanBasicsView
 from characters.views.changeling.house import HouseCreateView
+from characters.views.changeling.house_faction import HouseFactionCreateView
 from characters.views.changeling.kith import KithCreateView
 from characters.views.changeling.legacy import LegacyCreateView
 from characters.views.changeling.motley import MotleyCreateView
@@ -26,6 +27,11 @@ urls = [
         "house/",
         HouseCreateView.as_view(),
         name="house",
+    ),
+    path(
+        "house_faction/",
+        HouseFactionCreateView.as_view(),
+        name="house_faction",
     ),
     path(
         "legacy/",

--- a/characters/urls/changeling/detail.py
+++ b/characters/urls/changeling/detail.py
@@ -1,4 +1,5 @@
 from characters.views.changeling.house import HouseDetailView
+from characters.views.changeling.house_faction import HouseFactionDetailView
 from characters.views.changeling.kith import KithDetailView
 from characters.views.changeling.legacy import LegacyDetailView
 from django.urls import path
@@ -13,6 +14,11 @@ urls = [
         "house/<pk>/",
         HouseDetailView.as_view(),
         name="house",
+    ),
+    path(
+        "house_faction/<pk>/",
+        HouseFactionDetailView.as_view(),
+        name="house_faction",
     ),
     path(
         "legacy/<pk>/",

--- a/characters/urls/changeling/index.py
+++ b/characters/urls/changeling/index.py
@@ -1,4 +1,5 @@
 from characters.views.changeling.house import HouseListView
+from characters.views.changeling.house_faction import HouseFactionListView
 from characters.views.changeling.kith import KithListView
 from characters.views.changeling.legacy import LegacyListView
 from django.urls import path
@@ -13,6 +14,11 @@ urls = [
         "house/",
         HouseListView.as_view(),
         name="house",
+    ),
+    path(
+        "house_faction/",
+        HouseFactionListView.as_view(),
+        name="house_faction",
     ),
     path(
         "legacy/",

--- a/characters/urls/changeling/update.py
+++ b/characters/urls/changeling/update.py
@@ -1,6 +1,7 @@
 from characters.views.changeling.changeling import ChangelingUpdateView
 from characters.views.changeling.ctdhuman import CtDHumanUpdateView
 from characters.views.changeling.house import HouseUpdateView
+from characters.views.changeling.house_faction import HouseFactionUpdateView
 from characters.views.changeling.kith import KithUpdateView
 from characters.views.changeling.legacy import LegacyUpdateView
 from characters.views.changeling.motley import MotleyUpdateView
@@ -31,6 +32,11 @@ urls = [
         "house/<pk>/",
         HouseUpdateView.as_view(),
         name="house",
+    ),
+    path(
+        "house_faction/<pk>/",
+        HouseFactionUpdateView.as_view(),
+        name="house_faction",
     ),
     path(
         "legacy/<pk>/",

--- a/characters/views/changeling/house_faction.py
+++ b/characters/views/changeling/house_faction.py
@@ -1,0 +1,26 @@
+from characters.forms.changeling.house_faction import HouseFactionForm
+from characters.models.changeling.house_faction import HouseFaction
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+
+
+class HouseFactionDetailView(DetailView):
+    model = HouseFaction
+    template_name = "characters/changeling/house_faction/detail.html"
+
+
+class HouseFactionCreateView(CreateView):
+    model = HouseFaction
+    form_class = HouseFactionForm
+    template_name = "characters/changeling/house_faction/form.html"
+
+
+class HouseFactionUpdateView(UpdateView):
+    model = HouseFaction
+    form_class = HouseFactionForm
+    template_name = "characters/changeling/house_faction/form.html"
+
+
+class HouseFactionListView(ListView):
+    model = HouseFaction
+    ordering = ["name"]
+    template_name = "characters/changeling/house_faction/list.html"


### PR DESCRIPTION
This commit implements a complete CRUD interface for HouseFaction with the ability to select which Houses belong to each faction.

Changes:
- Added URL methods to HouseFaction model (get_creation_url, get_absolute_url, get_update_url, get_heading)
- Created HouseFactionForm with ModelMultipleChoiceField for house selection using checkboxes
- Created views for HouseFaction (Create, Update, Detail, List)
- Added URL patterns for all HouseFaction views
- Created templates for form, list, and detail views
- Added comprehensive tests for all views and the house relationship functionality

The form allows users to select multiple houses when creating or updating a faction, and properly maintains the many-to-many relationship between Houses and HouseFactions.

Resolves #855