### PR TITLE
Add staged character creation for Werewolves

### DIFF
--- a/characters/urls/werewolf/update.py
+++ b/characters/urls/werewolf/update.py
@@ -63,14 +63,14 @@ urls = [
         name="fomor_full",
     ),
     path(
-        "werewolf/<pk>/",
-        views.werewolf.WerewolfUpdateView.as_view(),
-        name="werewolf",
-    ),
-    path(
         "werewolf/full/<pk>/",
         views.werewolf.WerewolfUpdateView.as_view(),
         name="werewolf_full",
+    ),
+    path(
+        "werewolf/<pk>/",
+        views.werewolf.WerewolfCharacterCreationView.as_view(),
+        name="werewolf",
     ),
     path(
         "kinfolk/<pk>/",


### PR DESCRIPTION
Implements staged character creation for Werewolf characters, matching the Mage implementation pattern. This resolves #812.

Changes:
- Added WerewolfGiftsView for selecting starting Gifts (breed, auspice, tribe)
- Added WerewolfHistoryView for First Change narrative and timing
- Added WerewolfExtrasView for character description and background
- Added WerewolfFreebiesView for spending freebie points
- Added WerewolfLanguagesView for language selection
- Added WerewolfAlliesView and WerewolfFetishView for expanded backgrounds
- Added WerewolfSpecialtiesView for ability specialties
- Updated WerewolfCharacterCreationView with complete 10-stage mapping:
  1. Attributes
  2. Abilities
  3. Backgrounds
  4. Gifts (new)
  5. First Change History (new)
  6. Extras/Backstory (new)
  7. Freebies (new)
  8. Languages (new)
  9. Allies (new)
  10. Specialties (new)
- Updated werewolf update URLs to use WerewolfCharacterCreationView
- All views follow the established pattern from Mage character creation

The staged creation guides players through character creation step-by-step, ensuring all required elements are completed in the proper order.