### PR TITLE
Add full character creation staging for Fomori

### DIFF
--- a/characters/templates/characters/werewolf/fomor/appearance_block_display.html
+++ b/characters/templates/characters/werewolf/fomor/appearance_block_display.html
@@ -1,0 +1,24 @@
+{% load sanitize_text %}
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }} pointer"
+        data-toggle="collapse"
+        data-target="#appearanceSection"
+        aria-expanded="true"
+        aria-controls="appearanceSection">Appearance</h5>
+</div>
+<div id="appearanceSection" class="collapse show multi-collapse">
+    <div class="row">
+        <div class="col-sm">Date of Birth</div>
+        <div class="col-sm">{{ object.date_of_birth }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Apparent Age</div>
+        <div class="col-sm">{{ object.apparent_age }}</div>
+        <div class="col-sm">Age</div>
+        <div class="col-sm">{{ object.age }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Description</div>
+        <div class="col-sm">{{ object.description|sanitize_html|linebreaks }}</div>
+    </div>
+</div>

--- a/characters/templates/characters/werewolf/fomor/appearance_block_form.html
+++ b/characters/templates/characters/werewolf/fomor/appearance_block_form.html
@@ -1,0 +1,22 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Appearance</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Fill out character appearance and background details. Be sure to write a good description, as that will be publicly viewable.
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm">Date of Birth</div>
+    <div class="col-sm">{{ form.date_of_birth }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Apparent Age</div>
+    <div class="col-sm">{{ form.apparent_age }}</div>
+    <div class="col-sm">Age</div>
+    <div class="col-sm">{{ form.age }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Description</div>
+    <div class="col-sm">{{ form.description }}</div>
+</div>

--- a/characters/templates/characters/werewolf/fomor/chargen.html
+++ b/characters/templates/characters/werewolf/fomor/chargen.html
@@ -1,4 +1,5 @@
 {% extends "core/form.html" %}
+{% load dots %}
 {% block creation_title %}
     Fomor
 {% endblock creation_title %}
@@ -35,6 +36,114 @@
                 {% include "characters/core/background_block/detail.html" with backgrounds=object.backgrounds %}
             {% endif %}
         {% endblock backgrounds %}
+        {% block powers %}
+            {% if object.creation_status == 4 %}
+                <div class="row">
+                    <div class="col-sm">
+                        <div class="tg-card">
+                            <div class="tg-card-header">
+                                <h3 class="tg-card-title {{ object.get_heading }}">Fomori Powers</h3>
+                            </div>
+                            <div class="tg-card-body">
+                                <div class="form-group">
+                                    {{ form.rage.label_tag }}
+                                    {{ form.rage }}
+                                    {% if form.rage.help_text %}
+                                        <small class="form-text text-muted">{{ form.rage.help_text }}</small>
+                                    {% endif %}
+                                </div>
+                                <div class="form-group">
+                                    {{ form.gnosis.label_tag }}
+                                    {{ form.gnosis }}
+                                    {% if form.gnosis.help_text %}
+                                        <small class="form-text text-muted">{{ form.gnosis.help_text }}</small>
+                                    {% endif %}
+                                </div>
+                                <div class="form-group">
+                                    {{ form.powers.label_tag }}
+                                    {{ form.powers }}
+                                    {% if form.powers.help_text %}
+                                        <small class="form-text text-muted">{{ form.powers.help_text }}</small>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% elif object.creation_status > 4 %}
+                <div class="row">
+                    <div class="col-sm">
+                        <div class="tg-card">
+                            <div class="tg-card-header">
+                                <h3 class="tg-card-title {{ object.get_heading }}">Fomori Powers</h3>
+                            </div>
+                            <div class="tg-card-body">
+                                <div class="row">
+                                    <div class="col-md-6 mb-3">
+                                        <strong>Rage:</strong> {{ object.rage|dots }}
+                                    </div>
+                                    <div class="col-md-6 mb-3">
+                                        <strong>Gnosis:</strong> {{ object.gnosis|dots }}
+                                    </div>
+                                </div>
+                                {% if object.powers.all %}
+                                    <div class="row">
+                                        <div class="col-12">
+                                            <strong>Powers:</strong>
+                                            <ul>
+                                                {% for power in object.powers.all %}
+                                                    <li><a href="{{ power.get_absolute_url }}">{{ power.name }}</a></li>
+                                                {% endfor %}
+                                            </ul>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        {% endblock powers %}
+        {% block mfs %}
+            {% if object.creation_status >= 5 %}
+                {% include "characters/core/meritflaw/display_includes/meritflaw_block.html" %}
+            {% endif %}
+        {% endblock mfs %}
+        {% block appearance %}
+            {% if object.creation_status == 5 %}
+                {% include "characters/werewolf/fomor/appearance_block_form.html" %}
+            {% elif object.creation_status > 5 %}
+                {% include "characters/werewolf/fomor/appearance_block_display.html" %}
+            {% endif %}
+        {% endblock appearance %}
+        {% block history %}
+            {% if object.creation_status == 5 %}
+                {% include "characters/werewolf/fomor/history_block_form.html" %}
+            {% elif object.creation_status > 5 %}
+                {% include "characters/werewolf/fomor/history_block_display.html" %}
+            {% endif %}
+        {% endblock history %}
+        {% block freebies %}
+            {% if object.creation_status == 6 and object.freebies_approved %}
+                {% include "characters/werewolf/fomor/freebies_form.html" %}
+            {% elif object.creation_status == 6 %}
+                <div class="row">
+                    <h2 class="col-sm {{ object.get_heading }}">Waiting on ST to Assign Freebie Total</h2>
+                </div>
+            {% endif %}
+        {% endblock freebies %}
+        {% block languages %}
+            {% if object.creation_status > 7 %}
+                {% include "characters/core/human/language_display_block.html" %}
+            {% elif object.creation_status == 7 %}
+                {% include "characters/core/human/human_language_block_form.html" %}
+            {% endif %}
+        {% endblock languages %}
+        {% block specialties_form %}
+            {% if object.creation_status == 8 %}
+                {% include "characters/werewolf/fomor/specialties_block_form.html" %}
+            {% endif %}
+        {% endblock specialties_form %}
     {% else %}
         {% include "characters/core/character/not_owner.html" %}
     {% endif %}

--- a/characters/templates/characters/werewolf/fomor/freebies_form.html
+++ b/characters/templates/characters/werewolf/fomor/freebies_form.html
@@ -1,0 +1,138 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Freebie Spend</h2>
+</div>
+{% if object.freebies > 0 %}
+    <div class="row">
+        <div class="col-sm">Spend Freebie points. The costs are as follows:</div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">
+            <b>Trait</b>
+        </div>
+        <div class="col-sm-3 border">
+            <b>Cost</b>
+        </div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Attribute</div>
+        <div class="col-sm-3 border">5</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Ability</div>
+        <div class="col-sm-3 border">2</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Background</div>
+        <div class="col-sm-3 border">1</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Willpower</div>
+        <div class="col-sm-3 border">1</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Merits/Flaws</div>
+        <div class="col-sm-3 border">Rating</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row">
+        <h3 class="col-sm {{ object.get_heading }}">Freebies Remaining</h3>
+        <h3 class="col-sm {{ object.get_heading }}">{{ object.freebies }}</h3>
+    </div>
+{% endif %}
+<div class="row">
+    <div class="col-sm">{{ form.category }}</div>
+    <div class="col-sm d-none" id="example_wrap">{{ form.example }}</div>
+    <div class="col-sm d-none" id="value_wrap">{{ form.value }}</div>
+    <div class="col-sm d-none" id="note_wrap">{{ form.note }}</div>
+    <div class="col-sm d-none" id="pooled_wrap">Pooled? {{ form.pooled }}</div>
+</div>
+{% for item in object.spent_freebies %}
+    <div class="row">
+        <div class="col-sm">{{ item.trait }} {{ item.value }}</div>
+        <div class="col-sm">{{ item.cost }} freebies</div>
+    </div>
+{% endfor %}
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const categorySelectMenu = document.getElementById("id_category");
+        const exampleSelectMenu = document.getElementById("id_example")
+        const exampleElement = document.getElementById("example_wrap");
+        const valueElement = document.getElementById("value_wrap");
+        const noteElement = document.getElementById("note_wrap");
+        const pooled_wrap = document.getElementById("pooled_wrap");
+
+        var isGroupMember = {{ object.is_group_member|lower }};
+
+        categorySelectMenu.addEventListener("change", function() {
+            const selectedValue = this.value;
+
+            // Update the class of the element
+            if(["Willpower", "-----"].includes(this.value)){
+                exampleElement.classList.add("d-none");
+                valueElement.classList.add("d-none");
+                noteElement.classList.add("d-none");
+                pooled_wrap.classList.add("d-none");
+            } else {
+                exampleElement.classList.remove("d-none");
+                valueElement.classList.add("d-none");
+                noteElement.classList.add("d-none");
+                pooled_wrap.classList.add("d-none");
+            }
+            if(this.value == "MeritFlaw"){
+                valueElement.classList.remove("d-none");
+                noteElement.classList.add("d-none");
+                pooled_wrap.classList.add("d-none");
+            }
+            if(this.value == "New Background"){
+                exampleElement.classList.remove("d-none");
+                noteElement.classList.remove("d-none");
+                valueElement.classList.add("d-none");
+                if (isGroupMember) {
+                    pooled_wrap.classList.remove("d-none");
+                } else {
+                    pooled_wrap.classList.add("d-none");
+                }
+            }
+
+            // Make the AJAX call
+            $.ajax({                       // initialize an AJAX request
+                url: '{% url 'characters:werewolf:ajax:load_fomor_examples' %}',                    // set the url of the request (= localhost:8000/hr/ajax/load-character-type/)
+                data: {
+                'category': this.value,       // add the gameline id to the GET parameters
+                'object': {{object.id}}
+                },
+                success: function (data) {   // `data` is the return of the `load_character_type` view function
+                $("#id_example").html(data);  // replace the contents of the character_type input with the data that came from the server
+                $("#id_value").html('<option value="">---</option>');
+                }
+            });
+        });
+
+        exampleSelectMenu.addEventListener("change", function() {
+            const selectedValue = this.value;
+            if(categorySelectMenu.value == "MeritFlaw"){
+                $.ajax({
+                    url: '{% url 'characters:ajax:load_values' %}',
+                    data: {
+                        'example': this.value
+                    },
+                    success: function (data) {
+                        $("#id_value").html(data);
+                    }
+                });
+            }
+        });
+    });
+
+</script>

--- a/characters/templates/characters/werewolf/fomor/history_block_display.html
+++ b/characters/templates/characters/werewolf/fomor/history_block_display.html
@@ -1,0 +1,26 @@
+{% load sanitize_text %}
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }} pointer"
+        data-toggle="collapse"
+        data-target="#historySection"
+        aria-expanded="true"
+        aria-controls="historySection">History</h5>
+</div>
+<div id="historySection" class="collapse show multi-collapse">
+    <div class="row">
+        <div class="col-sm">History</div>
+        <div class="col-sm">{{ object.history|sanitize_html|linebreaks }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Goals</div>
+        <div class="col-sm">{{ object.goals|sanitize_html|linebreaks }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Notes</div>
+        <div class="col-sm">{{ object.notes|sanitize_html|linebreaks }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Public Information</div>
+        <div class="col-sm">{{ object.public_info|sanitize_html|linebreaks }}</div>
+    </div>
+</div>

--- a/characters/templates/characters/werewolf/fomor/history_block_form.html
+++ b/characters/templates/characters/werewolf/fomor/history_block_form.html
@@ -1,0 +1,24 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">History</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Write your character's history and background details. Anything publicly known, such as the Fame Background, should be represented in the Public Information field.
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm">History</div>
+    <div class="col-sm">{{ form.history }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Goals</div>
+    <div class="col-sm">{{ form.goals }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Notes</div>
+    <div class="col-sm">{{ form.notes }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Public Information</div>
+    <div class="col-sm">{{ form.public_info }}</div>
+</div>

--- a/characters/templates/characters/werewolf/fomor/specialties_block_form.html
+++ b/characters/templates/characters/werewolf/fomor/specialties_block_form.html
@@ -1,0 +1,14 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Choose Specialties</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Choose specialties. Recall that we use the Well-Skilled Craftsman rules so some Abilities require specialties before the 4th dot.
+    </div>
+</div>
+{% for field in form %}
+    <div class="row">
+        <div class="col-sm">{{ field.label }}</div>
+        <div class="col-sm">{{ field }}</div>
+    </div>
+{% endfor %}

--- a/characters/urls/werewolf/ajax.py
+++ b/characters/urls/werewolf/ajax.py
@@ -13,4 +13,9 @@ urls = [
         views.werewolf.kinfolk.KinfolkFreebieFormPopulationView.as_view(),
         name="load_kinfolk_examples",
     ),
+    path(
+        "load_fomor_examples/",
+        views.werewolf.fomor.FomorFreebieFormPopulationView.as_view(),
+        name="load_fomor_examples",
+    ),
 ]

--- a/characters/urls/werewolf/update.py
+++ b/characters/urls/werewolf/update.py
@@ -54,7 +54,7 @@ urls = [
     ),
     path(
         "fomor/<pk>/",
-        views.werewolf.FomorUpdateView.as_view(),
+        views.werewolf.FomorCharacterCreationView.as_view(),
         name="fomor",
     ),
     path(

--- a/characters/views/werewolf/__init__.py
+++ b/characters/views/werewolf/__init__.py
@@ -12,10 +12,19 @@ from .charm import (
     SpiritCharmUpdateView,
 )
 from .fomor import (
+    FomorAbilityView,
+    FomorAttributeView,
+    FomorBackgroundsView,
     FomorBasicsView,
     FomorCharacterCreationView,
     FomorCreateView,
     FomorDetailView,
+    FomorExtrasView,
+    FomorFreebieFormPopulationView,
+    FomorFreebiesView,
+    FomorLanguagesView,
+    FomorPowersView,
+    FomorSpecialtiesView,
     FomorUpdateView,
 )
 from .fomoripower import (

--- a/characters/views/werewolf/fomor.py
+++ b/characters/views/werewolf/fomor.py
@@ -1,10 +1,27 @@
+from typing import Any
+
+from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.werewolf.fomor import FomorCreationForm
+from characters.models.core import Human
+from characters.models.core.specialty import Specialty
 from characters.models.werewolf.fomor import Fomor
+from characters.models.werewolf.fomoripower import FomoriPower
 from characters.views.core.backgrounds import HumanBackgroundsView
-from characters.views.core.human import HumanAttributeView, HumanCharacterCreationView
+from characters.views.core.human import (
+    HumanAttributeView,
+    HumanCharacterCreationView,
+    HumanFreebieFormPopulationView,
+    HumanFreebiesView,
+)
 from characters.views.werewolf.wtahuman import WtAHumanAbilityView
+from core.forms.language import HumanLanguageForm
+from core.models import Language
 from core.views.approved_user_mixin import SpecialUserMixin
+from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
 from django.views.generic import CreateView, DetailView, FormView, UpdateView
 
 
@@ -206,17 +223,182 @@ class FomorBackgroundsView(HumanBackgroundsView):
     template_name = "characters/werewolf/fomor/chargen.html"
 
 
+class FomorPowersView(SpecialUserMixin, UpdateView):
+    model = Fomor
+    fields = ["powers", "rage", "gnosis"]
+    template_name = "characters/werewolf/fomor/chargen.html"
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["powers"].queryset = FomoriPower.objects.all()
+        form.fields["powers"].required = False
+        form.fields["powers"].help_text = (
+            "Select the powers your Fomor possesses. Fomori typically have 1-3 powers."
+        )
+        form.fields["rage"].help_text = "Fomori typically have 1-5 Rage"
+        form.fields["gnosis"].help_text = "Fomori typically have 1-5 Gnosis"
+        return form
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
+        return context
+
+    def form_valid(self, form):
+        self.object.creation_status += 1
+        self.object.save()
+        return super().form_valid(form)
+
+
+class FomorExtrasView(SpecialUserMixin, UpdateView):
+    model = Fomor
+    fields = [
+        "date_of_birth",
+        "apparent_age",
+        "age",
+        "description",
+        "history",
+        "goals",
+        "notes",
+        "public_info",
+    ]
+    template_name = "characters/werewolf/fomor/chargen.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
+        return context
+
+    def form_valid(self, form):
+        self.object.creation_status += 1
+        self.object.save()
+        return super().form_valid(form)
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["date_of_birth"].widget = forms.DateInput(attrs={"type": "date"})
+        form.fields["description"].widget.attrs.update(
+            {
+                "placeholder": "Describe your character's physical appearance. Be detailed, this will be visible to other players."
+            }
+        )
+        form.fields["history"].widget.attrs.update(
+            {
+                "placeholder": "Describe character history/backstory. Include information about their transformation into a Fomor, how they gained their powers, and their relationship with the Wyrm."
+            }
+        )
+        form.fields["goals"].widget.attrs.update(
+            {
+                "placeholder": "Describe your character's goals and motivations."
+            }
+        )
+        form.fields["notes"].widget.attrs.update({"placeholder": "Notes"})
+        form.fields["public_info"].widget.attrs.update(
+            {
+                "placeholder": "This will be displayed to all players who look at your character."
+            }
+        )
+        return form
+
+
+class FomorFreebiesView(HumanFreebiesView):
+    model = Fomor
+    form_class = HumanFreebiesForm
+    template_name = "characters/werewolf/fomor/chargen.html"
+
+
+class FomorFreebieFormPopulationView(HumanFreebieFormPopulationView):
+    primary_class = Fomor
+    template_name = "characters/core/human/load_examples_dropdown_list.html"
+
+
+class FomorLanguagesView(SpecialUserMixin, FormView):
+    form_class = HumanLanguageForm
+    template_name = "characters/werewolf/fomor/chargen.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        obj = get_object_or_404(Fomor, pk=kwargs.get("pk"))
+        if "Language" not in obj.merits_and_flaws.values_list("name", flat=True):
+            obj.languages.add(Language.objects.get(name="English"))
+            obj.creation_status += 1
+            obj.save()
+            return HttpResponseRedirect(obj.get_absolute_url())
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        fomor_pk = self.kwargs.get("pk")
+        num_languages = Fomor.objects.get(pk=fomor_pk).num_languages()
+        kwargs.update({"pk": fomor_pk, "num_languages": int(num_languages)})
+        return kwargs
+
+    def form_valid(self, form):
+        fomor_pk = self.kwargs.get("pk")
+        fomor = get_object_or_404(Fomor, pk=fomor_pk)
+        num_languages = fomor.num_languages()
+        fomor.languages.add(Language.objects.get(name="English"))
+        for i in range(num_languages):
+            language_name = form.cleaned_data.get(f"language_{i+1}")
+            if language_name:
+                language, created = Language.objects.get_or_create(name=language_name)
+                fomor.languages.add(language)
+        fomor.creation_status += 1
+        fomor.save()
+        return HttpResponseRedirect(fomor.get_absolute_url())
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["object"] = get_object_or_404(Fomor, pk=self.kwargs.get("pk"))
+        context["is_approved_user"] = self.check_if_special_user(
+            context["object"], self.request.user
+        )
+        return context
+
+
+class FomorSpecialtiesView(SpecialUserMixin, FormView):
+    form_class = SpecialtiesForm
+    template_name = "characters/werewolf/fomor/chargen.html"
+
+    def get_context_data(self, **kwargs) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["object"] = Fomor.objects.get(id=self.kwargs["pk"])
+        context["is_approved_user"] = self.check_if_special_user(
+            context["object"], self.request.user
+        )
+        return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        fomor = Fomor.objects.get(id=self.kwargs["pk"])
+        kwargs["object"] = fomor
+        kwargs["specialties_needed"] = fomor.needed_specialties()
+        return kwargs
+
+    def form_valid(self, form):
+        context = self.get_context_data()
+        fomor = context["object"]
+        for field in form.fields:
+            spec = Specialty.objects.get_or_create(name=form.data[field], stat=field)[0]
+            fomor.specialties.add(spec)
+        fomor.status = "Sub"
+        fomor.save()
+        return HttpResponseRedirect(fomor.get_absolute_url())
+
+
 class FomorCharacterCreationView(HumanCharacterCreationView):
     view_mapping = {
         1: FomorAttributeView,
         2: FomorAbilityView,
         3: FomorBackgroundsView,
-        # TODO: Powers
-        # TODO: Backstory
-        # TODO: Freebies
-        # TODO: Languages
-        # TODO: Expanded Backgrounds
-        # TODO: Specialties
+        4: FomorPowersView,
+        5: FomorExtrasView,
+        6: FomorFreebiesView,
+        7: FomorLanguagesView,
+        8: FomorSpecialtiesView,
     }
     model_class = Fomor
     key_property = "creation_status"


### PR DESCRIPTION
Implement complete 8-stage character creation process for Fomor characters, similar to Mage character creation. This resolves #813.

Stages implemented:
1. Attributes - Physical/Social/Mental distribution (6/4/3)
2. Abilities - Talent/Skill/Knowledge distribution
3. Backgrounds - Limited to allies, contacts, resources (3 points)
4. Powers - Fomori powers selection, rage, and gnosis
5. Extras - Appearance, history, goals, and backstory
6. Freebies - Spending freebie points with ST approval
7. Languages - Language selection based on Merit
8. Specialties - Required specialties for abilities ≥4

Changes:
- Add FomorPowersView for selecting powers, rage, and gnosis
- Add FomorExtrasView for biographical information
- Add FomorFreebiesView with AJAX support for freebie spending
- Add FomorLanguagesView for language selection
- Add FomorSpecialtiesView for required specialties
- Update FomorCharacterCreationView with complete 8-stage mapping
- Create template includes for each stage (form and display variants)
- Add AJAX endpoint for Fomor freebie form population
- Update URL routing to use FomorCharacterCreationView for staged creation
- Export all new views in characters.views.werewolf module

The implementation follows the established pattern from Mage character creation, using a DictView dispatcher that routes to stage-specific views based on the character's creation_status property.