### PR TITLE
Add full character creation for Changelings

### DIFF
--- a/characters/models/changeling/changeling.py
+++ b/characters/models/changeling/changeling.py
@@ -10,6 +10,8 @@ from django.utils.timezone import now
 class Changeling(CtDHuman):
     type = "changeling"
 
+    freebie_step = 6
+
     court = models.CharField(
         default="",
         max_length=20,
@@ -289,3 +291,33 @@ class Changeling(CtDHuman):
         if "Sidhe" in self.kith.name:
             self.add_attribute("appearance", maximum=10)
             self.add_attribute("appearance", maximum=10)
+
+    def art_freebies(self, form):
+        """Spend freebies to increase an art"""
+        trait = form.cleaned_data["example"]
+        value = getattr(self, trait.property_name, 0) + 1
+        cost = 5
+        self.add_art(trait.property_name)
+        self.freebies -= cost
+        self.spent_freebies.append(self.freebie_spend_record(trait.name, trait.property_name, value, cost))
+        return True
+
+    def realm_freebies(self, form):
+        """Spend freebies to increase a realm"""
+        trait = form.cleaned_data["example"]
+        value = getattr(self, trait.property_name, 0) + 1
+        cost = 3
+        self.add_realm(trait.property_name)
+        self.freebies -= cost
+        self.spent_freebies.append(self.freebie_spend_record(trait.name, trait.property_name, value, cost))
+        return True
+
+    def glamour_freebies(self, form):
+        """Spend freebies to increase glamour"""
+        trait = "Glamour"
+        value = self.glamour + 1
+        cost = 3
+        self.add_glamour()
+        self.freebies -= cost
+        self.spent_freebies.append(self.freebie_spend_record(trait, "glamour", value, cost))
+        return True

--- a/characters/templates/characters/changeling/changeling/arts_realms_display.html
+++ b/characters/templates/characters/changeling/changeling/arts_realms_display.html
@@ -1,0 +1,134 @@
+{% load dots %}
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Arts & Realms</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        <h3 class="{{ object.get_heading }}">Arts</h3>
+    </div>
+</div>
+<div class="row">
+    {% if object.autumn > 0 %}
+        <div class="col-sm-3">Autumn</div>
+        <div class="col-sm-3">{{ object.autumn|dots }}</div>
+    {% endif %}
+    {% if object.chicanery > 0 %}
+        <div class="col-sm-3">Chicanery</div>
+        <div class="col-sm-3">{{ object.chicanery|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.chronos > 0 %}
+        <div class="col-sm-3">Chronos</div>
+        <div class="col-sm-3">{{ object.chronos|dots }}</div>
+    {% endif %}
+    {% if object.contract > 0 %}
+        <div class="col-sm-3">Contract</div>
+        <div class="col-sm-3">{{ object.contract|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.dragons_ire > 0 %}
+        <div class="col-sm-3">Dragon's Ire</div>
+        <div class="col-sm-3">{{ object.dragons_ire|dots }}</div>
+    {% endif %}
+    {% if object.legerdemain > 0 %}
+        <div class="col-sm-3">Legerdemain</div>
+        <div class="col-sm-3">{{ object.legerdemain|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.metamorphosis > 0 %}
+        <div class="col-sm-3">Metamorphosis</div>
+        <div class="col-sm-3">{{ object.metamorphosis|dots }}</div>
+    {% endif %}
+    {% if object.naming > 0 %}
+        <div class="col-sm-3">Naming</div>
+        <div class="col-sm-3">{{ object.naming|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.oneiromancy > 0 %}
+        <div class="col-sm-3">Oneiromancy</div>
+        <div class="col-sm-3">{{ object.oneiromancy|dots }}</div>
+    {% endif %}
+    {% if object.primal > 0 %}
+        <div class="col-sm-3">Primal</div>
+        <div class="col-sm-3">{{ object.primal|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.pyretics > 0 %}
+        <div class="col-sm-3">Pyretics</div>
+        <div class="col-sm-3">{{ object.pyretics|dots }}</div>
+    {% endif %}
+    {% if object.skycraft > 0 %}
+        <div class="col-sm-3">Skycraft</div>
+        <div class="col-sm-3">{{ object.skycraft|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.soothsay > 0 %}
+        <div class="col-sm-3">Soothsay</div>
+        <div class="col-sm-3">{{ object.soothsay|dots }}</div>
+    {% endif %}
+    {% if object.sovereign > 0 %}
+        <div class="col-sm-3">Sovereign</div>
+        <div class="col-sm-3">{{ object.sovereign|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.spring > 0 %}
+        <div class="col-sm-3">Spring</div>
+        <div class="col-sm-3">{{ object.spring|dots }}</div>
+    {% endif %}
+    {% if object.summer > 0 %}
+        <div class="col-sm-3">Summer</div>
+        <div class="col-sm-3">{{ object.summer|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.wayfare > 0 %}
+        <div class="col-sm-3">Wayfare</div>
+        <div class="col-sm-3">{{ object.wayfare|dots }}</div>
+    {% endif %}
+    {% if object.winter > 0 %}
+        <div class="col-sm-3">Winter</div>
+        <div class="col-sm-3">{{ object.winter|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    <div class="col-sm">
+        <h3 class="{{ object.get_heading }}">Realms</h3>
+    </div>
+</div>
+<div class="row">
+    {% if object.actor > 0 %}
+        <div class="col-sm-3">Actor</div>
+        <div class="col-sm-3">{{ object.actor|dots }}</div>
+    {% endif %}
+    {% if object.fae > 0 %}
+        <div class="col-sm-3">Fae</div>
+        <div class="col-sm-3">{{ object.fae|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.nature_realm > 0 %}
+        <div class="col-sm-3">Nature</div>
+        <div class="col-sm-3">{{ object.nature_realm|dots }}</div>
+    {% endif %}
+    {% if object.prop > 0 %}
+        <div class="col-sm-3">Prop</div>
+        <div class="col-sm-3">{{ object.prop|dots }}</div>
+    {% endif %}
+</div>
+<div class="row">
+    {% if object.scene > 0 %}
+        <div class="col-sm-3">Scene</div>
+        <div class="col-sm-3">{{ object.scene|dots }}</div>
+    {% endif %}
+    {% if object.time > 0 %}
+        <div class="col-sm-3">Time</div>
+        <div class="col-sm-3">{{ object.time|dots }}</div>
+    {% endif %}
+</div>

--- a/characters/templates/characters/changeling/changeling/arts_realms_form.html
+++ b/characters/templates/characters/changeling/changeling/arts_realms_form.html
@@ -1,0 +1,90 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Arts & Realms</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Distribute 3 dots among Arts and 5 dots among Realms. Each can have a maximum of 5 dots.
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm">
+        <h3 class="{{ object.get_heading }}">Arts (3 dots total)</h3>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Autumn</div>
+    <div class="col-sm-3">{{ form.autumn }}</div>
+    <div class="col-sm-3">Chicanery</div>
+    <div class="col-sm-3">{{ form.chicanery }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Chronos</div>
+    <div class="col-sm-3">{{ form.chronos }}</div>
+    <div class="col-sm-3">Contract</div>
+    <div class="col-sm-3">{{ form.contract }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Dragon's Ire</div>
+    <div class="col-sm-3">{{ form.dragons_ire }}</div>
+    <div class="col-sm-3">Legerdemain</div>
+    <div class="col-sm-3">{{ form.legerdemain }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Metamorphosis</div>
+    <div class="col-sm-3">{{ form.metamorphosis }}</div>
+    <div class="col-sm-3">Naming</div>
+    <div class="col-sm-3">{{ form.naming }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Oneiromancy</div>
+    <div class="col-sm-3">{{ form.oneiromancy }}</div>
+    <div class="col-sm-3">Primal</div>
+    <div class="col-sm-3">{{ form.primal }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Pyretics</div>
+    <div class="col-sm-3">{{ form.pyretics }}</div>
+    <div class="col-sm-3">Skycraft</div>
+    <div class="col-sm-3">{{ form.skycraft }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Soothsay</div>
+    <div class="col-sm-3">{{ form.soothsay }}</div>
+    <div class="col-sm-3">Sovereign</div>
+    <div class="col-sm-3">{{ form.sovereign }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Spring</div>
+    <div class="col-sm-3">{{ form.spring }}</div>
+    <div class="col-sm-3">Summer</div>
+    <div class="col-sm-3">{{ form.summer }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Wayfare</div>
+    <div class="col-sm-3">{{ form.wayfare }}</div>
+    <div class="col-sm-3">Winter</div>
+    <div class="col-sm-3">{{ form.winter }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">
+        <h3 class="{{ object.get_heading }}">Realms (5 dots total)</h3>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Actor</div>
+    <div class="col-sm-3">{{ form.actor }}</div>
+    <div class="col-sm-3">Fae</div>
+    <div class="col-sm-3">{{ form.fae }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Nature</div>
+    <div class="col-sm-3">{{ form.nature_realm }}</div>
+    <div class="col-sm-3">Prop</div>
+    <div class="col-sm-3">{{ form.prop }}</div>
+</div>
+<div class="row">
+    <div class="col-sm-3">Scene</div>
+    <div class="col-sm-3">{{ form.scene }}</div>
+    <div class="col-sm-3">Time</div>
+    <div class="col-sm-3">{{ form.time }}</div>
+</div>

--- a/characters/templates/characters/changeling/changeling/chargen.html
+++ b/characters/templates/characters/changeling/changeling/chargen.html
@@ -35,6 +35,56 @@
                 {% include "characters/core/background_block/detail.html" with backgrounds=object.backgrounds %}
             {% endif %}
         {% endblock backgrounds %}
+        {% block arts_realms %}
+            {% if object.creation_status == 4 %}
+                {% include "characters/changeling/changeling/arts_realms_form.html" %}
+            {% elif object.creation_status > 4 %}
+                {% include "characters/changeling/changeling/arts_realms_display.html" %}
+            {% endif %}
+        {% endblock arts_realms %}
+        {% block advantages %}
+            {% include "characters/core/human/advantages_display.html" %}
+        {% endblock advantages %}
+        {% block appearance %}
+            {% if object.creation_status == 5 %}
+                {% include "characters/changeling/changeling/extras_form.html" %}
+            {% elif object.creation_status > 5 %}
+                {% include "characters/changeling/changeling/extras_display.html" %}
+            {% endif %}
+        {% endblock appearance %}
+        {% block mfs %}
+            {% if object.creation_status >= 5 %}
+                {% include "characters/core/meritflaw/display_includes/meritflaw_block.html" %}
+            {% endif %}
+        {% endblock mfs %}
+        {% block history %}
+            {% if object.creation_status == 5 %}
+                {% include "characters/changeling/changeling/history_form.html" %}
+            {% elif object.creation_status > 5 %}
+                {% include "characters/changeling/changeling/history_display.html" %}
+            {% endif %}
+        {% endblock history %}
+        {% block freebies %}
+            {% if object.creation_status == 6 and object.freebies_approved %}
+                {% include "characters/changeling/changeling/freebies_form.html" %}
+            {% elif object.creation_status == 6 %}
+                <div class="row">
+                    <h2 class="col-sm {{ object.get_heading }}">Waiting on ST to Assign Freebie Total</h2>
+                </div>
+            {% endif %}
+        {% endblock freebies %}
+        {% block languages %}
+            {% if object.creation_status > 7 %}
+                {% include "characters/core/human/language_display_block.html" %}
+            {% elif object.creation_status == 7 %}
+                {% include "characters/core/human/human_language_block_form.html" %}
+            {% endif %}
+        {% endblock languages %}
+        {% block specialties_form %}
+            {% if object.creation_status == 8 %}
+                {% include "characters/changeling/changeling/specialties_form.html" %}
+            {% endif %}
+        {% endblock specialties_form %}
     {% else %}
         {% include "characters/core/character/not_owner.html" %}
     {% endif %}

--- a/characters/templates/characters/changeling/changeling/extras_display.html
+++ b/characters/templates/characters/changeling/changeling/extras_display.html
@@ -1,0 +1,76 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Character Details</h2>
+</div>
+{% if object.date_of_birth or object.apparent_age or object.age %}
+    <div class="row">
+        {% if object.date_of_birth %}
+            <div class="col-sm">Date of Birth</div>
+            <div class="col-sm">{{ object.date_of_birth }}</div>
+        {% endif %}
+        {% if object.apparent_age %}
+            <div class="col-sm">Apparent Age</div>
+            <div class="col-sm">{{ object.apparent_age }}</div>
+        {% endif %}
+        {% if object.age %}
+            <div class="col-sm">Age</div>
+            <div class="col-sm">{{ object.age }}</div>
+        {% endif %}
+    </div>
+{% endif %}
+{% if object.description %}
+    <div class="row">
+        <div class="col-sm">Description</div>
+        <div class="col-sm">{{ object.description }}</div>
+    </div>
+{% endif %}
+{% if object.public_info %}
+    <div class="row">
+        <div class="col-sm">Public Information</div>
+        <div class="col-sm">{{ object.public_info }}</div>
+    </div>
+{% endif %}
+<div class="row">
+    <h3 class="col-sm {{ object.get_heading }}">Changeling Details</h3>
+</div>
+{% if object.true_name %}
+    <div class="row">
+        <div class="col-sm">True Name</div>
+        <div class="col-sm">{{ object.true_name }}</div>
+    </div>
+{% endif %}
+{% if object.fae_mien %}
+    <div class="row">
+        <div class="col-sm">Fae Mien</div>
+        <div class="col-sm">{{ object.fae_mien }}</div>
+    </div>
+{% endif %}
+{% if object.crysalis %}
+    <div class="row">
+        <div class="col-sm">Chrysalis</div>
+        <div class="col-sm">{{ object.crysalis }}</div>
+    </div>
+{% endif %}
+{% if object.date_of_crysalis %}
+    <div class="row">
+        <div class="col-sm">Date of Chrysalis</div>
+        <div class="col-sm">{{ object.date_of_crysalis }}</div>
+    </div>
+{% endif %}
+{% if object.musing_threshold %}
+    <div class="row">
+        <div class="col-sm">Musing Threshold</div>
+        <div class="col-sm">{{ object.get_musing_threshold_display }}</div>
+    </div>
+{% endif %}
+{% if object.ravaging_threshold %}
+    <div class="row">
+        <div class="col-sm">Ravaging Threshold</div>
+        <div class="col-sm">{{ object.get_ravaging_threshold_display }}</div>
+    </div>
+{% endif %}
+{% if object.antithesis %}
+    <div class="row">
+        <div class="col-sm">Antithesis</div>
+        <div class="col-sm">{{ object.antithesis }}</div>
+    </div>
+{% endif %}

--- a/characters/templates/characters/changeling/changeling/extras_form.html
+++ b/characters/templates/characters/changeling/changeling/extras_form.html
@@ -1,0 +1,57 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Character Details</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Fill out character appearance and background details. Be sure to write a good description, as that will be publicly viewable.
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm">Date of Birth</div>
+    <div class="col-sm">{{ form.date_of_birth }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Apparent Age</div>
+    <div class="col-sm">{{ form.apparent_age }}</div>
+    <div class="col-sm">Age</div>
+    <div class="col-sm">{{ form.age }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Description</div>
+    <div class="col-sm">{{ form.description }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Public Information</div>
+    <div class="col-sm">{{ form.public_info }}</div>
+</div>
+<div class="row">
+    <h3 class="col-sm {{ object.get_heading }}">Changeling Details</h3>
+</div>
+<div class="row">
+    <div class="col-sm">True Name</div>
+    <div class="col-sm">{{ form.true_name }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Fae Mien</div>
+    <div class="col-sm">{{ form.fae_mien }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Chrysalis</div>
+    <div class="col-sm">{{ form.crysalis }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Date of Chrysalis</div>
+    <div class="col-sm">{{ form.date_of_crysalis }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Musing Threshold</div>
+    <div class="col-sm">{{ form.musing_threshold }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Ravaging Threshold</div>
+    <div class="col-sm">{{ form.ravaging_threshold }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Antithesis</div>
+    <div class="col-sm">{{ form.antithesis }}</div>
+</div>

--- a/characters/templates/characters/changeling/changeling/freebies_form.html
+++ b/characters/templates/characters/changeling/changeling/freebies_form.html
@@ -1,0 +1,156 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Freebie Spend</h2>
+</div>
+{% if object.freebies > 0 %}
+    <div class="row">
+        <div class="col-sm">Spend Freebie points. The costs are as follows:</div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">
+            <b>Trait</b>
+        </div>
+        <div class="col-sm-3 border">
+            <b>Cost</b>
+        </div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Attribute</div>
+        <div class="col-sm-3 border">5</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Ability</div>
+        <div class="col-sm-3 border">2</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Background</div>
+        <div class="col-sm-3 border">1</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Art</div>
+        <div class="col-sm-3 border">5</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Realm</div>
+        <div class="col-sm-3 border">3</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Willpower</div>
+        <div class="col-sm-3 border">1</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Glamour</div>
+        <div class="col-sm-3 border">3</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row centertext">
+        <div class="col-sm-3"></div>
+        <div class="col-sm-3 border">Merits/Flaws</div>
+        <div class="col-sm-3 border">Rating</div>
+        <div class="col-sm-3"></div>
+    </div>
+    <div class="row">
+        <h3 class="col-sm {{ object.get_heading }}">Freebies Remaining</h3>
+        <h3 class="col-sm {{ object.get_heading }}">{{ object.freebies }}</h3>
+    </div>
+{% endif %}
+<div class="row">
+    <div class="col-sm">{{ form.category }}</div>
+    <div class="col-sm d-none" id="example_wrap">{{ form.example }}</div>
+    <div class="col-sm d-none" id="value_wrap">{{ form.value }}</div>
+    <div class="col-sm d-none" id="note_wrap">{{ form.note }}</div>
+    <div class="col-sm d-none" id="pooled_wrap">Pooled? {{ form.pooled }}</div>
+</div>
+{% for item in object.spent_freebies %}
+    <div class="row">
+        <div class="col-sm">{{ item.trait }} {{ item.value }}</div>
+        <div class="col-sm">{{ item.cost }} freebies</div>
+    </div>
+{% endfor %}
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const categorySelectMenu = document.getElementById("id_category");
+        const exampleSelectMenu = document.getElementById("id_example")
+        const exampleElement = document.getElementById("example_wrap");
+        const valueElement = document.getElementById("value_wrap");
+        const noteElement = document.getElementById("note_wrap");
+        const pooled_wrap = document.getElementById("pooled_wrap");
+
+        var isGroupMember = {{ object.is_group_member|lower }};
+
+        categorySelectMenu.addEventListener("change", function() {
+            const selectedValue = this.value;
+
+            // Update the class of the element
+            if(["Willpower", "-----", "Glamour"].includes(this.value)){
+                exampleElement.classList.add("d-none");
+                valueElement.classList.add("d-none");
+                noteElement.classList.add("d-none");
+                pooled_wrap.classList.add("d-none");
+            } else {
+                exampleElement.classList.remove("d-none");
+                valueElement.classList.add("d-none");
+                noteElement.classList.add("d-none");
+                pooled_wrap.classList.add("d-none");
+            }
+            if(this.value == "MeritFlaw"){
+                valueElement.classList.remove("d-none");
+                noteElement.classList.add("d-none");
+                pooled_wrap.classList.add("d-none");
+            }
+            if(this.value == "New Background"){
+                exampleElement.classList.remove("d-none");
+                noteElement.classList.remove("d-none");
+                valueElement.classList.add("d-none");
+                if (isGroupMember) {
+                    pooled_wrap.classList.remove("d-none");
+                } else {
+                    pooled_wrap.classList.add("d-none");
+                }
+            }
+
+            // Make the AJAX call
+            $.ajax({                       // initialize an AJAX request
+                url: '{% url 'characters:changeling:ajax:load_changeling_examples' %}',                    // set the url of the request
+                data: {
+                'category': this.value,       // add the category to the GET parameters
+                'object': {{object.id}}
+                },
+                success: function (data) {   // `data` is the return of the view function
+                $("#id_example").html(data);  // replace the contents of the example input with the data from the server
+                $("#id_value").html('<option value="">---</option>');
+                }
+            });
+        });
+
+        exampleSelectMenu.addEventListener("change", function() {
+            const selectedValue = this.value;
+            if(categorySelectMenu.value == "MeritFlaw"){
+                $.ajax({
+                    url: '{% url 'characters:ajax:load_values' %}',
+                    data: {
+                        'example': this.value
+                    },
+                    success: function (data) {
+                        $("#id_value").html(data);
+                    }
+                });
+            }
+        });
+    });
+
+</script>

--- a/characters/templates/characters/changeling/changeling/history_display.html
+++ b/characters/templates/characters/changeling/changeling/history_display.html
@@ -1,0 +1,21 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">History</h2>
+</div>
+{% if object.history %}
+    <div class="row">
+        <div class="col-sm">History</div>
+        <div class="col-sm">{{ object.history }}</div>
+    </div>
+{% endif %}
+{% if object.goals %}
+    <div class="row">
+        <div class="col-sm">Goals</div>
+        <div class="col-sm">{{ object.goals }}</div>
+    </div>
+{% endif %}
+{% if object.notes %}
+    <div class="row">
+        <div class="col-sm">Notes</div>
+        <div class="col-sm">{{ object.notes }}</div>
+    </div>
+{% endif %}

--- a/characters/templates/characters/changeling/changeling/history_form.html
+++ b/characters/templates/characters/changeling/changeling/history_form.html
@@ -1,0 +1,20 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">History</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Write your character's history and background details.
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm">History</div>
+    <div class="col-sm">{{ form.history }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Goals</div>
+    <div class="col-sm">{{ form.goals }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Notes</div>
+    <div class="col-sm">{{ form.notes }}</div>
+</div>

--- a/characters/templates/characters/changeling/changeling/specialties_form.html
+++ b/characters/templates/characters/changeling/changeling/specialties_form.html
@@ -1,0 +1,14 @@
+<div class="row">
+    <h2 class="col-sm {{ object.get_heading }}">Choose Specialties</h2>
+</div>
+<div class="row">
+    <div class="col-sm">
+        Choose specialties. Recall that we use the Well-Skilled Craftsman rules so some Abilities require specialties before the 4th dot.
+    </div>
+</div>
+{% for field in form %}
+    <div class="row">
+        <div class="col-sm">{{ field.label }}</div>
+        <div class="col-sm">{{ field }}</div>
+    </div>
+{% endfor %}

--- a/characters/urls/changeling/ajax.py
+++ b/characters/urls/changeling/ajax.py
@@ -8,4 +8,9 @@ urls = [
         views.changeling.ctdhuman.CtDHumanFreebieFormPopulationView.as_view(),
         name="load_ctdhuman_examples",
     ),
+    path(
+        "load_changeling_examples/",
+        views.changeling.changeling.ChangelingFreebieFormPopulationView.as_view(),
+        name="load_changeling_examples",
+    ),
 ]

--- a/characters/views/changeling/changeling.py
+++ b/characters/views/changeling/changeling.py
@@ -1,13 +1,31 @@
+from typing import Any
+
 from characters.forms.changeling.changeling import ChangelingCreationForm
+from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.specialty import SpecialtiesForm
 from characters.models.changeling.changeling import Changeling
+from characters.models.core.human import Human
 from characters.models.core.merit_flaw_block import MeritFlawRating
+from characters.models.core.specialty import Specialty
+from characters.models.core.statistic import Statistic
 from characters.views.changeling.ctdhuman import CtDHumanAbilityView
 from characters.views.core.backgrounds import HumanBackgroundsView
-from characters.views.core.human import HumanAttributeView, HumanCharacterCreationView
+from characters.views.core.generic_background import GenericBackgroundView
+from characters.views.core.human import (
+    HumanAttributeView,
+    HumanCharacterCreationView,
+    HumanFreebieFormPopulationView,
+    HumanFreebiesView,
+)
 from characters.views.mage.mtahuman import MtAHumanAbilityView
+from core.forms.language import HumanLanguageForm
+from core.models import Language
 from core.views.approved_user_mixin import SpecialUserMixin
+from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.views.generic import CreateView, DetailView, FormView, UpdateView
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render
+from django.views.generic import CreateView, DetailView, FormView, UpdateView, View
 
 
 class ChangelingDetailView(SpecialUserMixin, DetailView):
@@ -273,17 +291,343 @@ class ChangelingBackgroundsView(HumanBackgroundsView):
     template_name = "characters/changeling/changeling/chargen.html"
 
 
+class ChangelingArtsRealmsView(SpecialUserMixin, UpdateView):
+    model = Changeling
+    fields = [
+        "autumn",
+        "chicanery",
+        "chronos",
+        "contract",
+        "dragons_ire",
+        "legerdemain",
+        "metamorphosis",
+        "naming",
+        "oneiromancy",
+        "primal",
+        "pyretics",
+        "skycraft",
+        "soothsay",
+        "sovereign",
+        "spring",
+        "summer",
+        "wayfare",
+        "winter",
+        "actor",
+        "fae",
+        "nature_realm",
+        "prop",
+        "scene",
+        "time",
+    ]
+    template_name = "characters/changeling/changeling/chargen.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
+        return context
+
+    def form_valid(self, form):
+        # Get all arts values
+        arts = {
+            "autumn": form.cleaned_data.get("autumn", 0),
+            "chicanery": form.cleaned_data.get("chicanery", 0),
+            "chronos": form.cleaned_data.get("chronos", 0),
+            "contract": form.cleaned_data.get("contract", 0),
+            "dragons_ire": form.cleaned_data.get("dragons_ire", 0),
+            "legerdemain": form.cleaned_data.get("legerdemain", 0),
+            "metamorphosis": form.cleaned_data.get("metamorphosis", 0),
+            "naming": form.cleaned_data.get("naming", 0),
+            "oneiromancy": form.cleaned_data.get("oneiromancy", 0),
+            "primal": form.cleaned_data.get("primal", 0),
+            "pyretics": form.cleaned_data.get("pyretics", 0),
+            "skycraft": form.cleaned_data.get("skycraft", 0),
+            "soothsay": form.cleaned_data.get("soothsay", 0),
+            "sovereign": form.cleaned_data.get("sovereign", 0),
+            "spring": form.cleaned_data.get("spring", 0),
+            "summer": form.cleaned_data.get("summer", 0),
+            "wayfare": form.cleaned_data.get("wayfare", 0),
+            "winter": form.cleaned_data.get("winter", 0),
+        }
+
+        # Get all realms values
+        realms = {
+            "actor": form.cleaned_data.get("actor", 0),
+            "fae": form.cleaned_data.get("fae", 0),
+            "nature_realm": form.cleaned_data.get("nature_realm", 0),
+            "prop": form.cleaned_data.get("prop", 0),
+            "scene": form.cleaned_data.get("scene", 0),
+            "time": form.cleaned_data.get("time", 0),
+        }
+
+        # Validate arts total is 3
+        total_arts = sum(arts.values())
+        if total_arts != 3:
+            form.add_error(None, f"Arts must total 3 dots (currently {total_arts})")
+            return self.form_invalid(form)
+
+        # Validate realms total is 5
+        total_realms = sum(realms.values())
+        if total_realms != 5:
+            form.add_error(None, f"Realms must total 5 dots (currently {total_realms})")
+            return self.form_invalid(form)
+
+        # Validate individual values don't exceed 5
+        for art_name, value in arts.items():
+            if value > 5:
+                form.add_error(art_name, "Cannot exceed 5 dots")
+                return self.form_invalid(form)
+
+        for realm_name, value in realms.items():
+            if value > 5:
+                form.add_error(realm_name, "Cannot exceed 5 dots")
+                return self.form_invalid(form)
+
+        # All validations passed, increment creation_status and save
+        self.object.creation_status += 1
+        self.object.save()
+        return super().form_valid(form)
+
+
+class ChangelingExtrasView(SpecialUserMixin, UpdateView):
+    model = Changeling
+    fields = [
+        "date_of_birth",
+        "apparent_age",
+        "age",
+        "description",
+        "history",
+        "goals",
+        "notes",
+        "public_info",
+        "true_name",
+        "crysalis",
+        "date_of_crysalis",
+        "fae_mien",
+        "antithesis",
+        "musing_threshold",
+        "ravaging_threshold",
+    ]
+    template_name = "characters/changeling/changeling/chargen.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
+        return context
+
+    def form_valid(self, form):
+        self.object.creation_status += 1
+        self.object.save()
+        return super().form_valid(form)
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["date_of_birth"].widget = forms.DateInput(attrs={"type": "date"})
+        form.fields["date_of_birth"].required = False
+        form.fields["date_of_crysalis"].widget = forms.DateInput(
+            attrs={"type": "date"}
+        )
+        form.fields["date_of_crysalis"].required = False
+        form.fields["description"].widget.attrs.update(
+            {
+                "placeholder": "Describe your character's physical appearance. Be detailed, this will be visible to other players."
+            }
+        )
+        form.fields["history"].widget.attrs.update(
+            {
+                "placeholder": "Describe character history/backstory. Include information about their mortal life and their Chrysalis."
+            }
+        )
+        form.fields["goals"].widget.attrs.update(
+            {
+                "placeholder": "Describe your character's long and short term goals."
+            }
+        )
+        form.fields["notes"].widget.attrs.update({"placeholder": "Notes"})
+        form.fields["public_info"].widget.attrs.update(
+            {
+                "placeholder": "This will be displayed to all players who look at your character."
+            }
+        )
+        form.fields["true_name"].widget.attrs.update(
+            {"placeholder": "Your character's fae true name"}
+        )
+        form.fields["crysalis"].widget.attrs.update(
+            {
+                "placeholder": "Describe your character's Chrysalis - how they awakened to their fae nature."
+            }
+        )
+        form.fields["fae_mien"].widget.attrs.update(
+            {"placeholder": "Describe your character's fae appearance."}
+        )
+        form.fields["antithesis"].widget.attrs.update(
+            {
+                "placeholder": "What is your character's Antithesis? What causes them to gain Banality?"
+            }
+        )
+        return form
+
+
+class ChangelingFreebiesView(HumanFreebiesView):
+    model = Changeling
+    form_class = HumanFreebiesForm
+    template_name = "characters/changeling/changeling/chargen.html"
+
+    def get_category_functions(self):
+        d = super().get_category_functions()
+        d.update(
+            {
+                "art": self.object.art_freebies,
+                "realm": self.object.realm_freebies,
+                "glamour": self.object.glamour_freebies,
+            }
+        )
+        return d
+
+
+class ChangelingFreebieFormPopulationView(HumanFreebieFormPopulationView):
+    primary_class = Changeling
+    template_name = "characters/core/human/load_examples_dropdown_list.html"
+
+    def category_method_map(self):
+        base_map = super().category_method_map()
+        base_map.update(
+            {
+                "Art": self.art_options,
+                "Realm": self.realm_options,
+                "Glamour": self.glamour_options,
+            }
+        )
+        return base_map
+
+    def art_options(self):
+        """Return all arts that are below 5 dots"""
+        arts = [
+            "autumn",
+            "chicanery",
+            "chronos",
+            "contract",
+            "dragons_ire",
+            "legerdemain",
+            "metamorphosis",
+            "naming",
+            "oneiromancy",
+            "primal",
+            "pyretics",
+            "skycraft",
+            "soothsay",
+            "sovereign",
+            "spring",
+            "summer",
+            "wayfare",
+            "winter",
+        ]
+        return [
+            Statistic.objects.get(property_name=art)
+            for art in arts
+            if getattr(self.character, art, 0) < 5
+        ]
+
+    def realm_options(self):
+        """Return all realms that are below 5 dots"""
+        realms = ["actor", "fae", "nature_realm", "prop", "scene", "time"]
+        return [
+            Statistic.objects.get(property_name=realm)
+            for realm in realms
+            if getattr(self.character, realm, 0) < 5
+        ]
+
+    def glamour_options(self):
+        """Glamour doesn't use options"""
+        return []
+
+
+class ChangelingLanguagesView(SpecialUserMixin, FormView):
+    form_class = HumanLanguageForm
+    template_name = "characters/changeling/changeling/chargen.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        obj = get_object_or_404(Changeling, pk=kwargs.get("pk"))
+        if "Language" not in obj.merits_and_flaws.values_list("name", flat=True):
+            obj.languages.add(Language.objects.get(name="English"))
+            obj.creation_status += 1
+            obj.save()
+            return HttpResponseRedirect(obj.get_absolute_url())
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        changeling_pk = self.kwargs.get("pk")
+        num_languages = Changeling.objects.get(pk=changeling_pk).num_languages()
+        kwargs.update({"pk": changeling_pk, "num_languages": int(num_languages)})
+        return kwargs
+
+    def form_valid(self, form):
+        changeling_pk = self.kwargs.get("pk")
+        changeling = get_object_or_404(Changeling, pk=changeling_pk)
+        num_languages = changeling.num_languages()
+        changeling.languages.add(Language.objects.get(name="English"))
+        for i in range(num_languages):
+            language_name = form.cleaned_data.get(f"language_{i+1}")
+            if language_name:
+                language, created = Language.objects.get_or_create(name=language_name)
+                changeling.languages.add(language)
+        changeling.creation_status += 1
+        changeling.save()
+        return HttpResponseRedirect(changeling.get_absolute_url())
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["object"] = get_object_or_404(Changeling, pk=self.kwargs.get("pk"))
+        context["is_approved_user"] = self.check_if_special_user(
+            context["object"], self.request.user
+        )
+        return context
+
+
+class ChangelingSpecialtiesView(SpecialUserMixin, FormView):
+    form_class = SpecialtiesForm
+    template_name = "characters/changeling/changeling/chargen.html"
+
+    def get_context_data(self, **kwargs) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["object"] = Changeling.objects.get(id=self.kwargs["pk"])
+        context["is_approved_user"] = self.check_if_special_user(
+            context["object"], self.request.user
+        )
+        return context
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        changeling = Changeling.objects.get(id=self.kwargs["pk"])
+        kwargs["object"] = changeling
+        kwargs["specialties_needed"] = changeling.needed_specialties()
+        return kwargs
+
+    def form_valid(self, form):
+        context = self.get_context_data()
+        changeling = context["object"]
+        for field in form.fields:
+            spec = Specialty.objects.get_or_create(name=form.data[field], stat=field)[0]
+            changeling.specialties.add(spec)
+        changeling.status = "Sub"
+        changeling.save()
+        return HttpResponseRedirect(changeling.get_absolute_url())
+
+
 class ChangelingCharacterCreationView(HumanCharacterCreationView):
     view_mapping = {
         1: ChangelingAttributeView,
         2: ChangelingAbilityView,
         3: ChangelingBackgroundsView,
-        # TODO: Powers
-        # TODO: Backstory
-        # TODO: Freebies
-        # TODO: Languages
-        # TODO: Expanded Backgrounds
-        # TODO: Specialties
+        4: ChangelingArtsRealmsView,
+        5: ChangelingExtrasView,
+        6: ChangelingFreebiesView,
+        7: ChangelingLanguagesView,
+        8: ChangelingSpecialtiesView,
     }
     model_class = Changeling
     key_property = "creation_status"


### PR DESCRIPTION
Implements 8-stage character creation flow for Changelings:
1. Attributes (7/5/3 distribution)
2. Abilities (13/9/5 distribution)
3. Backgrounds
4. Arts & Realms (3 dots Arts, 5 dots Realms)
5. Extras/Backstory (Changeling-specific fields)
6. Freebies (with Art, Realm, and Glamour support)
7. Languages
8. Specialties (final, sets status to "Sub")

Changes:
- Added ChangelingArtsRealmsView for Arts/Realms selection with validation
- Added ChangelingExtrasView for character details and Changeling backstory
- Added ChangelingFreebiesView with Changeling-specific freebie categories
- Added ChangelingLanguagesView for language selection
- Added ChangelingSpecialtiesView to finalize character creation
- Updated chargen.html template with all 8 stages
- Created template includes for forms and displays
- Added ChangelingFreebieFormPopulationView for AJAX freebie form
- Added Art, Realm, and Glamour freebie methods to Changeling model
- Set freebie_step = 6 in Changeling model
- Updated AJAX URLs for Changeling freebie form population

Resolves #811