### PR TITLE
Refactor demon ritual files to import lores from demon_lores.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,111 @@
+# ==============================================================================
+# Tellurian Games - World of Darkness Character Manager
+# Environment Configuration Template
+# ==============================================================================
+# Copy this file to .env and fill in your actual values
+# The .env file is gitignored and should never be committed to version control
+# ==============================================================================
+
+# ==============================================================================
+# DJANGO CORE SETTINGS
+# ==============================================================================
+
+# SECURITY WARNING: Generate a strong secret key for production!
+# You can generate one with: python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
+SECRET_KEY=django-insecure-default-key-CHANGE-THIS-IN-PRODUCTION
+
+# Debug mode - MUST be False in production for security
+# Values: True or False
+DJANGO_DEBUG=True
+
+# Comma-separated list of allowed hostnames/domains
+# Example: example.com,www.example.com,localhost,127.0.0.1
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+
+# ==============================================================================
+# DATABASE CONFIGURATION (Optional - defaults to SQLite)
+# ==============================================================================
+# Currently the app uses SQLite by default. For production, consider PostgreSQL.
+# To enable PostgreSQL, uncomment and configure these variables, then update
+# settings.py DATABASES configuration to use them.
+
+# DATABASE_ENGINE=django.db.backends.postgresql
+# DATABASE_NAME=tg_db
+# DATABASE_USER=tg_user
+# DATABASE_PASSWORD=your_db_password_here
+# DATABASE_HOST=localhost
+# DATABASE_PORT=5432
+
+# For MySQL/MariaDB:
+# DATABASE_ENGINE=django.db.backends.mysql
+# DATABASE_NAME=tg_db
+# DATABASE_USER=tg_user
+# DATABASE_PASSWORD=your_db_password_here
+# DATABASE_HOST=localhost
+# DATABASE_PORT=3306
+
+# ==============================================================================
+# EMAIL CONFIGURATION
+# ==============================================================================
+
+# Email Backend
+# Development: django.core.mail.backends.console.EmailBackend (prints to console)
+# Production SMTP: django.core.mail.backends.smtp.EmailBackend
+# Production SES: django_ses.SESBackend
+# Production Mailgun: anymail.backends.mailgun.EmailBackend
+EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+
+# SMTP Settings (for standard email providers like Gmail, SendGrid, etc.)
+# Only needed if using EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=localhost
+EMAIL_PORT=25
+EMAIL_USE_TLS=False
+EMAIL_USE_SSL=False
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+EMAIL_TIMEOUT=30
+
+# Default sender addresses
+DEFAULT_FROM_EMAIL=noreply@tellurian-games.com
+SERVER_EMAIL=noreply@tellurian-games.com
+
+# Password reset token expiration (in seconds)
+# Default: 259200 (3 days)
+PASSWORD_RESET_TIMEOUT=259200
+
+# ==============================================================================
+# AWS SES CONFIGURATION (Optional - for Amazon Simple Email Service)
+# ==============================================================================
+# Uncomment these if you want to use AWS SES for email delivery
+# Requires: pip install django-ses
+
+# AWS_ACCESS_KEY_ID=your_aws_access_key_id
+# AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+# AWS_SES_REGION_NAME=us-east-1
+
+# ==============================================================================
+# MAILGUN CONFIGURATION (Optional - for Mailgun email service)
+# ==============================================================================
+# Uncomment these if you want to use Mailgun for email delivery
+# Requires: pip install django-anymail
+
+# MAILGUN_API_KEY=your_mailgun_api_key
+# MAILGUN_SENDER_DOMAIN=your_domain.com
+
+# ==============================================================================
+# FUTURE/OPTIONAL SERVICES
+# ==============================================================================
+# Add additional service configurations here as needed, such as:
+# - Redis for caching (REDIS_URL)
+# - Celery for background tasks (CELERY_BROKER_URL)
+# - Cloud storage (S3_BUCKET_NAME, etc.)
+# - Payment processors (STRIPE_SECRET_KEY, etc.)
+# - Analytics services
+# - Monitoring services (Sentry DSN, etc.)
+
+# ==============================================================================
+# DEVELOPMENT/TESTING
+# ==============================================================================
+# These variables may be set automatically by test frameworks or development tools
+
+# MOZ_HEADLESS=1  # Set automatically by tests for headless Firefox


### PR DESCRIPTION
Replace get_or_create() calls for lores with imports from demon_lores.py
and demon_earthbound_lores.py. This makes dependencies explicit and
ensures proper load order.

Changes:
- demon_earthbound_rituals.py: Import lores from demon_lores.py and
  demon_earthbound_lores.py
- demon_rituals_hotf_*.py (7 files): Import lores from demon_lores.py
  instead of using get_or_create

Benefits:
1. Explicit dependencies through import statements
2. Prevents accidental lore duplication
3. Ensures lores are defined before being used
4. Makes code more maintainable and easier to understand

Note: lore_expression and lore_survival kept as get_or_create since they
are not yet defined in demon_lores.py.

Files modified: 8