### PR TITLE
Fix SyntaxError: remove 'continue' statement not in loop

### DIFF
--- a/characters/views/mage/mage.py
+++ b/characters/views/mage/mage.py
@@ -476,7 +476,6 @@ class MageDetailView(HumanDetailView):
                             messages.error(request, str(e))
                             context["form"] = form
                             form_errors = True
-                            continue
                     elif category == "Tenet":
                         trait = example.name
                         trait_type = "tenet"


### PR DESCRIPTION
The 'continue' statement at line 479 was not inside a loop, causing a
SyntaxError when Django tried to load the URL configuration. The code
was already properly setting form_errors=True, which is checked at the
end of the method to handle error cases correctly.