### PR TITLE
Refactor business logic from views to forms

### DIFF
--- a/characters/forms/mage/mage.py
+++ b/characters/forms/mage/mage.py
@@ -1,6 +1,7 @@
 from characters.models.mage.faction import MageFaction
 from characters.models.mage.mage import Mage
 from django import forms
+from django.core.exceptions import ValidationError
 
 
 class MageCreationForm(forms.ModelForm):
@@ -49,3 +50,84 @@ class MageCreationForm(forms.ModelForm):
         if commit:
             instance.save()
         return instance
+
+
+class MageSpheresForm(forms.ModelForm):
+    """Form for selecting Spheres and Arete during character creation."""
+
+    class Meta:
+        model = Mage
+        fields = [
+            "arete",
+            "correspondence",
+            "time",
+            "spirit",
+            "forces",
+            "matter",
+            "life",
+            "entropy",
+            "mind",
+            "prime",
+            "affinity_sphere",
+            "corr_name",
+            "prime_name",
+            "spirit_name",
+            "resonance",
+        ]
+
+    def clean_affinity_sphere(self):
+        """Validate that an affinity sphere is selected."""
+        affinity_sphere = self.cleaned_data.get("affinity_sphere")
+        if affinity_sphere is None:
+            raise ValidationError("You must select a valid affinity sphere.")
+        return affinity_sphere
+
+    def clean_arete(self):
+        """Validate that Arete doesn't exceed 3 at character creation."""
+        arete = self.cleaned_data.get("arete", 1)
+        if arete > 3:
+            raise ValidationError("Arete may not exceed 3 at character creation.")
+        return arete
+
+    def clean(self):
+        """Validate sphere ratings and distribution."""
+        cleaned_data = super().clean()
+
+        # Get all sphere values
+        arete = cleaned_data.get("arete", 1)
+        correspondence = cleaned_data.get("correspondence", 0)
+        time = cleaned_data.get("time", 0)
+        spirit = cleaned_data.get("spirit", 0)
+        forces = cleaned_data.get("forces", 0)
+        matter = cleaned_data.get("matter", 0)
+        life = cleaned_data.get("life", 0)
+        entropy = cleaned_data.get("entropy", 0)
+        mind = cleaned_data.get("mind", 0)
+        prime = cleaned_data.get("prime", 0)
+        affinity_sphere = cleaned_data.get("affinity_sphere")
+
+        # Check individual sphere ratings
+        spheres = [correspondence, time, spirit, forces, matter, life, entropy, mind, prime]
+        for sphere_value in spheres:
+            if sphere_value < 0 or sphere_value > arete:
+                raise ValidationError(
+                    "Spheres must range from 0-Arete Rating."
+                )
+
+        # Check that affinity sphere is nonzero
+        if affinity_sphere and self.instance:
+            affinity_value = getattr(self.instance, affinity_sphere.property_name, None)
+            # Check in cleaned_data first (in case it's being set now)
+            if affinity_value == 0 and cleaned_data.get(affinity_sphere.property_name, 0) == 0:
+                raise ValidationError(
+                    "Affinity Sphere must be nonzero."
+                )
+
+        # Check total sphere points
+        total_spheres = sum(spheres)
+        if total_spheres != 6:
+            raise ValidationError(
+                f"Spheres must total 6 (currently {total_spheres})."
+            )
+
+        return cleaned_data

--- a/characters/forms/werewolf/garou.py
+++ b/characters/forms/werewolf/garou.py
@@ -1,5 +1,7 @@
 from characters.models.werewolf.garou import Werewolf
+from characters.models.werewolf.gift import GiftPermission
 from django import forms
+from django.core.exceptions import ValidationError
 
 
 class WerewolfCreationForm(forms.ModelForm):
@@ -33,3 +35,90 @@ class WerewolfCreationForm(forms.ModelForm):
         if commit:
             instance.save()
         return instance
+
+
+class WerewolfGiftsForm(forms.ModelForm):
+    """Form for selecting starting Gifts during character creation."""
+
+    class Meta:
+        model = Werewolf
+        fields = ["gifts"]
+
+    def clean_gifts(self):
+        """Validate that exactly 3 gifts are selected: one from breed, auspice, and tribe."""
+        gifts = self.cleaned_data.get("gifts")
+
+        if not gifts:
+            raise ValidationError("You must select gifts.")
+
+        # Check total count
+        if gifts.count() != 3:
+            raise ValidationError("You must select exactly 3 starting Gifts.")
+
+        # Get the character instance
+        instance = self.instance
+
+        # Check that character has required attributes
+        if not instance.tribe:
+            raise ValidationError("You must have a tribe to select starting Gifts.")
+
+        # Get permission objects
+        breed_perm = GiftPermission.objects.get_or_create(
+            shifter="werewolf", condition=instance.breed
+        )[0]
+        auspice_perm = GiftPermission.objects.get_or_create(
+            shifter="werewolf", condition=instance.auspice
+        )[0]
+        tribe_perm = GiftPermission.objects.get_or_create(
+            shifter="werewolf", condition=instance.tribe.name
+        )[0]
+
+        # Count gifts from each category
+        breed_count = sum(1 for gift in gifts if breed_perm in gift.allowed.all())
+        auspice_count = sum(1 for gift in gifts if auspice_perm in gift.allowed.all())
+        tribe_count = sum(1 for gift in gifts if tribe_perm in gift.allowed.all())
+
+        # Validate distribution
+        if breed_count != 1 or auspice_count != 1 or tribe_count != 1:
+            raise ValidationError(
+                "You must select exactly one Gift from your Breed, one from your Auspice, "
+                "and one from your Tribe."
+            )
+
+        return gifts
+
+
+class WerewolfHistoryForm(forms.ModelForm):
+    """Form for entering First Change history during character creation."""
+
+    class Meta:
+        model = Werewolf
+        fields = ["first_change", "age_of_first_change"]
+
+    def clean_first_change(self):
+        """Validate that First Change description is provided."""
+        first_change = self.cleaned_data.get("first_change")
+
+        if not first_change or first_change.strip() == "":
+            raise ValidationError("You must describe your First Change.")
+
+        return first_change
+
+    def clean_age_of_first_change(self):
+        """Validate that age of First Change is valid."""
+        age_of_first_change = self.cleaned_data.get("age_of_first_change")
+
+        if age_of_first_change is None:
+            raise ValidationError("Age of First Change is required.")
+
+        if age_of_first_change <= 0:
+            raise ValidationError("Age of First Change must be greater than 0.")
+
+        # Validate against current age (instance must exist)
+        if self.instance and self.instance.age:
+            if age_of_first_change >= self.instance.age:
+                raise ValidationError(
+                    f"Age of First Change must be less than current age ({self.instance.age})."
+                )
+
+        return age_of_first_change


### PR DESCRIPTION
Move validation logic from view layer to form layer for better separation of concerns:

- Created WerewolfGiftsForm with gift selection validation (breed/auspice/tribe requirements)
- Created WerewolfHistoryForm with first change validation (description and age constraints)
- Created MageSpheresForm with sphere distribution validation (arete limits, affinity requirements)

Updated views to use new form classes:
- WerewolfGiftsView now uses WerewolfGiftsForm (removed 40+ lines of validation)
- WerewolfHistoryView now uses WerewolfHistoryForm (removed validation logic)
- MageSpheresView now uses MageSpheresForm (removed 50+ lines of validation)

Views now handle only presentation logic and success actions (creation_status updates, freebie spending).
All validation and database queries for validation moved to form clean() methods.

Fixes PRACTICE_VIOLATIONS.md section 3.2 (Business Logic in Wrong Layer)