### PR TITLE
Add transaction atomicity to character approval and XP operations

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -3,6 +3,7 @@ from characters.models.core.human import Human
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django.contrib.auth.models import User
+from django.db import transaction
 
 
 class CustomAuthenticationForm(AuthenticationForm):
@@ -134,20 +135,21 @@ class StoryXP(forms.Form):
             )
 
     def save(self, commit=True):
-        for char in self.cleaned_data.keys():
-            total_gain = self.cleaned_data[char]["duration"]
-            if self.cleaned_data[char]["success"]:
-                total_gain += 1
-            if self.cleaned_data[char]["danger"]:
-                total_gain += 1
-            if self.cleaned_data[char]["growth"]:
-                total_gain += 1
-            if self.cleaned_data[char]["drama"]:
-                total_gain += 1
-            char.xp += total_gain
-            char.save()
-        self.story.xp_given = True
-        self.story.save()
+        with transaction.atomic():
+            for char in self.cleaned_data.keys():
+                total_gain = self.cleaned_data[char]["duration"]
+                if self.cleaned_data[char]["success"]:
+                    total_gain += 1
+                if self.cleaned_data[char]["danger"]:
+                    total_gain += 1
+                if self.cleaned_data[char]["growth"]:
+                    total_gain += 1
+                if self.cleaned_data[char]["drama"]:
+                    total_gain += 1
+                char.xp += total_gain
+                char.save()
+            self.story.xp_given = True
+            self.story.save()
 
     def clean(self):
         cleaned_data = super().clean()
@@ -185,7 +187,8 @@ class FreebieAwardForm(forms.Form):
         super().__init__(*args, **kwargs)
 
     def save(self, commit=True):
-        self.character.freebies += self.cleaned_data["backstory_freebies"]
-        self.character.freebies_approved = True
-        self.character.save()
+        with transaction.atomic():
+            self.character.freebies += self.cleaned_data["backstory_freebies"]
+            self.character.freebies_approved = True
+            self.character.save()
         return self.character


### PR DESCRIPTION
Wraps multi-step database operations in transaction.atomic() to prevent
partial failures and ensure data consistency:

- Character approval with group background updates (accounts/views.py:126-134)
- Scene read status marking (accounts/views.py:213-220)
- Story XP awarding to multiple characters (accounts/forms.py:133-148)
- Freebie point awarding (accounts/forms.py:185-189)

Also fixes N+1 query in character approval by using select_related() on
group_set queryset.

Resolves issue 3.4 (Missing Transactions) from PRACTICE_VIOLATIONS.md