### PR TITLE
Fix image approval to only show when image file exists

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -61,7 +61,7 @@ class ModelQuerySet(PolymorphicQuerySet):
 
     def with_pending_images(self):
         """Objects with images awaiting approval"""
-        return self.filter(image_status="sub")
+        return self.filter(image_status="sub").exclude(image="")
 
     def for_user_chronicles(self, user):
         """Objects in any of the user's chronicles"""
@@ -99,7 +99,7 @@ class ModelManager(PolymorphicManager):
 
     def with_pending_images(self):
         """Objects with images awaiting approval"""
-        return self.filter(image_status="sub")
+        return self.filter(image_status="sub").exclude(image="")
 
     def for_user_chronicles(self, user):
         """Objects in any of the user's chronicles"""


### PR DESCRIPTION
Updated with_pending_images() queryset method in both CharacterManager
and ModelManager to exclude objects without actual image files. This
prevents the profile page from showing approval options for images that
haven't been uploaded (image_status='sub' but image field is empty).