### PR TITLE
Add missing Group types and implement two-selector pattern for creation forms

### DIFF
--- a/characters/templates/characters/index.html
+++ b/characters/templates/characters/index.html
@@ -537,25 +537,58 @@
                                 {% csrf_token %}
                                 <div class="tg-form-group" style="margin-bottom: var(--spacing-3);">
                                     <label class="tg-form-label" style="display: block; text-align: left; margin-bottom: var(--spacing-2);">
-                                        <i class="fas fa-dice-d20 mr-2" style="color: var(--color-primary);"></i>Character Type
+                                        <i class="fas fa-book mr-2" style="color: var(--color-primary);"></i>Game Line
                                     </label>
-                                    <select name="char_type" id="id_char_type" class="tg-form-control tg-form-select" required>
-                                        {% for value, label in form.char_type.field.choices %}
+                                    <select name="gameline" id="id_gameline" class="tg-form-control tg-form-select" required>
+                                        {% for value, label in form.gameline.field.choices %}
                                             <option value="{{ value }}">{{ label }}</option>
                                         {% endfor %}
                                     </select>
                                 </div>
-                                <button type="submit" 
-                                        name="action" 
-                                        value="create" 
+                                <div class="tg-form-group" style="margin-bottom: var(--spacing-3);">
+                                    <label class="tg-form-label" style="display: block; text-align: left; margin-bottom: var(--spacing-2);">
+                                        <i class="fas fa-dice-d20 mr-2" style="color: var(--color-primary);"></i>Character Type
+                                    </label>
+                                    {{ form.char_type }}
+                                </div>
+                                <button type="submit"
+                                        name="action"
+                                        value="create"
                                         class="tg-btn btn-primary btn-lg"
-                                        style="width: 100%; 
-                                               box-shadow: var(--shadow-sm); 
+                                        style="width: 100%;
+                                               box-shadow: var(--shadow-sm);
                                                transition: var(--transition-fast);
                                                font-weight: 600;">
                                     <i class="fas fa-plus-circle mr-2"></i>Create Character
                                 </button>
                             </form>
+                            <script>
+                                document.addEventListener('DOMContentLoaded', function() {
+                                    const gamelineSelect = document.getElementById('id_gameline');
+                                    const charTypeSelect = document.getElementById('id_char_type');
+                                    const typesByGameline = JSON.parse(charTypeSelect.dataset.typesByGameline || '{}');
+
+                                    function updateCharTypes() {
+                                        const selectedGameline = gamelineSelect.value;
+                                        const types = typesByGameline[selectedGameline] || [];
+
+                                        // Clear existing options
+                                        charTypeSelect.innerHTML = '';
+
+                                        // Add new options
+                                        types.forEach(function(type) {
+                                            const option = document.createElement('option');
+                                            option.value = type.value;
+                                            option.textContent = type.label;
+                                            charTypeSelect.appendChild(option);
+                                        });
+                                    }
+
+                                    gamelineSelect.addEventListener('change', updateCharTypes);
+                                    // Initialize on page load
+                                    updateCharTypes();
+                                });
+                            </script>
                         </div>
                     </div>
                 </div>

--- a/items/forms/core/item_creation.py
+++ b/items/forms/core/item_creation.py
@@ -1,9 +1,20 @@
+import json
 from django import forms
 from game.models import ObjectType
+from core.constants import GameLine
 
 
 class ItemCreationForm(forms.Form):
-    item_type = forms.ChoiceField(choices=[])
+    gameline = forms.ChoiceField(
+        choices=[],
+        label="Game Line",
+        widget=forms.Select(attrs={"id": "id_item_gameline"}),
+    )
+    item_type = forms.ChoiceField(
+        choices=[],
+        label="Item Type",
+        widget=forms.Select(attrs={"id": "id_item_type"}),
+    )
     name = forms.CharField(
         max_length=100,
         label="Name",
@@ -14,18 +25,84 @@ class ItemCreationForm(forms.Form):
         max_value=5,
     )
 
+    def _format_label(self, name):
+        """Format item type labels."""
+        # Special cases
+        special_labels = {
+            "sorcerer_artifact": "Sorcerer Artifact",
+            "vampire_artifact": "Vampire Artifact",
+        }
+
+        if name in special_labels:
+            return special_labels[name]
+
+        # Default: title case with underscores replaced
+        return name.replace("_", " ").title()
+
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
-        if user.is_authenticated:
+
+        if user and user.is_authenticated:
             if user.profile.is_st():
-                self.fields["item_type"].choices = [
-                    (x.name, x.name.replace("_", " ").title())
-                    for x in ObjectType.objects.filter(type="obj")
+                # For STs, show all gamelines and item types
+                gamelines_with_items = set()
+                all_item_types = ObjectType.objects.filter(type="obj")
+
+                for obj in all_item_types:
+                    gamelines_with_items.add(obj.gameline)
+
+                # Create gameline choices
+                gameline_choices = [
+                    (code, name) for code, name in GameLine.CHOICES
+                    if code in gamelines_with_items
                 ]
+                self.fields["gameline"].choices = gameline_choices
+
+                # Build item type choices organized by gameline
+                item_types_by_gameline = {}
+                for obj in all_item_types:
+                    if obj.gameline not in item_types_by_gameline:
+                        item_types_by_gameline[obj.gameline] = []
+                    item_types_by_gameline[obj.gameline].append({
+                        "value": obj.name,
+                        "label": self._format_label(obj.name)
+                    })
+
+                # Sort each gameline's types by label
+                for gameline in item_types_by_gameline:
+                    item_types_by_gameline[gameline].sort(key=lambda x: x["label"])
+
+                # Store in widget attrs for JavaScript access
+                self.fields["item_type"].widget.attrs["data-types-by-gameline"] = json.dumps(
+                    item_types_by_gameline
+                )
+
+                # Initially populate with first gameline's types
+                if gameline_choices:
+                    first_gameline = gameline_choices[0][0]
+                    initial_choices = [
+                        (t["value"], t["label"])
+                        for t in item_types_by_gameline.get(first_gameline, [])
+                    ]
+                    self.fields["item_type"].choices = initial_choices
             else:
+                # For regular users, only show mage gameline
+                self.fields["gameline"].choices = [("mta", "Mage: the Ascension")]
+
+                mage_items = ObjectType.objects.filter(type="obj", gameline="mta")
+
+                item_types_by_gameline = {
+                    "mta": [
+                        {"value": obj.name, "label": self._format_label(obj.name)}
+                        for obj in mage_items
+                    ]
+                }
+                item_types_by_gameline["mta"].sort(key=lambda x: x["label"])
+
+                self.fields["item_type"].widget.attrs["data-types-by-gameline"] = json.dumps(
+                    item_types_by_gameline
+                )
                 self.fields["item_type"].choices = [
-                    (x.name, x.name.replace("_", " ").title())
-                    for x in ObjectType.objects.filter(type="obj")
-                    if x.name in []
+                    (t["value"], t["label"]) for t in item_types_by_gameline["mta"]
                 ]

--- a/items/templates/items/index.html
+++ b/items/templates/items/index.html
@@ -289,32 +289,64 @@
                         <!-- Form -->
                         <form id="itemForm" method="post" novalidate>
                             {% csrf_token %}
-                            
-                            <!-- Item Type Label - Left Aligned -->
-                            <div style="margin-bottom: var(--spacing-2); text-align: left;">
+
+                            <!-- Game Line -->
+                            <div style="margin-bottom: var(--spacing-3); text-align: left;">
+                                <label class="tg-form-label">
+                                    <i class="fas fa-book mr-2" style="color: var(--color-primary);"></i>Game Line
+                                </label>
+                                <select name="gameline" id="id_item_gameline" class="tg-form-control tg-form-select" required>
+                                    {% for value, label in form.gameline.field.choices %}
+                                        <option value="{{ value }}">{{ label }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+
+                            <!-- Item Type -->
+                            <div style="margin-bottom: var(--spacing-3); text-align: left;">
                                 <label class="tg-form-label">
                                     <i class="fas fa-box mr-2" style="color: var(--color-primary);"></i>Item Type
                                 </label>
-                            </div>
-                            
-                            <!-- Dropdown - Centered -->
-                            <div style="display: flex; justify-content: center; margin-bottom: var(--spacing-3);">
                                 {{ form.item_type }}
                             </div>
-                            
+
                             <!-- Button - Full Width, Centered Text -->
-                            <button type="submit" 
-                                    name="action" 
-                                    value="create" 
+                            <button type="submit"
+                                    name="action"
+                                    value="create"
                                     class="tg-btn btn-primary btn-lg"
-                                    style="width: 100%; 
-                                           box-shadow: var(--shadow-sm); 
+                                    style="width: 100%;
+                                           box-shadow: var(--shadow-sm);
                                            transition: var(--transition-fast);
                                            font-weight: 600;
                                            text-align: center;">
                                 <i class="fas fa-plus-circle mr-2"></i>Create Item
                             </button>
                         </form>
+                        <script>
+                            document.addEventListener('DOMContentLoaded', function() {
+                                const gamelineSelect = document.getElementById('id_item_gameline');
+                                const itemTypeSelect = document.getElementById('id_item_type');
+                                const typesByGameline = JSON.parse(itemTypeSelect.dataset.typesByGameline || '{}');
+
+                                function updateItemTypes() {
+                                    const selectedGameline = gamelineSelect.value;
+                                    const types = typesByGameline[selectedGameline] || [];
+
+                                    itemTypeSelect.innerHTML = '';
+
+                                    types.forEach(function(type) {
+                                        const option = document.createElement('option');
+                                        option.value = type.value;
+                                        option.textContent = type.label;
+                                        itemTypeSelect.appendChild(option);
+                                    });
+                                }
+
+                                gamelineSelect.addEventListener('change', updateItemTypes);
+                                updateItemTypes();
+                            });
+                        </script>
                     </div>
                 </div>
             </div>

--- a/locations/forms/core/location_creation.py
+++ b/locations/forms/core/location_creation.py
@@ -1,9 +1,20 @@
+import json
 from django import forms
 from game.models import ObjectType
+from core.constants import GameLine
 
 
 class LocationCreationForm(forms.Form):
-    loc_type = forms.ChoiceField(choices=[])
+    gameline = forms.ChoiceField(
+        choices=[],
+        label="Game Line",
+        widget=forms.Select(attrs={"id": "id_loc_gameline"}),
+    )
+    loc_type = forms.ChoiceField(
+        choices=[],
+        label="Location Type",
+        widget=forms.Select(attrs={"id": "id_loc_type"}),
+    )
     name = forms.CharField(
         max_length=100,
         label="Name",
@@ -14,18 +25,84 @@ class LocationCreationForm(forms.Form):
         max_value=5,
     )
 
+    def _format_label(self, name):
+        """Format location type labels."""
+        # Special cases
+        special_labels = {
+            "reality_zone": "Reality Zone",
+            "horizon_realm": "Horizon Realm",
+        }
+
+        if name in special_labels:
+            return special_labels[name]
+
+        # Default: title case with underscores replaced
+        return name.replace("_", " ").title()
+
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
-        if user.is_authenticated:
+
+        if user and user.is_authenticated:
             if user.profile.is_st():
-                self.fields["loc_type"].choices = [
-                    (x.name, x.name.replace("_", " ").title())
-                    for x in ObjectType.objects.filter(type="loc")
+                # For STs, show all gamelines and location types
+                gamelines_with_locs = set()
+                all_loc_types = ObjectType.objects.filter(type="loc")
+
+                for obj in all_loc_types:
+                    gamelines_with_locs.add(obj.gameline)
+
+                # Create gameline choices
+                gameline_choices = [
+                    (code, name) for code, name in GameLine.CHOICES
+                    if code in gamelines_with_locs
                 ]
+                self.fields["gameline"].choices = gameline_choices
+
+                # Build location type choices organized by gameline
+                loc_types_by_gameline = {}
+                for obj in all_loc_types:
+                    if obj.gameline not in loc_types_by_gameline:
+                        loc_types_by_gameline[obj.gameline] = []
+                    loc_types_by_gameline[obj.gameline].append({
+                        "value": obj.name,
+                        "label": self._format_label(obj.name)
+                    })
+
+                # Sort each gameline's types by label
+                for gameline in loc_types_by_gameline:
+                    loc_types_by_gameline[gameline].sort(key=lambda x: x["label"])
+
+                # Store in widget attrs for JavaScript access
+                self.fields["loc_type"].widget.attrs["data-types-by-gameline"] = json.dumps(
+                    loc_types_by_gameline
+                )
+
+                # Initially populate with first gameline's types
+                if gameline_choices:
+                    first_gameline = gameline_choices[0][0]
+                    initial_choices = [
+                        (t["value"], t["label"])
+                        for t in loc_types_by_gameline.get(first_gameline, [])
+                    ]
+                    self.fields["loc_type"].choices = initial_choices
             else:
+                # For regular users, only show mage gameline
+                self.fields["gameline"].choices = [("mta", "Mage: the Ascension")]
+
+                mage_locs = ObjectType.objects.filter(type="loc", gameline="mta")
+
+                loc_types_by_gameline = {
+                    "mta": [
+                        {"value": obj.name, "label": self._format_label(obj.name)}
+                        for obj in mage_locs
+                    ]
+                }
+                loc_types_by_gameline["mta"].sort(key=lambda x: x["label"])
+
+                self.fields["loc_type"].widget.attrs["data-types-by-gameline"] = json.dumps(
+                    loc_types_by_gameline
+                )
                 self.fields["loc_type"].choices = [
-                    (x.name, x.name.replace("_", " ").title())
-                    for x in ObjectType.objects.filter(type="loc")
-                    if x.name in []
+                    (t["value"], t["label"]) for t in loc_types_by_gameline["mta"]
                 ]

--- a/locations/templates/locations/index.html
+++ b/locations/templates/locations/index.html
@@ -265,32 +265,64 @@
                         <!-- Form -->
                         <form id="locForm" method="post" novalidate>
                             {% csrf_token %}
-                            
-                            <!-- Location Type Label - Left Aligned -->
-                            <div style="margin-bottom: var(--spacing-2); text-align: left;">
+
+                            <!-- Game Line -->
+                            <div style="margin-bottom: var(--spacing-3); text-align: left;">
+                                <label class="tg-form-label">
+                                    <i class="fas fa-book mr-2" style="color: var(--color-primary);"></i>Game Line
+                                </label>
+                                <select name="gameline" id="id_loc_gameline" class="tg-form-control tg-form-select" required>
+                                    {% for value, label in form.gameline.field.choices %}
+                                        <option value="{{ value }}">{{ label }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+
+                            <!-- Location Type -->
+                            <div style="margin-bottom: var(--spacing-3); text-align: left;">
                                 <label class="tg-form-label">
                                     <i class="fas fa-map-marker-alt mr-2" style="color: var(--color-primary);"></i>Location Type
                                 </label>
-                            </div>
-                            
-                            <!-- Dropdown - Centered -->
-                            <div style="display: flex; justify-content: center; margin-bottom: var(--spacing-3);">
                                 {{ form.loc_type }}
                             </div>
-                            
+
                             <!-- Button - Full Width, Centered Text -->
-                            <button type="submit" 
-                                    name="action" 
-                                    value="create" 
+                            <button type="submit"
+                                    name="action"
+                                    value="create"
                                     class="tg-btn btn-primary btn-lg"
-                                    style="width: 100%; 
-                                           box-shadow: var(--shadow-sm); 
+                                    style="width: 100%;
+                                           box-shadow: var(--shadow-sm);
                                            transition: var(--transition-fast);
                                            font-weight: 600;
                                            text-align: center;">
                                 <i class="fas fa-plus-circle mr-2"></i>Create Location
                             </button>
                         </form>
+                        <script>
+                            document.addEventListener('DOMContentLoaded', function() {
+                                const gamelineSelect = document.getElementById('id_loc_gameline');
+                                const locTypeSelect = document.getElementById('id_loc_type');
+                                const typesByGameline = JSON.parse(locTypeSelect.dataset.typesByGameline || '{}');
+
+                                function updateLocTypes() {
+                                    const selectedGameline = gamelineSelect.value;
+                                    const types = typesByGameline[selectedGameline] || [];
+
+                                    locTypeSelect.innerHTML = '';
+
+                                    types.forEach(function(type) {
+                                        const option = document.createElement('option');
+                                        option.value = type.value;
+                                        option.textContent = type.label;
+                                        locTypeSelect.appendChild(option);
+                                    });
+                                }
+
+                                gamelineSelect.addEventListener('change', updateLocTypes);
+                                updateLocTypes();
+                            });
+                        </script>
                     </div>
                 </div>
             </div>

--- a/populate_db/objects.py
+++ b/populate_db/objects.py
@@ -35,6 +35,7 @@ ObjectType.objects.get_or_create(name="vampire_sect", type="char", gameline="vtm
 ObjectType.objects.get_or_create(name="vampire", type="char", gameline="vtm")
 ObjectType.objects.get_or_create(name="ghoul", type="char", gameline="vtm")
 ObjectType.objects.get_or_create(name="vtm_human", type="char", gameline="vtm")
+ObjectType.objects.get_or_create(name="coterie", type="char", gameline="vtm")
 
 # VtM Item Objects
 ObjectType.objects.get_or_create(name="vampire_artifact", type="obj", gameline="vtm")
@@ -74,6 +75,7 @@ ObjectType.objects.get_or_create(name="rite", type="char", gameline="wta")
 ObjectType.objects.get_or_create(name="gift", type="char", gameline="wta")
 ObjectType.objects.get_or_create(name="gift_permission", type="char", gameline="wta")
 ObjectType.objects.get_or_create(name="fomori_power", type="char", gameline="wta")
+ObjectType.objects.get_or_create(name="pack", type="char", gameline="wta")
 
 # WtA Item Objects
 ObjectType.objects.get_or_create(name="fetish", type="obj", gameline="wta")
@@ -134,6 +136,7 @@ ObjectType.objects.get_or_create(name="treasure", type="obj", gameline="ctd")
 # WtO Character Objects
 ObjectType.objects.get_or_create(name="wraith", type="char", gameline="wto")
 ObjectType.objects.get_or_create(name="wto_human", type="char", gameline="wto")
+ObjectType.objects.get_or_create(name="circle", type="char", gameline="wto")
 
 # WtO Item Objects
 ObjectType.objects.get_or_create(name="artifact", type="obj", gameline="wto")
@@ -150,6 +153,7 @@ earthbound = ObjectType.objects.get_or_create(name="earthbound", type="char", ga
 dtfhuman = ObjectType.objects.get_or_create(
     name="dtf_human", type="char", gameline="dtf"
 )[0]
+ObjectType.objects.get_or_create(name="conclave", type="char", gameline="dtf")
 
 # DtF Item Objects
 ObjectType.objects.get_or_create(name="relic", type="obj", gameline="dtf")


### PR DESCRIPTION
ObjectType additions:
- Added Group subclasses: coterie (VtM), pack (WtA), circle (WtO), conclave (DtF)
  (cabal and motley were already present)

Form improvements (characters, locations, items):
- Split single dropdown into two selectors: gameline first, then type
- Types are organized by gameline and dynamically filtered via JavaScript
- All forms now use consistent pattern:
  1. Select game line (Vampire, Werewolf, Mage, etc.)
  2. Select type within that gameline
- Data stored in data-types-by-gameline attribute for client-side filtering
- Labels formatted consistently with special handling for humans, artifacts, etc.

Benefits:
- Much better UX - no more scrolling through 20+ unsorted options
- Types are organized by game line making it easier to find what you need
- Consistent pattern across all three creation forms
- Works for both ST and regular users (regular users only see Mage options)
- JavaScript provides instant filtering without page reload