### PR TITLE
Implement full CRUD and approval workflows for game app models

### DIFF
--- a/game/models.py
+++ b/game/models.py
@@ -59,6 +59,9 @@ class SettingElement(models.Model):
     def __str__(self):
         return self.name
 
+    def get_absolute_url(self):
+        return reverse("game:setting_element:detail", kwargs={"pk": self.pk})
+
 
 class Gameline(models.Model):
     name = models.CharField(max_length=100, default="")
@@ -231,6 +234,9 @@ class Week(models.Model):
 
     def __str__(self):
         return f"{self.start_date } - { self.end_date }"
+
+    def get_absolute_url(self):
+        return reverse("game:week:detail", kwargs={"pk": self.pk})
 
     def finished_scenes(self):
         # Subquery to get the most recent datetime_created for each Scene

--- a/game/templates/game/setting_element/detail.html
+++ b/game/templates/game/setting_element/detail.html
@@ -1,0 +1,60 @@
+{% extends "core/base.html" %}
+{% load sanitize_text %}
+{% block title %}
+    {{ object.name }}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wod">
+            <div class="tg-card-header text-center">
+                <h1 class="tg-card-title wod_heading">{{ object.name }}</h1>
+            </div>
+        </div>
+
+        {% if is_st %}
+            <div class="tg-card mb-4">
+                <div class="tg-card-body text-center" style="padding: 16px;">
+                    <a href="{% url 'game:setting_element:update' object.pk %}" class="btn btn-primary">Edit Setting Element</a>
+                </div>
+            </div>
+        {% endif %}
+
+        <!-- Description -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Description</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div style="line-height: 1.6;">
+                    {{ object.description|sanitize_html }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Chronicles Using This Element -->
+        {% if chronicles %}
+            <div class="tg-card mb-4">
+                <div class="tg-card-header text-center">
+                    <h5 class="tg-card-title wod_heading">Used in Chronicles</h5>
+                </div>
+                <div class="tg-card-body" style="padding: 20px;">
+                    <div class="row">
+                        {% for chronicle in chronicles %}
+                            <div class="col-sm-6 col-md-4 mb-3">
+                                <div class="tg-card h-100">
+                                    <div class="tg-card-body text-center" style="padding: 12px;">
+                                        <a href="{{ chronicle.get_absolute_url }}" style="font-weight: 600;">{{ chronicle.name }}</a>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="text-center mb-4">
+            <a href="{% url 'game:setting_element:list' %}" class="btn btn-secondary">Back to List</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/setting_element/form.html
+++ b/game/templates/game/setting_element/form.html
@@ -1,0 +1,58 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update {{ object.name }}
+    {% else %}
+        Create Setting Element
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update {{ object.name }}
+                    {% else %}
+                        Create Setting Element
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {{ field }}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{{ object.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:setting_element:list' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/setting_element/list.html
+++ b/game/templates/game/setting_element/list.html
@@ -1,0 +1,67 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Setting Elements
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">Setting Elements & Common Knowledge</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                {% if user.profile.is_st %}
+                    <div class="mb-4 text-center">
+                        <a href="{% url 'game:setting_element:create' %}" class="btn btn-primary">Create New Setting Element</a>
+                    </div>
+                {% endif %}
+
+                {% if object_list %}
+                    <div class="row">
+                        {% for element in object_list %}
+                            <div class="col-sm-6 col-md-4 mb-3">
+                                <div class="tg-card h-100">
+                                    <div class="tg-card-body" style="padding: 16px;">
+                                        <h6 style="font-weight: 600; margin-bottom: 8px;">
+                                            <a href="{{ element.get_absolute_url }}" style="color: var(--theme-text-primary);">{{ element.name }}</a>
+                                        </h6>
+                                        <p style="font-size: 0.875rem; color: var(--theme-text-secondary); margin: 0;">
+                                            {{ element.description|truncatewords:20 }}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    {% if is_paginated %}
+                        <nav aria-label="Page navigation" class="mt-4">
+                            <ul class="pagination justify-content-center">
+                                {% if page_obj.has_previous %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page=1">First</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                    </li>
+                                {% endif %}
+                                <li class="page-item active">
+                                    <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                                </li>
+                                {% if page_obj.has_next %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </nav>
+                    {% endif %}
+                {% else %}
+                    <p class="text-center text-muted">No setting elements found.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/story_xp_request/detail.html
+++ b/game/templates/game/story_xp_request/detail.html
@@ -1,0 +1,108 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Story XP Request - {{ object.character.name }}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wod">
+            <div class="tg-card-header text-center">
+                <h1 class="tg-card-title wod_heading">Story XP Request</h1>
+                <div style="font-size: 0.875rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                    {{ object.character.name }} - {{ object.story.name }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Request Details -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Request Details</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Character</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);"><a href="{{ object.character.get_absolute_url }}">{{ object.character.name }}</a></div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Player</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.character.owner.username }}</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-12">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Story</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);"><a href="{{ object.story.get_absolute_url }}">{{ object.story.name }}</a></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- XP Categories -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Story XP Categories</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div class="tg-table-responsive">
+                    <table class="tg-table">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th>Awarded</th>
+                                <th>XP Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Story Success</td>
+                                <td>{% if object.success %}✓{% else %}—{% endif %}</td>
+                                <td>{% if object.success %}1{% else %}0{% endif %}</td>
+                            </tr>
+                            <tr>
+                                <td>Story Danger</td>
+                                <td>{% if object.danger %}✓{% else %}—{% endif %}</td>
+                                <td>{% if object.danger %}1{% else %}0{% endif %}</td>
+                            </tr>
+                            <tr>
+                                <td>Character Growth</td>
+                                <td>{% if object.growth %}✓{% else %}—{% endif %}</td>
+                                <td>{% if object.growth %}1{% else %}0{% endif %}</td>
+                            </tr>
+                            <tr>
+                                <td>Drama and Roleplaying</td>
+                                <td>{% if object.drama %}✓{% else %}—{% endif %}</td>
+                                <td>{% if object.drama %}1{% else %}0{% endif %}</td>
+                            </tr>
+                            <tr>
+                                <td>Duration Bonus</td>
+                                <td>{{ object.duration }} sessions</td>
+                                <td>{{ object.duration }}</td>
+                            </tr>
+                        </tbody>
+                        <tfoot>
+                            <tr style="font-weight: 600;">
+                                <td colspan="2">Total Story XP</td>
+                                <td>
+                                    {% widthratio object.success 1 1|add:object.danger|add:object.growth|add:object.drama|add:object.duration as total_xp %}
+                                    {{ total_xp }}
+                                </td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="text-center mb-4">
+            <a href="{% url 'game:story_xp_request:list' %}" class="btn btn-secondary">Back to List</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/story_xp_request/list.html
+++ b/game/templates/game/story_xp_request/list.html
@@ -1,0 +1,81 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Story XP Requests
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">Story XP Requests</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                {% if object_list %}
+                    <div class="tg-table-responsive">
+                        <table class="tg-table">
+                            <thead>
+                                <tr>
+                                    <th>Story</th>
+                                    <th>Character</th>
+                                    {% if is_st %}
+                                        <th>Player</th>
+                                    {% endif %}
+                                    <th>Success</th>
+                                    <th>Danger</th>
+                                    <th>Growth</th>
+                                    <th>Drama</th>
+                                    <th>Duration</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for request in object_list %}
+                                    <tr>
+                                        <td><a href="{{ request.story.get_absolute_url }}">{{ request.story.name }}</a></td>
+                                        <td><a href="{{ request.character.get_absolute_url }}">{{ request.character.name }}</a></td>
+                                        {% if is_st %}
+                                            <td>{{ request.character.owner.username }}</td>
+                                        {% endif %}
+                                        <td>{% if request.success %}✓{% endif %}</td>
+                                        <td>{% if request.danger %}✓{% endif %}</td>
+                                        <td>{% if request.growth %}✓{% endif %}</td>
+                                        <td>{% if request.drama %}✓{% endif %}</td>
+                                        <td>{{ request.duration }}</td>
+                                        <td><a href="{% url 'game:story_xp_request:detail' request.pk %}" class="btn btn-sm btn-primary">View</a></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {% if is_paginated %}
+                        <nav aria-label="Page navigation" class="mt-4">
+                            <ul class="pagination justify-content-center">
+                                {% if page_obj.has_previous %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page=1">First</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                    </li>
+                                {% endif %}
+                                <li class="page-item active">
+                                    <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                                </li>
+                                {% if page_obj.has_next %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </nav>
+                    {% endif %}
+                {% else %}
+                    <p class="text-center text-muted">No story XP requests found.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/week/detail.html
+++ b/game/templates/game/week/detail.html
@@ -1,0 +1,202 @@
+{% extends "core/base.html" %}
+{% load sanitize_text %}
+{% block title %}
+    Week: {{ object }}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wod">
+            <div class="tg-card-header text-center">
+                <h1 class="tg-card-title wod_heading">Week: {{ object.start_date }} - {{ object.end_date }}</h1>
+            </div>
+        </div>
+
+        {% if is_st %}
+            <div class="tg-card mb-4">
+                <div class="tg-card-body text-center" style="padding: 16px;">
+                    <a href="{% url 'game:week:update' object.pk %}" class="btn btn-primary">Edit Week</a>
+                </div>
+            </div>
+        {% endif %}
+
+        <!-- Finished Scenes -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Finished Scenes</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                {% if finished_scenes %}
+                    <div class="tg-table-responsive">
+                        <table class="tg-table">
+                            <thead>
+                                <tr>
+                                    <th>Scene Name</th>
+                                    <th>Location</th>
+                                    <th>Date</th>
+                                    <th>Characters</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for scene in finished_scenes %}
+                                    <tr>
+                                        <td><a href="{{ scene.get_absolute_url }}">{{ scene.name }}</a></td>
+                                        <td>{{ scene.location.name }}</td>
+                                        <td>{{ scene.date_of_scene }}</td>
+                                        <td>{{ scene.characters.count }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <p class="text-center text-muted">No scenes finished during this week.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Weekly Characters -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Active Characters</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                {% if weekly_characters %}
+                    <div class="row">
+                        {% for character in weekly_characters %}
+                            <div class="col-sm-6 col-md-4 mb-3">
+                                <div class="tg-card h-100">
+                                    <div class="tg-card-body text-center" style="padding: 12px;">
+                                        <a href="{{ character.get_absolute_url }}" style="font-weight: 600;">{{ character.name }}</a>
+                                        <div style="font-size: 0.75rem; color: var(--theme-text-secondary); margin-top: 4px;">
+                                            {{ character.owner.username }}
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <p class="text-center text-muted">No characters participated this week.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- XP Requests -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">XP Requests</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                {% if is_st %}
+                    <!-- Pending Requests -->
+                    {% if pending_requests %}
+                        <h6 style="font-weight: 600; color: var(--theme-text-secondary); margin-bottom: 16px;">Pending Requests ({{ pending_requests.count }})</h6>
+                        <div class="tg-table-responsive mb-4">
+                            <table class="tg-table">
+                                <thead>
+                                    <tr>
+                                        <th>Character</th>
+                                        <th>Player</th>
+                                        <th>Finishing</th>
+                                        <th>Learning</th>
+                                        <th>RP</th>
+                                        <th>Focus</th>
+                                        <th>Standing Out</th>
+                                        <th>Total XP</th>
+                                        <th>Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for request in pending_requests %}
+                                        <tr>
+                                            <td><a href="{{ request.character.get_absolute_url }}">{{ request.character.name }}</a></td>
+                                            <td>{{ request.character.owner.username }}</td>
+                                            <td>{% if request.finishing %}✓{% endif %}</td>
+                                            <td>{% if request.learning %}✓{% endif %}</td>
+                                            <td>{% if request.rp %}✓{% endif %}</td>
+                                            <td>{% if request.focus %}✓{% endif %}</td>
+                                            <td>{% if request.standingout %}✓{% endif %}</td>
+                                            <td>{{ request.total_xp }}</td>
+                                            <td><a href="{% url 'game:weekly_xp_request:detail' request.pk %}" class="btn btn-sm btn-primary">Review</a></td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% endif %}
+
+                    <!-- Approved Requests -->
+                    {% if approved_requests %}
+                        <h6 style="font-weight: 600; color: var(--theme-text-secondary); margin-bottom: 16px;">Approved Requests ({{ approved_requests.count }})</h6>
+                        <div class="tg-table-responsive">
+                            <table class="tg-table">
+                                <thead>
+                                    <tr>
+                                        <th>Character</th>
+                                        <th>Player</th>
+                                        <th>Finishing</th>
+                                        <th>Learning</th>
+                                        <th>RP</th>
+                                        <th>Focus</th>
+                                        <th>Standing Out</th>
+                                        <th>Total XP</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for request in approved_requests %}
+                                        <tr>
+                                            <td><a href="{{ request.character.get_absolute_url }}">{{ request.character.name }}</a></td>
+                                            <td>{{ request.character.owner.username }}</td>
+                                            <td>{% if request.finishing %}✓{% endif %}</td>
+                                            <td>{% if request.learning %}✓{% endif %}</td>
+                                            <td>{% if request.rp %}✓{% endif %}</td>
+                                            <td>{% if request.focus %}✓{% endif %}</td>
+                                            <td>{% if request.standingout %}✓{% endif %}</td>
+                                            <td>{{ request.total_xp }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% endif %}
+                {% else %}
+                    <!-- Player view: show only their requests -->
+                    {% if xp_requests %}
+                        <div class="tg-table-responsive">
+                            <table class="tg-table">
+                                <thead>
+                                    <tr>
+                                        <th>Character</th>
+                                        <th>Status</th>
+                                        <th>Total XP</th>
+                                        <th>Action</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for request in xp_requests %}
+                                        {% if request.character.owner == user %}
+                                            <tr>
+                                                <td><a href="{{ request.character.get_absolute_url }}">{{ request.character.name }}</a></td>
+                                                <td>
+                                                    {% if request.approved %}
+                                                        <span class="tg-badge badge-app">Approved</span>
+                                                    {% else %}
+                                                        <span class="tg-badge badge-sub">Pending</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td>{{ request.total_xp }}</td>
+                                                <td><a href="{% url 'game:weekly_xp_request:detail' request.pk %}" class="btn btn-sm btn-primary">View</a></td>
+                                            </tr>
+                                        {% endif %}
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% else %}
+                        <p class="text-center text-muted">No XP requests for this week.</p>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/week/form.html
+++ b/game/templates/game/week/form.html
@@ -1,0 +1,58 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update Week
+    {% else %}
+        Create Week
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update Week
+                    {% else %}
+                        Create Week
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {{ field }}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{{ object.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:week:list' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/week/list.html
+++ b/game/templates/game/week/list.html
@@ -1,0 +1,64 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Weeks
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">Weekly Periods</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                {% if is_st %}
+                    <div class="mb-4 text-center">
+                        <a href="{% url 'game:week:create' %}" class="btn btn-primary">Create New Week</a>
+                    </div>
+                {% endif %}
+                <div class="row">
+                    {% for week in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ week.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ week }}</a>
+                                    <div style="font-size: 0.75rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                                        {{ week.finished_scenes.count }} scenes
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No weeks found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {% if is_paginated %}
+                    <nav aria-label="Page navigation" class="mt-4">
+                        <ul class="pagination justify-content-center">
+                            {% if page_obj.has_previous %}
+                                <li class="page-item">
+                                    <a class="page-link" href="?page=1">First</a>
+                                </li>
+                                <li class="page-item">
+                                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                </li>
+                            {% endif %}
+                            <li class="page-item active">
+                                <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                            </li>
+                            {% if page_obj.has_next %}
+                                <li class="page-item">
+                                    <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                </li>
+                                <li class="page-item">
+                                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+                                </li>
+                            {% endif %}
+                        </ul>
+                    </nav>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/weekly_xp_request/detail.html
+++ b/game/templates/game/weekly_xp_request/detail.html
@@ -1,0 +1,184 @@
+{% extends "core/base.html" %}
+{% block title %}
+    XP Request - {{ object.character.name }}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wod">
+            <div class="tg-card-header text-center">
+                <h1 class="tg-card-title wod_heading">Weekly XP Request</h1>
+                <div style="font-size: 0.875rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                    {{ object.character.name }} - {{ object.week }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Request Details -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Request Details</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Character</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);"><a href="{{ object.character.get_absolute_url }}">{{ object.character.name }}</a></div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Player</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.character.owner.username }}</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Week</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);"><a href="{{ object.week.get_absolute_url }}">{{ object.week }}</a></div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Status</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">
+                                {% if object.approved %}
+                                    <span class="tg-badge badge-app">Approved</span>
+                                {% else %}
+                                    <span class="tg-badge badge-sub">Pending</span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- XP Categories -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">XP Categories</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div class="tg-table-responsive">
+                    <table class="tg-table">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th>Claimed</th>
+                                <th>Scene</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>Finishing a Scene</td>
+                                <td>{% if object.finishing %}✓{% else %}—{% endif %}</td>
+                                <td>—</td>
+                            </tr>
+                            <tr>
+                                <td>Learning Something New</td>
+                                <td>{% if object.learning %}✓{% else %}—{% endif %}</td>
+                                <td>
+                                    {% if object.learning_scene %}
+                                        <a href="{{ object.learning_scene.get_absolute_url }}">{{ object.learning_scene.name }}</a>
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Roleplaying</td>
+                                <td>{% if object.rp %}✓{% else %}—{% endif %}</td>
+                                <td>
+                                    {% if object.rp_scene %}
+                                        <a href="{{ object.rp_scene.get_absolute_url }}">{{ object.rp_scene.name }}</a>
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Focus on Character Concept</td>
+                                <td>{% if object.focus %}✓{% else %}—{% endif %}</td>
+                                <td>
+                                    {% if object.focus_scene %}
+                                        <a href="{{ object.focus_scene.get_absolute_url }}">{{ object.focus_scene.name }}</a>
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>Standing Out</td>
+                                <td>{% if object.standingout %}✓{% else %}—{% endif %}</td>
+                                <td>
+                                    {% if object.standingout_scene %}
+                                        <a href="{{ object.standingout_scene.get_absolute_url }}">{{ object.standingout_scene.name }}</a>
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        </tbody>
+                        <tfoot>
+                            <tr style="font-weight: 600;">
+                                <td>Total XP</td>
+                                <td>{{ object.total_xp }}</td>
+                                <td>—</td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- ST Approval Form -->
+        {% if is_st and not object.approved %}
+            <div class="tg-card mb-4">
+                <div class="tg-card-header text-center">
+                    <h5 class="tg-card-title wod_heading">Review Request</h5>
+                </div>
+                <div class="tg-card-body" style="padding: 24px;">
+                    <form method="post" action="{% url 'game:weekly_xp_request:approve' object.pk %}">
+                        {% csrf_token %}
+                        <p class="mb-4" style="color: var(--theme-text-secondary);">
+                            Review the XP categories below and adjust as needed before approving the request.
+                        </p>
+                        {% for field in approval_form %}
+                            <div class="row mb-3">
+                                <div class="col-md-4">
+                                    <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                </div>
+                                <div class="col-md-8">
+                                    {{ field }}
+                                </div>
+                            </div>
+                            {% if field.errors %}
+                                <div class="row mb-3">
+                                    <div class="col-md-8 offset-md-4">
+                                        <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        {% endfor %}
+                        <div class="row">
+                            <div class="col-md-8 offset-md-4">
+                                <button type="submit" class="btn btn-success">Approve Request</button>
+                                <a href="{{ object.week.get_absolute_url }}" class="btn btn-secondary">Back to Week</a>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        {% endif %}
+
+        {% if object.approved or not is_st %}
+            <div class="text-center mb-4">
+                <a href="{{ object.week.get_absolute_url }}" class="btn btn-secondary">Back to Week</a>
+            </div>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/game/templates/game/weekly_xp_request/form.html
+++ b/game/templates/game/weekly_xp_request/form.html
@@ -1,0 +1,62 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Submit Weekly XP Request
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">Submit Weekly XP Request</h3>
+                <div style="font-size: 0.875rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                    {{ character.name }} - {{ week }}
+                </div>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="alert alert-info mb-4">
+                    <strong>Note:</strong> You automatically receive 1 XP for finishing a scene. You may claim up to 4 additional XP by selecting the categories below and providing the relevant scenes.
+                </div>
+
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        {% if field.name != 'finishing' %}
+                            <div class="row mb-3">
+                                <div class="col-md-4">
+                                    <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                    {% if field.help_text %}
+                                        <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                    {% endif %}
+                                </div>
+                                <div class="col-md-8">
+                                    {{ field }}
+                                </div>
+                            </div>
+                            {% if field.errors %}
+                                <div class="row mb-3">
+                                    <div class="col-md-8 offset-md-4">
+                                        <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+
+                    {% if form.non_field_errors %}
+                        <div class="row mb-3">
+                            <div class="col-12">
+                                <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Submit Request</button>
+                            <a href="{{ week.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/weekly_xp_request/list.html
+++ b/game/templates/game/weekly_xp_request/list.html
@@ -1,0 +1,87 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Weekly XP Requests
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">Weekly XP Requests</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                {% if is_st and pending_count > 0 %}
+                    <div class="alert alert-info mb-4 text-center">
+                        <strong>{{ pending_count }}</strong> pending request{{ pending_count|pluralize }} awaiting review
+                    </div>
+                {% endif %}
+
+                {% if object_list %}
+                    <div class="tg-table-responsive">
+                        <table class="tg-table">
+                            <thead>
+                                <tr>
+                                    <th>Week</th>
+                                    <th>Character</th>
+                                    {% if is_st %}
+                                        <th>Player</th>
+                                    {% endif %}
+                                    <th>Status</th>
+                                    <th>Total XP</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for request in object_list %}
+                                    <tr>
+                                        <td><a href="{{ request.week.get_absolute_url }}">{{ request.week }}</a></td>
+                                        <td><a href="{{ request.character.get_absolute_url }}">{{ request.character.name }}</a></td>
+                                        {% if is_st %}
+                                            <td>{{ request.character.owner.username }}</td>
+                                        {% endif %}
+                                        <td>
+                                            {% if request.approved %}
+                                                <span class="tg-badge badge-app">Approved</span>
+                                            {% else %}
+                                                <span class="tg-badge badge-sub">Pending</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ request.total_xp }}</td>
+                                        <td><a href="{% url 'game:weekly_xp_request:detail' request.pk %}" class="btn btn-sm btn-primary">View</a></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {% if is_paginated %}
+                        <nav aria-label="Page navigation" class="mt-4">
+                            <ul class="pagination justify-content-center">
+                                {% if page_obj.has_previous %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page=1">First</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                    </li>
+                                {% endif %}
+                                <li class="page-item active">
+                                    <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                                </li>
+                                {% if page_obj.has_next %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </nav>
+                    {% endif %}
+                {% else %}
+                    <p class="text-center text-muted">No XP requests found.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/urls.py
+++ b/game/urls.py
@@ -11,6 +11,36 @@ story_urls = [
     path("<pk>/update/", views.StoryUpdateView.as_view(), name="update"),
 ]
 
+week_urls = [
+    path("list/", views.WeekListView.as_view(), name="list"),
+    path("<pk>/", views.WeekDetailView.as_view(), name="detail"),
+    path("create/", views.WeekCreateView.as_view(), name="create"),
+    path("<pk>/update/", views.WeekUpdateView.as_view(), name="update"),
+]
+
+weekly_xp_request_urls = [
+    path("list/", views.WeeklyXPRequestListView.as_view(), name="list"),
+    path("<pk>/", views.WeeklyXPRequestDetailView.as_view(), name="detail"),
+    path(
+        "create/<week_pk>/<character_pk>/",
+        views.WeeklyXPRequestCreateView.as_view(),
+        name="create",
+    ),
+    path("<pk>/approve/", views.WeeklyXPRequestApproveView.as_view(), name="approve"),
+]
+
+story_xp_request_urls = [
+    path("list/", views.StoryXPRequestListView.as_view(), name="list"),
+    path("<pk>/", views.StoryXPRequestDetailView.as_view(), name="detail"),
+]
+
+setting_element_urls = [
+    path("list/", views.SettingElementListView.as_view(), name="list"),
+    path("<pk>/", views.SettingElementDetailView.as_view(), name="detail"),
+    path("create/", views.SettingElementCreateView.as_view(), name="create"),
+    path("<pk>/update/", views.SettingElementUpdateView.as_view(), name="update"),
+]
+
 urlpatterns = [
     path("chronicles/", views.ChronicleListView.as_view(), name="chronicles"),
     path("chronicle/<pk>", views.ChronicleDetailView.as_view(), name="chronicle"),
@@ -38,4 +68,8 @@ urlpatterns = [
     path("journals/", views.JournalListView.as_view(), name="journals"),
     path("journal/<pk>", views.JournalDetailView.as_view(), name="journal"),
     path("story/", include((story_urls, "story"))),
+    path("week/", include((week_urls, "week"))),
+    path("weekly-xp-request/", include((weekly_xp_request_urls, "weekly_xp_request"))),
+    path("story-xp-request/", include((story_xp_request_urls, "story_xp_request"))),
+    path("setting-element/", include((setting_element_urls, "setting_element"))),
 ]

--- a/game/views.py
+++ b/game/views.py
@@ -3,6 +3,7 @@ import itertools
 from characters.models.core import CharacterModel
 from characters.models.core.character import Character
 from core.mixins import EditPermissionMixin, MessageMixin, ViewPermissionMixin
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from django.db.models import OuterRef, Subquery
@@ -24,8 +25,20 @@ from game.forms import (
     SceneCreationForm,
     StoryForm,
     STResponseForm,
+    WeeklyXPRequestForm,
 )
-from game.models import Chronicle, Journal, JournalEntry, Post, Scene, Story
+from game.models import (
+    Chronicle,
+    Journal,
+    JournalEntry,
+    Post,
+    Scene,
+    SettingElement,
+    Story,
+    StoryXPRequest,
+    Week,
+    WeeklyXPRequest,
+)
 from items.models.core import ItemModel
 from locations.models.core import LocationModel
 
@@ -349,3 +362,255 @@ class StoryUpdateView(MessageMixin, UpdateView):
 
     def get_success_url(self):
         return reverse("game:story:detail", kwargs={"pk": self.object.pk})
+
+
+# Week Views
+class WeekListView(LoginRequiredMixin, ListView):
+    model = Week
+    ordering = ["-end_date"]
+    template_name = "game/week/list.html"
+    paginate_by = 20
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        return context
+
+
+class WeekDetailView(LoginRequiredMixin, DetailView):
+    model = Week
+    template_name = "game/week/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        context["finished_scenes"] = self.object.finished_scenes().with_location()
+        context["weekly_characters"] = self.object.weekly_characters()
+
+        # Get XP requests for this week
+        context["xp_requests"] = WeeklyXPRequest.objects.filter(
+            week=self.object
+        ).select_related("character")
+
+        # Separate pending and approved requests
+        context["pending_requests"] = context["xp_requests"].filter(approved=False)
+        context["approved_requests"] = context["xp_requests"].filter(approved=True)
+
+        return context
+
+
+class WeekCreateView(StorytellerRequiredMixin, MessageMixin, CreateView):
+    model = Week
+    fields = ["end_date"]
+    template_name = "game/week/form.html"
+    success_message = "Week created successfully!"
+    error_message = "Failed to create week. Please correct the errors below."
+
+    def get_success_url(self):
+        return reverse("game:week:detail", kwargs={"pk": self.object.pk})
+
+
+class WeekUpdateView(StorytellerRequiredMixin, MessageMixin, UpdateView):
+    model = Week
+    fields = ["end_date"]
+    template_name = "game/week/form.html"
+    success_message = "Week updated successfully!"
+    error_message = "Failed to update week. Please correct the errors below."
+
+    def get_success_url(self):
+        return reverse("game:week:detail", kwargs={"pk": self.object.pk})
+
+
+# WeeklyXPRequest Views
+class WeeklyXPRequestListView(LoginRequiredMixin, ListView):
+    model = WeeklyXPRequest
+    template_name = "game/weekly_xp_request/list.html"
+    ordering = ["-week__end_date", "character__name"]
+    paginate_by = 50
+
+    def get_queryset(self):
+        qs = super().get_queryset().select_related("character", "week")
+        # If not ST, only show own character requests
+        if not self.request.user.profile.is_st():
+            qs = qs.filter(character__owner=self.request.user)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        if context["is_st"]:
+            context["pending_count"] = WeeklyXPRequest.objects.filter(
+                approved=False
+            ).count()
+        return context
+
+
+class WeeklyXPRequestDetailView(LoginRequiredMixin, DetailView):
+    model = WeeklyXPRequest
+    template_name = "game/weekly_xp_request/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        context["is_owner"] = self.object.character.owner == self.request.user
+
+        # Add approval form for STs
+        if context["is_st"] and not self.object.approved:
+            context["approval_form"] = WeeklyXPRequestForm(
+                instance=self.object,
+                character=self.object.character,
+                week=self.object.week,
+            )
+
+        return context
+
+
+class WeeklyXPRequestCreateView(LoginRequiredMixin, MessageMixin, CreateView):
+    model = WeeklyXPRequest
+    form_class = WeeklyXPRequestForm
+    template_name = "game/weekly_xp_request/form.html"
+    success_message = "Weekly XP request submitted successfully!"
+    error_message = "Failed to submit XP request. Please correct the errors below."
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["character"] = get_object_or_404(
+            CharacterModel, pk=self.kwargs["character_pk"]
+        )
+        kwargs["week"] = get_object_or_404(Week, pk=self.kwargs["week_pk"])
+        return kwargs
+
+    def form_valid(self, form):
+        # Check that user owns the character
+        if form.character.owner != self.request.user:
+            messages.error(self.request, "You can only submit requests for your own characters.")
+            raise PermissionDenied("You can only submit requests for your own characters")
+
+        # Check if request already exists
+        if WeeklyXPRequest.objects.filter(
+            character=form.character, week=form.week
+        ).exists():
+            messages.error(
+                self.request,
+                f"XP request already exists for {form.character.name} for this week."
+            )
+            return redirect("game:week:detail", pk=form.week.pk)
+
+        form.player_save()
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse("game:week:detail", kwargs={"pk": self.object.week.pk})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["character"] = get_object_or_404(
+            CharacterModel, pk=self.kwargs["character_pk"]
+        )
+        context["week"] = get_object_or_404(Week, pk=self.kwargs["week_pk"])
+        return context
+
+
+class WeeklyXPRequestApproveView(StorytellerRequiredMixin, View):
+    """View for STs to approve/deny weekly XP requests."""
+
+    def post(self, request, *args, **kwargs):
+        xp_request = get_object_or_404(WeeklyXPRequest, pk=kwargs["pk"])
+
+        if xp_request.approved:
+            messages.warning(request, "This XP request has already been approved.")
+            return redirect("game:weekly_xp_request:detail", pk=xp_request.pk)
+
+        form = WeeklyXPRequestForm(
+            request.POST,
+            instance=xp_request,
+            character=xp_request.character,
+            week=xp_request.week,
+        )
+
+        if form.is_valid():
+            form.st_save()
+            messages.success(
+                request,
+                f"XP request for {xp_request.character.name} approved successfully! "
+                f"{form.instance.total_xp()} XP awarded."
+            )
+            return redirect("game:week:detail", pk=xp_request.week.pk)
+        else:
+            messages.error(request, "Failed to approve XP request. Please check the form.")
+            return redirect("game:weekly_xp_request:detail", pk=xp_request.pk)
+
+
+# StoryXPRequest Views
+class StoryXPRequestListView(LoginRequiredMixin, ListView):
+    model = StoryXPRequest
+    template_name = "game/story_xp_request/list.html"
+    ordering = ["story__name", "character__name"]
+    paginate_by = 50
+
+    def get_queryset(self):
+        qs = super().get_queryset().select_related("character", "story")
+        # If not ST, only show own character requests
+        if not self.request.user.profile.is_st():
+            qs = qs.filter(character__owner=self.request.user)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        return context
+
+
+class StoryXPRequestDetailView(LoginRequiredMixin, DetailView):
+    model = StoryXPRequest
+    template_name = "game/story_xp_request/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        context["is_owner"] = self.object.character.owner == self.request.user
+        return context
+
+
+# SettingElement Views
+class SettingElementListView(LoginRequiredMixin, ListView):
+    model = SettingElement
+    template_name = "game/setting_element/list.html"
+    ordering = ["name"]
+    paginate_by = 50
+
+
+class SettingElementDetailView(LoginRequiredMixin, DetailView):
+    model = SettingElement
+    template_name = "game/setting_element/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["is_st"] = self.request.user.profile.is_st()
+        # Find chronicles that use this setting element
+        context["chronicles"] = Chronicle.objects.filter(
+            common_knowledge_elements=self.object
+        )
+        return context
+
+
+class SettingElementCreateView(StorytellerRequiredMixin, MessageMixin, CreateView):
+    model = SettingElement
+    fields = ["name", "description"]
+    template_name = "game/setting_element/form.html"
+    success_message = "Setting element '{name}' created successfully!"
+    error_message = "Failed to create setting element. Please correct the errors below."
+
+    def get_success_url(self):
+        return reverse("game:setting_element:detail", kwargs={"pk": self.object.pk})
+
+
+class SettingElementUpdateView(StorytellerRequiredMixin, MessageMixin, UpdateView):
+    model = SettingElement
+    fields = ["name", "description"]
+    template_name = "game/setting_element/form.html"
+    success_message = "Setting element '{name}' updated successfully!"
+    error_message = "Failed to update setting element. Please correct the errors below."
+
+    def get_success_url(self):
+        return reverse("game:setting_element:detail", kwargs={"pk": self.object.pk})


### PR DESCRIPTION
Added comprehensive views, templates, and URL routes for:
- Week: Full CRUD operations with list, detail, create, and update views
- WeeklyXPRequest: Request submission and ST approval workflow with detailed tracking
- StoryXPRequest: List and detail views for story-based XP awards
- SettingElement: Full CRUD for chronicle lore/common knowledge management

Key features:
- Week detail view shows finished scenes, active characters, and XP requests
- WeeklyXPRequest approval workflow allows STs to review and adjust XP awards
- Permission checks ensure only STs can create/edit weeks and approve XP requests
- Players can view their own XP requests and submit new ones
- All templates follow project styling conventions (tg-card, wod_heading, etc.)
- Added get_absolute_url methods to Week and SettingElement models
- Pagination support for all list views

This completes the limited implementations listed in the TODO for Journal-related game models.