### PR TITLE
Implement Thorn reference data views, templates, and URLs for Wraith

### DIFF
--- a/characters/templates/characters/wraith/thorn/detail.html
+++ b/characters/templates/characters/wraith/thorn/detail.html
@@ -1,0 +1,105 @@
+{% extends "core/object.html" %}
+{% load sanitize_text dots %}
+
+{% block contents %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h5 class="tg-card-title wto_heading">Thorn Details</h5>
+        </div>
+        <div class="tg-card-body" style="padding: 24px;">
+            <div class="row">
+                <div class="col-md-4 mb-3">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--theme-text-primary); margin-bottom: 4px;">{{ object.get_thorn_type_display }}</div>
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary);">Type</div>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--theme-text-primary); margin-bottom: 4px;">{{ object.point_cost }}</div>
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary);">Point Cost</div>
+                    </div>
+                </div>
+                {% if object.activation_cost %}
+                    <div class="col-md-4 mb-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 1.5rem; font-weight: 700; color: var(--theme-text-primary); margin-bottom: 4px;">{{ object.activation_cost }}</div>
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary);">Activation Cost</div>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+
+            {% if object.activation_trigger %}
+                <div class="row mb-3">
+                    <div class="col-12">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Activation Trigger</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.activation_trigger|sanitize_html }}</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if object.mechanical_description %}
+                <div class="row mb-3">
+                    <div class="col-12">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Mechanical Description</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.mechanical_description|sanitize_html }}</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if object.resistance_system %}
+                <div class="row mb-3">
+                    <div class="col-md-8">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Resistance System</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.resistance_system|sanitize_html }}</div>
+                        </div>
+                    </div>
+                    {% if object.resistance_difficulty %}
+                        <div class="col-md-4">
+                            <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                                <div style="font-size: 1.5rem; font-weight: 700; color: var(--theme-text-primary); margin-bottom: 4px;">{{ object.resistance_difficulty }}</div>
+                                <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary);">Resistance Difficulty</div>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
+
+            <div class="row">
+                {% if object.duration %}
+                    <div class="col-md-6 mb-3">
+                        <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                            <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Duration:</span>
+                            <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.duration }}</span>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if object.frequency_limitation %}
+                    <div class="col-md-6 mb-3">
+                        <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                            <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Frequency:</span>
+                            <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.frequency_limitation }}</span>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+
+            {% if object.limitations %}
+                <div class="row">
+                    <div class="col-12">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Limitations</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.limitations|sanitize_html }}</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock contents %}

--- a/characters/templates/characters/wraith/thorn/form.html
+++ b/characters/templates/characters/wraith/thorn/form.html
@@ -1,0 +1,54 @@
+{% extends "core/form.html" %}
+{% block creation_title %}
+    Create Thorn
+{% endblock creation_title %}
+{% block contents %}
+    <div class="row">
+        <div class="col-sm">Name</div>
+        <div class="col-sm">{{ form.name }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Description</div>
+        <div class="col-sm">{{ form.description }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Thorn Type</div>
+        <div class="col-sm">{{ form.thorn_type }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Point Cost</div>
+        <div class="col-sm">{{ form.point_cost }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Activation Cost</div>
+        <div class="col-sm">{{ form.activation_cost }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Activation Trigger</div>
+        <div class="col-sm">{{ form.activation_trigger }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Mechanical Description</div>
+        <div class="col-sm">{{ form.mechanical_description }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Resistance System</div>
+        <div class="col-sm">{{ form.resistance_system }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Resistance Difficulty</div>
+        <div class="col-sm">{{ form.resistance_difficulty }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Duration</div>
+        <div class="col-sm">{{ form.duration }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Frequency Limitation</div>
+        <div class="col-sm">{{ form.frequency_limitation }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Limitations</div>
+        <div class="col-sm">{{ form.limitations }}</div>
+    </div>
+{% endblock contents %}

--- a/characters/templates/characters/wraith/thorn/list.html
+++ b/characters/templates/characters/wraith/thorn/list.html
@@ -1,0 +1,156 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Thorns
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wto">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title wto_heading">Thorns</h1>
+            </div>
+        </div>
+
+        <!-- Filter Panel -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header">
+                <button class="btn btn-link"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#filterPanel"
+                        aria-expanded="false"
+                        aria-controls="filterPanel">
+                    <i class="fas fa-filter"></i> Filter Thorns
+                </button>
+            </div>
+            <div class="collapse" id="filterPanel">
+                <div class="tg-card-body">
+                    <div class="row">
+                        <div class="col-md-4 mb-3">
+                            <label for="nameFilter" class="form-label" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px;">Name</label>
+                            <input type="text" class="form-control" id="nameFilter" placeholder="Search by name...">
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="typeFilter" class="form-label" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px;">Type</label>
+                            <select class="form-select" id="typeFilter">
+                                <option value="">All Types</option>
+                                <option value="individual">Individual Thorn</option>
+                                <option value="collective">Collective Thorn</option>
+                            </select>
+                        </div>
+                        <div class="col-md-4 mb-3">
+                            <label for="costFilter" class="form-label" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px;">Point Cost</label>
+                            <select class="form-select" id="costFilter">
+                                <option value="">All Costs</option>
+                                {% for cost in point_costs %}
+                                    <option value="{{ cost }}">{{ cost }} point{{ cost|pluralize }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-12">
+                            <button type="button" class="btn btn-secondary" id="clearFilters">Clear Filters</button>
+                            <span class="ms-3" id="resultCount" style="font-weight: 600; color: var(--theme-text-secondary);"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Thorns List -->
+        <div class="tg-card">
+            <div class="tg-card-body" style="padding: 0;">
+                <div id="thornsList">
+                    {% for obj in object_list %}
+                        <div class="thorn-item"
+                             data-name="{{ obj.name|lower }}"
+                             data-type="{{ obj.thorn_type }}"
+                             data-cost="{{ obj.point_cost }}"
+                             style="border-bottom: 1px solid rgba(0,0,0,0.1);">
+                            <div style="padding: 12px 20px; display: flex; justify-content: space-between; align-items: center;">
+                                <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary); text-decoration: none;">
+                                    {{ obj.name }}
+                                </a>
+                                <div style="display: flex; gap: 12px; align-items: center;">
+                                    <span class="tg-badge badge-pill" style="background-color: rgba(0,0,0,0.1); color: var(--theme-text-secondary);">
+                                        {{ obj.get_thorn_type_display }}
+                                    </span>
+                                    <span style="font-size: 0.85rem; color: var(--theme-text-secondary);">
+                                        {{ obj.point_cost }} point{{ obj.point_cost|pluralize }}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div style="padding: 20px; text-align: center; color: var(--theme-text-secondary);">
+                            No thorns found.
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const nameFilter = document.getElementById('nameFilter');
+            const typeFilter = document.getElementById('typeFilter');
+            const costFilter = document.getElementById('costFilter');
+            const clearButton = document.getElementById('clearFilters');
+            const resultCount = document.getElementById('resultCount');
+            const thornItems = document.querySelectorAll('.thorn-item');
+
+            function filterThorns() {
+                const nameValue = nameFilter.value.toLowerCase();
+                const typeValue = typeFilter.value;
+                const costValue = costFilter.value;
+
+                let visibleCount = 0;
+
+                thornItems.forEach(function(item) {
+                    const itemName = item.getAttribute('data-name');
+                    const itemType = item.getAttribute('data-type');
+                    const itemCost = item.getAttribute('data-cost');
+
+                    let showItem = true;
+
+                    // Filter by name
+                    if (nameValue && !itemName.includes(nameValue)) {
+                        showItem = false;
+                    }
+
+                    // Filter by type
+                    if (typeValue && itemType !== typeValue) {
+                        showItem = false;
+                    }
+
+                    // Filter by cost
+                    if (costValue && itemCost !== costValue) {
+                        showItem = false;
+                    }
+
+                    item.style.display = showItem ? '' : 'none';
+                    if (showItem) visibleCount++;
+                });
+
+                // Update result count
+                resultCount.textContent = `Showing ${visibleCount} of ${thornItems.length} thorns`;
+            }
+
+            // Add event listeners
+            nameFilter.addEventListener('input', filterThorns);
+            typeFilter.addEventListener('change', filterThorns);
+            costFilter.addEventListener('change', filterThorns);
+
+            clearButton.addEventListener('click', function() {
+                nameFilter.value = '';
+                typeFilter.value = '';
+                costFilter.value = '';
+                filterThorns();
+            });
+
+            // Initial count
+            filterThorns();
+        });
+    </script>
+{% endblock content %}

--- a/characters/urls/wraith/create.py
+++ b/characters/urls/wraith/create.py
@@ -3,6 +3,11 @@ from django.urls import path
 
 urls = [
     path(
+        "thorn/",
+        views.wraith.ThornCreateView.as_view(),
+        name="thorn",
+    ),
+    path(
         "wtohuman/",
         views.wraith.WtOHumanBasicsView.as_view(),
         name="wto_human",

--- a/characters/urls/wraith/detail.py
+++ b/characters/urls/wraith/detail.py
@@ -2,6 +2,12 @@ from characters import views
 from django.urls import path
 
 urls = [
+    # Thorn detail view
+    path(
+        "thorn/<pk>/",
+        views.wraith.ThornDetailView.as_view(),
+        name="thorn",
+    ),
     # Staged character creation routes
     path(
         "wraith/<int:pk>/chargen/",

--- a/characters/urls/wraith/index.py
+++ b/characters/urls/wraith/index.py
@@ -1,4 +1,6 @@
 from characters import views
 from django.urls import path
 
-urls = []
+urls = [
+    path("thorns/", views.wraith.ThornListView.as_view(), name="thorn"),
+]

--- a/characters/urls/wraith/update.py
+++ b/characters/urls/wraith/update.py
@@ -3,6 +3,11 @@ from django.urls import path
 
 urls = [
     path(
+        "thorn/<pk>/",
+        views.wraith.ThornUpdateView.as_view(),
+        name="thorn",
+    ),
+    path(
         "wtohuman/<pk>/",
         views.wraith.WtOHumanUpdateView.as_view(),
         name="wto_human",

--- a/characters/views/wraith/__init__.py
+++ b/characters/views/wraith/__init__.py
@@ -1,3 +1,9 @@
+from .thorn import (
+    ThornCreateView,
+    ThornDetailView,
+    ThornListView,
+    ThornUpdateView,
+)
 from .wraith_chargen import (
     WraithAbilityView,
     WraithAlliesView,

--- a/characters/views/wraith/thorn.py
+++ b/characters/views/wraith/thorn.py
@@ -1,0 +1,64 @@
+from characters.models.wraith.thorn import Thorn
+from core.mixins import MessageMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+
+
+class ThornDetailView(DetailView):
+    model = Thorn
+    template_name = "characters/wraith/thorn/detail.html"
+
+
+class ThornCreateView(MessageMixin, CreateView):
+    model = Thorn
+    fields = [
+        "name",
+        "description",
+        "thorn_type",
+        "point_cost",
+        "activation_cost",
+        "activation_trigger",
+        "mechanical_description",
+        "resistance_system",
+        "resistance_difficulty",
+        "duration",
+        "frequency_limitation",
+        "limitations",
+    ]
+    template_name = "characters/wraith/thorn/form.html"
+    success_message = "Thorn created successfully."
+    error_message = "There was an error creating the Thorn."
+
+
+class ThornUpdateView(MessageMixin, UpdateView):
+    model = Thorn
+    fields = [
+        "name",
+        "description",
+        "thorn_type",
+        "point_cost",
+        "activation_cost",
+        "activation_trigger",
+        "mechanical_description",
+        "resistance_system",
+        "resistance_difficulty",
+        "duration",
+        "frequency_limitation",
+        "limitations",
+    ]
+    template_name = "characters/wraith/thorn/form.html"
+    success_message = "Thorn updated successfully."
+    error_message = "There was an error updating the Thorn."
+
+
+class ThornListView(ListView):
+    model = Thorn
+    ordering = ["name"]
+    template_name = "characters/wraith/thorn/list.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Get unique point costs for filtering
+        context["point_costs"] = sorted(
+            set(Thorn.objects.values_list("point_cost", flat=True))
+        )
+        return context


### PR DESCRIPTION
Complete implementation of Thorn (Wraith Shadow weakness) reference data:

- Views: Detail, Create, Update, and List views with filtering
- Templates: Professional detail view, filterable list with JS, and form
- URLs: Full CRUD routing in wraith detail/create/update/index URLs
- Admin: Already registered in characters/admin.py
- Model: Already exists in characters/models/wraith/thorn.py
- Populate script: Already exists in populate_db/wraith/wraith_thorns.py

This completes the critical gap for Wraith Thorn implementation.
Note: Wraith locations (Haunt and Necropolis) were already fully
implemented with admin, views, URLs, and templates.