### PR TITLE
Add authorization checks to game views

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -377,3 +377,28 @@ class DeleteMessageMixin:
             messages.success(request, message)
 
         return super().delete(request, *args, **kwargs)
+
+
+class StorytellerRequiredMixin:
+    """
+    Mixin that restricts access to storytellers and admins only.
+
+    Checks if the user has storyteller status via profile.is_st().
+    This is for general ST-only operations, not chronicle-specific.
+
+    Usage:
+        class StoryCreateView(StorytellerRequiredMixin, CreateView):
+            model = Story
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        """Check if user is ST before dispatching."""
+        # Allow admins
+        if request.user.is_superuser or request.user.is_staff:
+            return super().dispatch(request, *args, **kwargs)
+
+        # Check if user is a storyteller
+        if not request.user.is_authenticated or not request.user.profile.is_st():
+            raise PermissionDenied("Only storytellers can perform this action")
+
+        return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
This commit implements comprehensive authorization checks across the game app to fix security vulnerabilities:

1. Moved StorytellerRequiredMixin to core/mixins.py
   - Consolidates ST permission checking with other mixins
   - Checks profile.is_st() for general ST-only operations
   - Allows admins and authenticated storytellers

2. Added StorytellerRequiredMixin to Story views
   - StoryCreateView: Only STs can create stories
   - StoryUpdateView: Only STs can update stories

3. Added authorization checks to JournalDetailView
   - Entry submission: Only journal owner can add entries
   - ST responses: Only storytellers can add ST responses

Security issues fixed:
- Users can no longer create/update stories without ST status
- Users can no longer add entries to other users' journals
- Users can no longer submit ST responses without ST status

Note: Scene closing and character posting were already protected
with proper authorization checks.