### PR TITLE
Complete CRUD implementation for Vampire Artifacts

### DIFF
--- a/items/forms/__init__.py
+++ b/items/forms/__init__.py
@@ -1,1 +1,1 @@
-from . import core, mage
+from . import core, mage, vampire

--- a/items/forms/vampire/__init__.py
+++ b/items/forms/vampire/__init__.py
@@ -1,0 +1,6 @@
+from .artifact import LimitedVampireArtifactEditForm, VampireArtifactForm
+
+__all__ = [
+    "VampireArtifactForm",
+    "LimitedVampireArtifactEditForm",
+]

--- a/items/forms/vampire/artifact.py
+++ b/items/forms/vampire/artifact.py
@@ -1,0 +1,145 @@
+"""
+Forms for VampireArtifact model.
+
+Includes both full edit form for STs/admins and limited edit form for owners.
+"""
+
+from django import forms
+from items.models.vampire import VampireArtifact
+
+
+class VampireArtifactForm(forms.ModelForm):
+    """
+    Full edit form for VampireArtifact.
+
+    Available to:
+    - Chronicle Head STs (full permissions)
+    - Admins (full permissions)
+
+    Includes all mechanical and descriptive fields.
+    """
+
+    class Meta:
+        model = VampireArtifact
+        fields = [
+            "name",
+            "description",
+            "power_level",
+            "background_cost",
+            "is_cursed",
+            "is_unique",
+            "requires_blood",
+            "powers",
+            "history",
+        ]
+        widgets = {
+            "name": forms.TextInput(
+                attrs={
+                    "placeholder": "Enter artifact name...",
+                    "class": "form-control",
+                }
+            ),
+            "description": forms.Textarea(
+                attrs={
+                    "rows": 4,
+                    "placeholder": "Physical description and appearance...",
+                    "class": "form-control",
+                }
+            ),
+            "power_level": forms.NumberInput(
+                attrs={
+                    "min": 1,
+                    "max": 5,
+                    "class": "form-control",
+                }
+            ),
+            "background_cost": forms.NumberInput(
+                attrs={
+                    "min": 0,
+                    "max": 10,
+                    "class": "form-control",
+                }
+            ),
+            "is_cursed": forms.CheckboxInput(
+                attrs={
+                    "class": "form-check-input",
+                }
+            ),
+            "is_unique": forms.CheckboxInput(
+                attrs={
+                    "class": "form-check-input",
+                }
+            ),
+            "requires_blood": forms.CheckboxInput(
+                attrs={
+                    "class": "form-check-input",
+                }
+            ),
+            "powers": forms.Textarea(
+                attrs={
+                    "rows": 6,
+                    "placeholder": "Describe the artifact's powers and effects...",
+                    "class": "form-control",
+                }
+            ),
+            "history": forms.Textarea(
+                attrs={
+                    "rows": 6,
+                    "placeholder": "History and provenance of the artifact...",
+                    "class": "form-control",
+                }
+            ),
+        }
+        help_texts = {
+            "name": "Name of the vampire artifact",
+            "description": "Physical appearance and basic description",
+            "power_level": "Power level from 1 (minor) to 5 (legendary)",
+            "background_cost": "Background points required to own this artifact",
+            "is_cursed": "Check if the artifact carries a curse",
+            "is_unique": "Check if this is a one-of-a-kind artifact",
+            "requires_blood": "Check if the artifact requires blood to activate or use",
+            "powers": "Detailed description of the artifact's powers and game effects",
+            "history": "Historical background and lore surrounding the artifact",
+        }
+
+
+class LimitedVampireArtifactEditForm(forms.ModelForm):
+    """
+    Limited edit form for VampireArtifact owners.
+
+    Owners can only edit:
+    - description (physical appearance)
+    - history (background/lore)
+
+    Owners CANNOT edit:
+    - name, power_level, background_cost
+    - Mechanical properties (is_cursed, is_unique, requires_blood)
+    - powers (game mechanics)
+    """
+
+    class Meta:
+        model = VampireArtifact
+        fields = [
+            "description",
+            "history",
+        ]
+        widgets = {
+            "description": forms.Textarea(
+                attrs={
+                    "rows": 4,
+                    "placeholder": "Physical description and appearance...",
+                    "class": "form-control",
+                }
+            ),
+            "history": forms.Textarea(
+                attrs={
+                    "rows": 6,
+                    "placeholder": "History and provenance of the artifact...",
+                    "class": "form-control",
+                }
+            ),
+        }
+        help_texts = {
+            "description": "Update the physical appearance and basic description",
+            "history": "Add to the historical background and lore (subject to ST approval)",
+        }

--- a/items/models/vampire/artifact.py
+++ b/items/models/vampire/artifact.py
@@ -52,6 +52,9 @@ class VampireArtifact(ItemModel):
         verbose_name = "Vampire Artifact"
         verbose_name_plural = "Vampire Artifacts"
 
+    def get_absolute_url(self):
+        return reverse("items:vampire:artifact", kwargs={"pk": self.pk})
+
     def get_update_url(self):
         return reverse("items:vampire:update:artifact", args=[str(self.id)])
 

--- a/items/views/vampire/__init__.py
+++ b/items/views/vampire/__init__.py
@@ -1,43 +1,55 @@
+from core.mixins import EditPermissionMixin, MessageMixin, ViewPermissionMixin
+from core.permissions import Permission, PermissionManager
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from items.forms.vampire import LimitedVampireArtifactEditForm, VampireArtifactForm
 from items.models.vampire import Bloodstone, VampireArtifact
 
 
 # VampireArtifact Views
-class VampireArtifactDetailView(DetailView):
+class VampireArtifactDetailView(ViewPermissionMixin, DetailView):
     model = VampireArtifact
     template_name = "items/vampire/artifact/detail.html"
 
 
-class VampireArtifactCreateView(CreateView):
+class VampireArtifactCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = VampireArtifact
-    fields = [
-        "name",
-        "description",
-        "power_level",
-        "background_cost",
-        "is_cursed",
-        "is_unique",
-        "requires_blood",
-        "powers",
-        "history",
-    ]
+    form_class = VampireArtifactForm
     template_name = "items/vampire/artifact/form.html"
+    success_message = "Vampire Artifact '{name}' created successfully!"
+    error_message = "Failed to create Vampire Artifact. Please correct the errors below."
+
+    def form_valid(self, form):
+        # Set owner to current user if not already set
+        if not form.instance.owner:
+            form.instance.owner = self.request.user
+        return super().form_valid(form)
 
 
-class VampireArtifactUpdateView(UpdateView):
+class VampireArtifactUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = VampireArtifact
-    fields = [
-        "name",
-        "description",
-        "power_level",
-        "background_cost",
-        "is_cursed",
-        "is_unique",
-        "requires_blood",
-        "powers",
-        "history",
-    ]
+    form_class = VampireArtifactForm
     template_name = "items/vampire/artifact/form.html"
+    success_message = "Vampire Artifact '{name}' updated successfully!"
+    error_message = "Failed to update Vampire Artifact. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedVampireArtifactEditForm.
+        STs and admins get full access to all fields.
+        """
+        # Check if user has full edit permission
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+
+        if has_full_edit:
+            # STs and admins get all fields
+            return VampireArtifactForm
+        else:
+            # Owners get limited fields (description, history)
+            return LimitedVampireArtifactEditForm
 
 
 class VampireArtifactListView(ListView):


### PR DESCRIPTION
This commit implements full CRUD functionality for VampireArtifact items,
following the project's established patterns for permissions, forms, and views.

Changes:
- Created VampireArtifactForm with all fields and proper widgets
- Created LimitedVampireArtifactEditForm restricting owners to description/history
- Updated VampireArtifactDetailView with ViewPermissionMixin
- Updated VampireArtifactCreateView with LoginRequiredMixin, MessageMixin, and owner assignment
- Updated VampireArtifactUpdateView with EditPermissionMixin, MessageMixin, and dynamic form selection
- Added get_absolute_url() method to VampireArtifact model
- Added vampire forms module to items.forms imports

Implementation follows patterns from:
- items/views/core/item.py for permission mixins
- items/forms/core/limited_edit.py for owner restrictions
- Project's CLAUDE.md coding standards

Features:
- Full CRUD: Create, Read, Update, Delete (via admin)
- Permission-based access control using ViewPermissionMixin and EditPermissionMixin
- Owner restrictions: owners can only edit description and history
- STs and admins can edit all fields including mechanical properties
- Success/error messages on create and update
- Automatic owner assignment on creation
- Proper URL routing with items:vampire:artifact namespace