### PR TITLE
Refactor all tests from pytest to Django unittest framework

### DIFF
--- a/core/tests/test_permissions_comprehensive.py
+++ b/core/tests/test_permissions_comprehensive.py
@@ -13,25 +13,22 @@ Tests all permission scenarios across different user roles:
 Tests visibility tiers and proper 404 responses for unauthorized access.
 """
 
-import pytest
 from characters.models.core.character import Character
 from characters.models.core.human import Human
 from core.models import Observer
 from core.permissions import Permission, PermissionManager, Role, VisibilityTier
 from django.contrib.auth.models import User
-from django.test import Client
+from django.test import Client, TestCase
 from django.urls import reverse
 from game.models import Chronicle
 
 
-@pytest.mark.django_db
-class TestPermissionRoles:
+class TestPermissionRoles(TestCase):
     """Test role detection for different user types."""
 
-    @pytest.fixture
-    def users(self):
-        """Create test users."""
-        return {
+    def setUp(self):
+        """Create test users and data."""
+        self.users = {
             "owner": User.objects.create_user("owner", "owner@test.com", "password123"),
             "head_st": User.objects.create_user(
                 "head_st", "head_st@test.com", "password123"
@@ -57,231 +54,244 @@ class TestPermissionRoles:
             ),
         }
 
-    @pytest.fixture
-    def chronicle(self, users):
-        """Create test chronicle."""
-        chron = Chronicle.objects.create(
+        # Create test chronicle
+        self.chronicle = Chronicle.objects.create(
             name="Test Chronicle",
             description="A test chronicle for permissions",
         )
         # Set head ST (assuming Chronicle has head_st field or storytellers M2M)
         # Adjust based on your actual Chronicle model
-        if hasattr(chron, "head_st"):
-            chron.head_st = users["head_st"]
-            chron.save()
-        elif hasattr(chron, "storytellers"):
-            chron.storytellers.add(users["head_st"])
+        if hasattr(self.chronicle, "head_st"):
+            self.chronicle.head_st = self.users["head_st"]
+            self.chronicle.save()
+        elif hasattr(self.chronicle, "storytellers"):
+            self.chronicle.storytellers.add(self.users["head_st"])
 
         # Add game ST (if model supports it)
-        if hasattr(chron, "game_storytellers"):
-            chron.game_storytellers.add(users["game_st"])
+        if hasattr(self.chronicle, "game_storytellers"):
+            self.chronicle.game_storytellers.add(self.users["game_st"])
 
-        return chron
-
-    @pytest.fixture
-    def character(self, users, chronicle):
-        """Create test character."""
-        char = Human.objects.create(
+        # Create test character
+        self.character = Human.objects.create(
             name="Test Character",
-            owner=users["owner"],
-            chronicle=chronicle,
+            owner=self.users["owner"],
+            chronicle=self.chronicle,
             status="App",
             concept="Test Concept",
         )
 
         # Add observer
         Observer.objects.create(
-            content_object=char,
-            user=users["observer"],
-            granted_by=users["owner"],
+            content_object=self.character,
+            user=self.users["observer"],
+            granted_by=self.users["owner"],
         )
 
         # Create player's character in same chronicle
         Human.objects.create(
             name="Player's Character",
-            owner=users["player"],
-            chronicle=chronicle,
+            owner=self.users["player"],
+            chronicle=self.chronicle,
             status="App",
             concept="Player Concept",
         )
 
-        return char
-
-    def test_owner_role_detected(self, users, character):
+    def test_owner_role_detected(self):
         """Test that owner role is correctly detected."""
-        roles = PermissionManager.get_user_roles(users["owner"], character)
-        assert Role.OWNER in roles
-        assert Role.AUTHENTICATED in roles
+        roles = PermissionManager.get_user_roles(self.users["owner"], self.character)
+        self.assertIn(Role.OWNER, roles)
+        self.assertIn(Role.AUTHENTICATED, roles)
 
-    def test_head_st_role_detected(self, users, character):
+    def test_head_st_role_detected(self):
         """Test that chronicle head ST role is correctly detected."""
-        roles = PermissionManager.get_user_roles(users["head_st"], character)
+        roles = PermissionManager.get_user_roles(self.users["head_st"], self.character)
         # This depends on how your Chronicle model is structured
         # Adjust assertion based on your implementation
-        assert Role.AUTHENTICATED in roles
+        self.assertIn(Role.AUTHENTICATED, roles)
         # If head_st field exists and is set:
-        # assert Role.CHRONICLE_HEAD_ST in roles
+        # self.assertIn(Role.CHRONICLE_HEAD_ST, roles)
 
-    def test_game_st_role_detected(self, users, character):
+    def test_game_st_role_detected(self):
         """Test that game ST role is correctly detected."""
-        roles = PermissionManager.get_user_roles(users["game_st"], character)
-        assert Role.AUTHENTICATED in roles
+        roles = PermissionManager.get_user_roles(self.users["game_st"], self.character)
+        self.assertIn(Role.AUTHENTICATED, roles)
         # If game_storytellers field exists:
-        # assert Role.GAME_ST in roles
+        # self.assertIn(Role.GAME_ST, roles)
 
-    def test_player_role_detected(self, users, character):
+    def test_player_role_detected(self):
         """Test that player role is correctly detected for chronicle members."""
-        roles = PermissionManager.get_user_roles(users["player"], character)
-        assert Role.PLAYER in roles
-        assert Role.AUTHENTICATED in roles
+        roles = PermissionManager.get_user_roles(self.users["player"], self.character)
+        self.assertIn(Role.PLAYER, roles)
+        self.assertIn(Role.AUTHENTICATED, roles)
 
-    def test_observer_role_detected(self, users, character):
+    def test_observer_role_detected(self):
         """Test that observer role is correctly detected."""
-        roles = PermissionManager.get_user_roles(users["observer"], character)
-        assert Role.OBSERVER in roles
-        assert Role.AUTHENTICATED in roles
+        roles = PermissionManager.get_user_roles(self.users["observer"], self.character)
+        self.assertIn(Role.OBSERVER, roles)
+        self.assertIn(Role.AUTHENTICATED, roles)
 
-    def test_stranger_has_no_special_roles(self, users, character):
+    def test_stranger_has_no_special_roles(self):
         """Test that stranger has only authenticated role."""
-        roles = PermissionManager.get_user_roles(users["stranger"], character)
-        assert Role.OWNER not in roles
-        assert Role.PLAYER not in roles
-        assert Role.OBSERVER not in roles
-        assert Role.AUTHENTICATED in roles
+        roles = PermissionManager.get_user_roles(self.users["stranger"], self.character)
+        self.assertNotIn(Role.OWNER, roles)
+        self.assertNotIn(Role.PLAYER, roles)
+        self.assertNotIn(Role.OBSERVER, roles)
+        self.assertIn(Role.AUTHENTICATED, roles)
 
-    def test_admin_role_detected(self, users, character):
+    def test_admin_role_detected(self):
         """Test that admin role is correctly detected."""
-        roles = PermissionManager.get_user_roles(users["admin"], character)
-        assert Role.ADMIN in roles
-        assert Role.AUTHENTICATED in roles
+        roles = PermissionManager.get_user_roles(self.users["admin"], self.character)
+        self.assertIn(Role.ADMIN, roles)
+        self.assertIn(Role.AUTHENTICATED, roles)
 
 
-@pytest.mark.django_db
-class TestOwnerPermissions:
+class TestOwnerPermissions(TestCase):
     """Test permissions for character owners."""
 
-    @pytest.fixture
-    def users(self):
-        return {
+    def setUp(self):
+        """Create test users and data."""
+        self.users = {
             "owner": User.objects.create_user("owner", "owner@test.com", "password123"),
             "head_st": User.objects.create_user(
                 "head_st", "head_st@test.com", "password123"
             ),
         }
 
-    @pytest.fixture
-    def chronicle(self, users):
-        chron = Chronicle.objects.create(name="Test Chronicle")
-        if hasattr(chron, "head_st"):
-            chron.head_st = users["head_st"]
-            chron.save()
-        return chron
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        if hasattr(self.chronicle, "head_st"):
+            self.chronicle.head_st = self.users["head_st"]
+            self.chronicle.save()
 
-    @pytest.fixture
-    def character(self, users, chronicle):
-        return Human.objects.create(
+        self.character = Human.objects.create(
             name="Test Character",
-            owner=users["owner"],
-            chronicle=chronicle,
+            owner=self.users["owner"],
+            chronicle=self.chronicle,
             status="App",
             concept="Test Concept",
         )
 
-    def test_owner_can_view_full(self, users, character):
+    def test_owner_can_view_full(self):
         """Owner should have full view permission."""
-        assert PermissionManager.user_has_permission(
-            users["owner"], character, Permission.VIEW_FULL
+        self.assertTrue(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.VIEW_FULL
+            )
         )
 
-    def test_owner_cannot_edit_full(self, users, character):
+    def test_owner_cannot_edit_full(self):
         """Owner should NOT have full edit permission (cannot modify stats directly)."""
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.EDIT_FULL
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.EDIT_FULL
+            )
         )
 
-    def test_owner_can_edit_limited(self, users, character):
+    def test_owner_can_edit_limited(self):
         """Owner should have limited edit permission (notes, description)."""
-        assert PermissionManager.user_has_permission(
-            users["owner"], character, Permission.EDIT_LIMITED
+        self.assertTrue(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.EDIT_LIMITED
+            )
         )
 
-    def test_owner_can_spend_xp_when_approved(self, users, character):
+    def test_owner_can_spend_xp_when_approved(self):
         """Owner should be able to spend XP on approved characters."""
-        character.status = "App"
-        character.save()
-        assert PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_XP
+        self.character.status = "App"
+        self.character.save()
+        self.assertTrue(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_XP
+            )
         )
 
-    def test_owner_cannot_spend_xp_when_unfinished(self, users, character):
+    def test_owner_cannot_spend_xp_when_unfinished(self):
         """Owner should NOT be able to spend XP on unfinished characters."""
-        character.status = "Un"
-        character.save()
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_XP
+        self.character.status = "Un"
+        self.character.save()
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_XP
+            )
         )
 
-    def test_owner_can_spend_freebies_when_unfinished(self, users, character):
+    def test_owner_can_spend_freebies_when_unfinished(self):
         """Owner should be able to spend freebies on unfinished characters."""
-        character.status = "Un"
-        character.save()
-        assert PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_FREEBIES
+        self.character.status = "Un"
+        self.character.save()
+        self.assertTrue(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_FREEBIES
+            )
         )
 
-    def test_owner_cannot_spend_freebies_when_approved(self, users, character):
+    def test_owner_cannot_spend_freebies_when_approved(self):
         """Owner should NOT be able to spend freebies after approval."""
-        character.status = "App"
-        character.save()
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_FREEBIES
+        self.character.status = "App"
+        self.character.save()
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_FREEBIES
+            )
         )
 
-    def test_owner_cannot_edit_when_submitted(self, users, character):
+    def test_owner_cannot_edit_when_submitted(self):
         """Owner should have no permissions when character is submitted."""
-        character.status = "Sub"
-        character.save()
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.EDIT_LIMITED
+        self.character.status = "Sub"
+        self.character.save()
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.EDIT_LIMITED
+            )
         )
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_XP
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_XP
+            )
         )
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_FREEBIES
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_FREEBIES
+            )
         )
 
-    def test_owner_cannot_edit_when_deceased(self, users, character):
+    def test_owner_cannot_edit_when_deceased(self):
         """Owner should have no permissions when character is deceased."""
-        character.status = "Dec"
-        character.save()
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.EDIT_LIMITED
+        self.character.status = "Dec"
+        self.character.save()
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.EDIT_LIMITED
+            )
         )
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.SPEND_XP
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.SPEND_XP
+            )
         )
 
-    def test_owner_can_delete(self, users, character):
+    def test_owner_can_delete(self):
         """Owner should be able to delete their own character."""
-        assert PermissionManager.user_has_permission(
-            users["owner"], character, Permission.DELETE
+        self.assertTrue(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.DELETE
+            )
         )
 
-    def test_owner_cannot_approve(self, users, character):
+    def test_owner_cannot_approve(self):
         """Owner should NOT be able to approve their own character."""
-        assert not PermissionManager.user_has_permission(
-            users["owner"], character, Permission.APPROVE
+        self.assertFalse(
+            PermissionManager.user_has_permission(
+                self.users["owner"], self.character, Permission.APPROVE
+            )
         )
 
 
-@pytest.mark.django_db
-class TestStorytellerPermissions:
+class TestStorytellerPermissions(TestCase):
     """Test permissions for storytellers."""
 
-    @pytest.fixture
-    def users(self):
-        return {
+    def setUp(self):
+        """Create test users and data."""
+        self.users = {
             "owner": User.objects.create_user("owner", "owner@test.com", "password123"),
             "head_st": User.objects.create_user(
                 "head_st", "head_st@test.com", "password123"
@@ -291,66 +301,64 @@ class TestStorytellerPermissions:
             ),
         }
 
-    @pytest.fixture
-    def chronicle(self, users):
-        chron = Chronicle.objects.create(name="Test Chronicle")
-        if hasattr(chron, "head_st"):
-            chron.head_st = users["head_st"]
-            chron.save()
-        if hasattr(chron, "game_storytellers"):
-            chron.game_storytellers.add(users["game_st"])
-        return chron
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        if hasattr(self.chronicle, "head_st"):
+            self.chronicle.head_st = self.users["head_st"]
+            self.chronicle.save()
+        if hasattr(self.chronicle, "game_storytellers"):
+            self.chronicle.game_storytellers.add(self.users["game_st"])
 
-    @pytest.fixture
-    def character(self, users, chronicle):
-        return Human.objects.create(
+        self.character = Human.objects.create(
             name="Test Character",
-            owner=users["owner"],
-            chronicle=chronicle,
+            owner=self.users["owner"],
+            chronicle=self.chronicle,
             status="App",
             concept="Test Concept",
         )
 
-    def test_head_st_can_view_full(self, users, character):
+    def test_head_st_can_view_full(self):
         """Chronicle Head ST should have full view permission."""
         # Adjust based on your Chronicle model implementation
         # This test assumes head_st field exists
-        roles = PermissionManager.get_user_roles(users["head_st"], character)
+        roles = PermissionManager.get_user_roles(self.users["head_st"], self.character)
         has_view = PermissionManager.user_has_permission(
-            users["head_st"], character, Permission.VIEW_FULL
+            self.users["head_st"], self.character, Permission.VIEW_FULL
         )
         # Assert based on whether CHRONICLE_HEAD_ST role is detected
         # If role is properly detected, this should be True
 
-    def test_head_st_can_edit_full(self, users, character):
+    def test_head_st_can_edit_full(self):
         """Chronicle Head ST should have full edit permission."""
         # Test depends on Chronicle model having head_st field
         pass
 
-    def test_game_st_can_view_full(self, users, character):
+    def test_game_st_can_view_full(self):
         """Game ST should have full view permission (read-only)."""
         # Test depends on Chronicle model having game_storytellers field
         pass
 
-    def test_game_st_cannot_edit(self, users, character):
+    def test_game_st_cannot_edit(self):
         """Game ST should NOT have edit permission (read-only)."""
-        roles = PermissionManager.get_user_roles(users["game_st"], character)
+        roles = PermissionManager.get_user_roles(self.users["game_st"], self.character)
         if Role.GAME_ST in roles:
-            assert not PermissionManager.user_has_permission(
-                users["game_st"], character, Permission.EDIT_FULL
+            self.assertFalse(
+                PermissionManager.user_has_permission(
+                    self.users["game_st"], self.character, Permission.EDIT_FULL
+                )
             )
-            assert not PermissionManager.user_has_permission(
-                users["game_st"], character, Permission.EDIT_LIMITED
+            self.assertFalse(
+                PermissionManager.user_has_permission(
+                    self.users["game_st"], self.character, Permission.EDIT_LIMITED
+                )
             )
 
 
-@pytest.mark.django_db
-class TestVisibilityTiers:
+class TestVisibilityTiers(TestCase):
     """Test visibility tier system."""
 
-    @pytest.fixture
-    def users(self):
-        return {
+    def setUp(self):
+        """Create test users and data."""
+        self.users = {
             "owner": User.objects.create_user("owner", "owner@test.com", "password123"),
             "player": User.objects.create_user(
                 "player", "player@test.com", "password123"
@@ -363,16 +371,12 @@ class TestVisibilityTiers:
             ),
         }
 
-    @pytest.fixture
-    def chronicle(self):
-        return Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
 
-    @pytest.fixture
-    def character(self, users, chronicle):
-        char = Human.objects.create(
+        self.character = Human.objects.create(
             name="Test Character",
-            owner=users["owner"],
-            chronicle=chronicle,
+            owner=self.users["owner"],
+            chronicle=self.chronicle,
             status="App",
             concept="Test Concept",
         )
@@ -380,161 +384,148 @@ class TestVisibilityTiers:
         # Add player's character
         Human.objects.create(
             name="Player's Character",
-            owner=users["player"],
-            chronicle=chronicle,
+            owner=self.users["player"],
+            chronicle=self.chronicle,
             status="App",
             concept="Player Concept",
         )
 
         # Add observer
         Observer.objects.create(
-            content_object=char,
-            user=users["observer"],
-            granted_by=users["owner"],
+            content_object=self.character,
+            user=self.users["observer"],
+            granted_by=self.users["owner"],
         )
 
-        return char
-
-    def test_owner_gets_full_visibility(self, users, character):
+    def test_owner_gets_full_visibility(self):
         """Owner should get FULL visibility tier."""
-        tier = PermissionManager.get_visibility_tier(users["owner"], character)
-        assert tier == VisibilityTier.FULL
+        tier = PermissionManager.get_visibility_tier(self.users["owner"], self.character)
+        self.assertEqual(tier, VisibilityTier.FULL)
 
-    def test_player_gets_partial_visibility(self, users, character):
+    def test_player_gets_partial_visibility(self):
         """Player in same chronicle should get PARTIAL visibility tier."""
-        tier = PermissionManager.get_visibility_tier(users["player"], character)
-        assert tier == VisibilityTier.PARTIAL
+        tier = PermissionManager.get_visibility_tier(self.users["player"], self.character)
+        self.assertEqual(tier, VisibilityTier.PARTIAL)
 
-    def test_observer_gets_partial_visibility(self, users, character):
+    def test_observer_gets_partial_visibility(self):
         """Observer should get PARTIAL visibility tier."""
-        tier = PermissionManager.get_visibility_tier(users["observer"], character)
-        assert tier == VisibilityTier.PARTIAL
+        tier = PermissionManager.get_visibility_tier(self.users["observer"], self.character)
+        self.assertEqual(tier, VisibilityTier.PARTIAL)
 
-    def test_stranger_gets_no_visibility(self, users, character):
+    def test_stranger_gets_no_visibility(self):
         """Stranger should get NONE visibility tier."""
-        tier = PermissionManager.get_visibility_tier(users["stranger"], character)
-        assert tier == VisibilityTier.NONE
+        tier = PermissionManager.get_visibility_tier(self.users["stranger"], self.character)
+        self.assertEqual(tier, VisibilityTier.NONE)
 
 
-@pytest.mark.django_db
-class TestViewPermissions404:
+class TestViewPermissions404(TestCase):
     """Test that views return proper 404 responses for unauthorized access."""
 
-    @pytest.fixture
-    def users(self):
-        return {
+    def setUp(self):
+        """Create test users and data."""
+        self.users = {
             "owner": User.objects.create_user("owner", "owner@test.com", "password123"),
             "stranger": User.objects.create_user(
                 "stranger", "stranger@test.com", "password123"
             ),
         }
 
-    @pytest.fixture
-    def chronicle(self):
-        return Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
 
-    @pytest.fixture
-    def character(self, users, chronicle):
-        return Human.objects.create(
+        self.character = Human.objects.create(
             name="Test Character",
-            owner=users["owner"],
-            chronicle=chronicle,
+            owner=self.users["owner"],
+            chronicle=self.chronicle,
             status="App",
             concept="Test Concept",
         )
 
-    def test_owner_can_view_detail(self, users, character):
+    def test_owner_can_view_detail(self):
         """Owner should be able to view character detail page."""
         client = Client()
-        client.force_login(users["owner"])
-        url = reverse("characters:character", kwargs={"pk": character.pk})
+        client.force_login(self.users["owner"])
+        url = reverse("characters:character", kwargs={"pk": self.character.pk})
         response = client.get(url)
-        assert response.status_code == 200
+        self.assertEqual(response.status_code, 200)
 
-    def test_stranger_gets_404_on_detail(self, users, character):
+    def test_stranger_gets_404_on_detail(self):
         """Stranger should get 404 when accessing character detail."""
         client = Client()
-        client.force_login(users["stranger"])
-        url = reverse("characters:character", kwargs={"pk": character.pk})
+        client.force_login(self.users["stranger"])
+        url = reverse("characters:character", kwargs={"pk": self.character.pk})
         response = client.get(url)
         # Should return 404, not 403, to avoid information leakage
-        assert response.status_code == 404
+        self.assertEqual(response.status_code, 404)
 
-    def test_stranger_gets_403_on_edit(self, users, character):
+    def test_stranger_gets_403_on_edit(self):
         """Stranger should get 403 (or 404) when attempting to edit."""
         client = Client()
-        client.force_login(users["stranger"])
-        url = reverse("characters:update:character", kwargs={"pk": character.pk})
+        client.force_login(self.users["stranger"])
+        url = reverse("characters:update:character", kwargs={"pk": self.character.pk})
         response = client.get(url)
         # Edit views may return 403 or 404 depending on implementation
-        assert response.status_code in [403, 404]
+        self.assertIn(response.status_code, [403, 404])
 
-    def test_anonymous_cannot_view(self, character):
+    def test_anonymous_cannot_view(self):
         """Anonymous users should be redirected or get 404."""
         client = Client()
-        url = reverse("characters:character", kwargs={"pk": character.pk})
+        url = reverse("characters:character", kwargs={"pk": self.character.pk})
         response = client.get(url)
         # Should redirect to login or return 404
-        assert response.status_code in [302, 404]
+        self.assertIn(response.status_code, [302, 404])
 
 
-@pytest.mark.django_db
-class TestLimitedFormPermissions:
+class TestLimitedFormPermissions(TestCase):
     """Test that owners can only edit limited fields."""
 
-    @pytest.fixture
-    def users(self):
-        return {
+    def setUp(self):
+        """Create test users and data."""
+        self.users = {
             "owner": User.objects.create_user("owner", "owner@test.com", "password123"),
             "head_st": User.objects.create_user(
                 "head_st", "head_st@test.com", "password123"
             ),
         }
 
-    @pytest.fixture
-    def chronicle(self, users):
-        chron = Chronicle.objects.create(name="Test Chronicle")
-        if hasattr(chron, "head_st"):
-            chron.head_st = users["head_st"]
-            chron.save()
-        return chron
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        if hasattr(self.chronicle, "head_st"):
+            self.chronicle.head_st = self.users["head_st"]
+            self.chronicle.save()
 
-    @pytest.fixture
-    def character(self, users, chronicle):
-        return Human.objects.create(
+        self.character = Human.objects.create(
             name="Test Character",
-            owner=users["owner"],
-            chronicle=chronicle,
+            owner=self.users["owner"],
+            chronicle=self.chronicle,
             status="App",
             concept="Test Concept",
             willpower=5,
         )
 
-    def test_owner_can_update_notes(self, users, character):
+    def test_owner_can_update_notes(self):
         """Owner should be able to update notes field."""
         client = Client()
-        client.force_login(users["owner"])
-        url = reverse("characters:update:character", kwargs={"pk": character.pk})
+        client.force_login(self.users["owner"])
+        url = reverse("characters:update:character", kwargs={"pk": self.character.pk})
 
         response = client.post(
             url,
             {
                 "notes": "Updated notes",
-                "description": character.description,
-                "public_info": character.public_info,
+                "description": self.character.description,
+                "public_info": self.character.public_info,
             },
         )
 
-        character.refresh_from_db()
-        assert character.notes == "Updated notes"
+        self.character.refresh_from_db()
+        self.assertEqual(self.character.notes, "Updated notes")
 
-    def test_owner_cannot_update_willpower_via_form(self, users, character):
+    def test_owner_cannot_update_willpower_via_form(self):
         """Owner should NOT be able to update willpower (mechanical field) via limited form."""
         client = Client()
-        client.force_login(users["owner"])
-        url = reverse("characters:update:character", kwargs={"pk": character.pk})
+        client.force_login(self.users["owner"])
+        url = reverse("characters:update:character", kwargs={"pk": self.character.pk})
 
-        original_willpower = character.willpower
+        original_willpower = self.character.willpower
 
         # Try to update willpower (should be ignored by limited form)
         response = client.post(
@@ -547,17 +538,17 @@ class TestLimitedFormPermissions:
             },
         )
 
-        character.refresh_from_db()
+        self.character.refresh_from_db()
         # Willpower should remain unchanged
-        assert character.willpower == original_willpower
+        self.assertEqual(self.character.willpower, original_willpower)
 
-    def test_owner_cannot_update_status(self, users, character):
+    def test_owner_cannot_update_status(self):
         """Owner should NOT be able to update status via limited form."""
         client = Client()
-        client.force_login(users["owner"])
-        url = reverse("characters:update:character", kwargs={"pk": character.pk})
+        client.force_login(self.users["owner"])
+        url = reverse("characters:update:character", kwargs={"pk": self.character.pk})
 
-        original_status = character.status
+        original_status = self.character.status
 
         response = client.post(
             url,
@@ -569,5 +560,5 @@ class TestLimitedFormPermissions:
             },
         )
 
-        character.refresh_from_db()
-        assert character.status == original_status
+        self.character.refresh_from_db()
+        self.assertEqual(self.character.status, original_status)

--- a/core/tests_error_handlers.py
+++ b/core/tests_error_handlers.py
@@ -8,19 +8,17 @@ Tests that:
 - Error templates render correctly
 """
 
-import pytest
 from accounts.models import Profile
 from core.views.errors import error_401, error_403, error_404, error_500
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
-from django.test import Client, RequestFactory, override_settings
+from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 User = get_user_model()
 
 
-@pytest.mark.django_db
-class TestErrorViews:
+class TestErrorViews(TestCase):
     """Test custom error views return correct status codes and templates."""
 
     def test_error_401_view(self):
@@ -31,9 +29,9 @@ class TestErrorViews:
 
         response = error_401(request)
 
-        assert response.status_code == 401
-        assert b"Authentication Required" in response.content
-        assert b"Error 401" in response.content
+        self.assertEqual(response.status_code, 401)
+        self.assertIn(b"Authentication Required", response.content)
+        self.assertIn(b"Error 401", response.content)
 
     def test_error_403_view(self):
         """Test that 403 error view returns correct status code and template."""
@@ -42,9 +40,9 @@ class TestErrorViews:
 
         response = error_403(request)
 
-        assert response.status_code == 403
-        assert b"Access Forbidden" in response.content
-        assert b"Error 403" in response.content
+        self.assertEqual(response.status_code, 403)
+        self.assertIn(b"Access Forbidden", response.content)
+        self.assertIn(b"Error 403", response.content)
 
     def test_error_404_view(self):
         """Test that 404 error view returns correct status code and template."""
@@ -53,9 +51,9 @@ class TestErrorViews:
 
         response = error_404(request)
 
-        assert response.status_code == 404
-        assert b"Page Not Found" in response.content
-        assert b"Error 404" in response.content
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b"Page Not Found", response.content)
+        self.assertIn(b"Error 404", response.content)
 
     def test_error_500_view(self):
         """Test that 500 error view returns correct status code and template."""
@@ -64,65 +62,58 @@ class TestErrorViews:
 
         response = error_500(request)
 
-        assert response.status_code == 500
-        assert b"Server Error" in response.content
-        assert b"Error 500" in response.content
+        self.assertEqual(response.status_code, 500)
+        self.assertIn(b"Server Error", response.content)
+        self.assertIn(b"Error 500", response.content)
 
 
-@pytest.mark.django_db
-class TestAuthenticationErrors:
+class TestAuthenticationErrors(TestCase):
     """Test that authentication and authorization errors return proper status codes."""
 
-    @pytest.fixture
-    def user(self):
-        """Create a test user."""
-        user = User.objects.create_user(username="testuser", password="testpass123")
-        Profile.objects.create(user=user)
-        return user
+    def setUp(self):
+        """Create a test user and client."""
+        self.user = User.objects.create_user(username="testuser", password="testpass123")
+        Profile.objects.create(user=self.user)
+        self.client = Client()
 
-    @pytest.fixture
-    def client(self):
-        """Create a test client."""
-        return Client()
-
-    def test_unauthenticated_access_to_profile_returns_401(self, client):
+    def test_unauthenticated_access_to_profile_returns_401(self):
         """Test that accessing profile page while not logged in returns 401."""
         # Create a user to have a valid profile URL
         user = User.objects.create_user(username="testuser2", password="testpass123")
         profile = Profile.objects.create(user=user)
 
         url = profile.get_absolute_url()
-        response = client.get(url)
+        response = self.client.get(url)
 
-        assert response.status_code == 401
-        assert b"Authentication Required" in response.content
+        self.assertEqual(response.status_code, 401)
+        self.assertIn(b"Authentication Required", response.content)
 
-    def test_authenticated_user_can_access_own_profile(self, client, user):
+    def test_authenticated_user_can_access_own_profile(self):
         """Test that authenticated user can access their own profile."""
-        client.login(username="testuser", password="testpass123")
-        url = user.profile.get_absolute_url()
+        self.client.login(username="testuser", password="testpass123")
+        url = self.user.profile.get_absolute_url()
 
-        response = client.get(url)
+        response = self.client.get(url)
 
         # Should be successful (200) or redirect (302), not 401 or 403
-        assert response.status_code in [200, 302]
+        self.assertIn(response.status_code, [200, 302])
 
-    def test_404_for_nonexistent_page(self, client):
+    def test_404_for_nonexistent_page(self):
         """Test that non-existent pages return 404."""
-        response = client.get("/this-page-does-not-exist-at-all/")
+        response = self.client.get("/this-page-does-not-exist-at-all/")
 
-        assert response.status_code == 404
-        assert b"Page Not Found" in response.content
+        self.assertEqual(response.status_code, 404)
+        self.assertIn(b"Page Not Found", response.content)
 
 
-@pytest.mark.django_db
-class TestPermissionDenied:
+class TestPermissionDenied(TestCase):
     """Test that PermissionDenied exceptions are handled correctly."""
 
-    def test_permission_denied_in_view(self, client):
+    def test_permission_denied_in_view(self):
         """Test that views raising PermissionDenied return 403."""
         user = User.objects.create_user(username="testuser", password="testpass123")
         Profile.objects.create(user=user)
+        client = Client()
         client.login(username="testuser", password="testpass123")
 
         # Try to access a view that requires ST privileges
@@ -133,4 +124,4 @@ class TestPermissionDenied:
         # The response might vary depending on the view implementation
         # but PermissionDenied should result in 403
         # Note: This is a general test - specific views may handle differently
-        assert response.status_code in [200, 302, 403, 405]  # Various valid responses
+        self.assertIn(response.status_code, [200, 302, 403, 405])  # Various valid responses


### PR DESCRIPTION
Converted all remaining pytest-based test files to use Django's unittest
framework for consistency across the codebase.

Changes:
- Removed pytest imports and decorators
- Converted @pytest.fixture methods to setUp() methods
- Changed class inheritance from @pytest.mark.django_db to TestCase/TransactionTestCase
- Replaced pytest.raises with self.assertRaises/assertRaisesMessage
- Replaced all assert statements with Django unittest assertions
  (assertEqual, assertTrue, assertIn, etc.)
- Maintained all original test functionality and behavior

Files refactored:
- characters/tests/core/test_transaction_integration.py
- characters/tests/core/test_validation_constraints.py
- core/test_permissions.py
- core/tests/test_permissions_comprehensive.py
- core/tests_error_handlers.py
- game/tests_xp_freebie_migration.py