### PR TITLE
Add four new Wraith location types

### DIFF
--- a/locations/models/wraith/__init__.py
+++ b/locations/models/wraith/__init__.py
@@ -1,2 +1,6 @@
+from .byway import Byway
+from .citadel import Citadel
+from .freehold import WraithFreehold
 from .haunt import Haunt
 from .necropolis import Necropolis
+from .nihil import Nihil

--- a/locations/models/wraith/byway.py
+++ b/locations/models/wraith/byway.py
@@ -1,0 +1,87 @@
+from django.db import models
+from django.urls import reverse
+from locations.models.core import LocationModel
+
+
+class Byway(LocationModel):
+    """Tempest path connecting Necropolises and other underworld locations."""
+
+    type = "byway"
+
+    DANGER_LEVEL_CHOICES = [
+        ("safe", "Safe - Well-patrolled and maintained"),
+        ("moderate", "Moderate - Occasional dangers"),
+        ("dangerous", "Dangerous - Frequent hazards"),
+        ("treacherous", "Treacherous - Extreme danger"),
+        ("lethal", "Lethal - Nearly impassable"),
+    ]
+
+    STABILITY_CHOICES = [
+        ("stable", "Stable - Permanent route"),
+        ("shifting", "Shifting - Route changes occasionally"),
+        ("unstable", "Unstable - Frequently changes"),
+        ("ephemeral", "Ephemeral - Temporary route"),
+    ]
+
+    danger_level = models.CharField(
+        max_length=20, choices=DANGER_LEVEL_CHOICES, default="moderate"
+    )
+
+    stability = models.CharField(
+        max_length=20, choices=STABILITY_CHOICES, default="stable"
+    )
+
+    # Travel details
+    origin = models.CharField(
+        max_length=200, blank=True, help_text="Starting location (e.g., Necropolis name)"
+    )
+    destination = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text="Ending location (e.g., Necropolis name)",
+    )
+    travel_time = models.CharField(
+        max_length=100,
+        blank=True,
+        help_text="Typical travel time (e.g., '3 days', '1 week')",
+    )
+
+    # Tempest properties
+    maelstrom_proximity = models.IntegerField(
+        default=5, help_text="Proximity to maelstroms (1-10, higher = closer/more dangerous)"
+    )
+    spectral_activity = models.IntegerField(
+        default=5, help_text="Level of Spectre activity (1-10)"
+    )
+
+    # Special features
+    has_waystation = models.BooleanField(
+        default=False, help_text="Contains rest stop or waystation"
+    )
+    patrolled = models.BooleanField(
+        default=False, help_text="Regularly patrolled by Hierarchy forces"
+    )
+    haunted = models.BooleanField(
+        default=False, help_text="Known to be haunted by dangerous entities"
+    )
+
+    class Meta:
+        verbose_name = "Byway"
+        verbose_name_plural = "Byways"
+        ordering = ["name"]
+
+    def __str__(self):
+        return f"{self.name} (Byway)"
+
+    def get_absolute_url(self):
+        return reverse("locations:wraith:byway", kwargs={"pk": self.pk})
+
+    def get_update_url(self):
+        return reverse("locations:wraith:update:byway", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("locations:wraith:create:byway")
+
+    def get_heading(self):
+        return "wto_heading"

--- a/locations/models/wraith/citadel.py
+++ b/locations/models/wraith/citadel.py
@@ -1,0 +1,70 @@
+from django.db import models
+from django.urls import reverse
+from locations.models.core import LocationModel
+
+
+class Citadel(LocationModel):
+    """Fortified stronghold within a Necropolis or independent territory."""
+
+    type = "citadel"
+
+    CITADEL_PURPOSE_CHOICES = [
+        ("guild_hall", "Guild Hall"),
+        ("legion_fortress", "Legion Fortress"),
+        ("hierarchy_outpost", "Hierarchy Outpost"),
+        ("renegade_stronghold", "Renegade Stronghold"),
+        ("trade_hub", "Trade Hub"),
+        ("prison", "Prison/Oubliette"),
+        ("palace", "Palace/Seat of Power"),
+        ("other", "Other"),
+    ]
+
+    purpose = models.CharField(
+        max_length=50, choices=CITADEL_PURPOSE_CHOICES, default="guild_hall"
+    )
+
+    # Defense and military
+    defense_rating = models.IntegerField(default=1, help_text="Defense strength (1-10)")
+    garrison_size = models.IntegerField(
+        default=0, help_text="Number of wraiths garrisoned"
+    )
+    commander = models.CharField(
+        max_length=100, blank=True, help_text="Name of military commander"
+    )
+
+    # Affiliation
+    controlling_faction = models.CharField(
+        max_length=100, blank=True, help_text="Guild, Legion, or faction in control"
+    )
+
+    # Special features
+    has_soulforges = models.BooleanField(
+        default=False, help_text="Contains soulforging facilities"
+    )
+    has_prison = models.BooleanField(
+        default=False, help_text="Contains prison/oubliette"
+    )
+    has_gateway = models.BooleanField(
+        default=False, help_text="Contains gateway to other realms"
+    )
+
+    class Meta:
+        verbose_name = "Citadel"
+        verbose_name_plural = "Citadels"
+        ordering = ["name"]
+
+    def __str__(self):
+        return f"{self.name} (Citadel)"
+
+    def get_absolute_url(self):
+        return reverse("locations:wraith:citadel", kwargs={"pk": self.pk})
+
+    def get_update_url(self):
+        return reverse("locations:wraith:update:citadel", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("locations:wraith:create:citadel")
+
+    def get_heading(self):
+        return "wto_heading"

--- a/locations/models/wraith/freehold.py
+++ b/locations/models/wraith/freehold.py
@@ -1,0 +1,92 @@
+from django.db import models
+from django.urls import reverse
+from locations.models.core import LocationModel
+
+
+class WraithFreehold(LocationModel):
+    """Independent wraith territory outside Hierarchy control."""
+
+    type = "wraith_freehold"
+
+    GOVERNMENT_TYPE_CHOICES = [
+        ("council", "Council Rule"),
+        ("democracy", "Democracy"),
+        ("autocracy", "Autocracy"),
+        ("anarchy", "Anarchy"),
+        ("theocracy", "Theocracy"),
+        ("oligarchy", "Oligarchy"),
+        ("other", "Other"),
+    ]
+
+    HIERARCHY_RELATION_CHOICES = [
+        ("independent", "Independent - No formal relations"),
+        ("neutral", "Neutral - Tolerated by Hierarchy"),
+        ("alliance", "Alliance - Formal agreement with Hierarchy"),
+        ("hostile", "Hostile - At odds with Hierarchy"),
+        ("secret", "Secret - Hidden from Hierarchy"),
+        ("tributary", "Tributary - Pays tribute to Hierarchy"),
+    ]
+
+    # Population and governance
+    population = models.IntegerField(default=0, help_text="Number of wraith inhabitants")
+    government_type = models.CharField(
+        max_length=20, choices=GOVERNMENT_TYPE_CHOICES, default="council"
+    )
+    leader = models.CharField(
+        max_length=100, blank=True, help_text="Name of primary leader or ruling body"
+    )
+
+    # Relations
+    hierarchy_relation = models.CharField(
+        max_length=20, choices=HIERARCHY_RELATION_CHOICES, default="independent"
+    )
+    allied_factions = models.TextField(
+        blank=True, help_text="Factions, guilds, or legions allied with this freehold"
+    )
+
+    # Resources and capabilities
+    defense_rating = models.IntegerField(default=1, help_text="Defensive strength (1-10)")
+    resource_level = models.IntegerField(
+        default=1, help_text="Available resources and wealth (1-10)"
+    )
+
+    # Special features
+    has_soulforges = models.BooleanField(
+        default=False, help_text="Contains soulforging facilities"
+    )
+    has_library = models.BooleanField(
+        default=False, help_text="Contains significant library or archives"
+    )
+    has_safe_passage = models.BooleanField(
+        default=False, help_text="Offers safe passage through territory"
+    )
+    hidden = models.BooleanField(
+        default=False, help_text="Location is hidden or secret"
+    )
+
+    # Philosophy/purpose
+    founding_principle = models.TextField(
+        blank=True,
+        help_text="Core beliefs or reasons for independence (e.g., 'Freedom from tyranny', 'Guild solidarity')",
+    )
+
+    class Meta:
+        verbose_name = "Wraith Freehold"
+        verbose_name_plural = "Wraith Freeholds"
+        ordering = ["name"]
+
+    def __str__(self):
+        return f"{self.name} (Freehold)"
+
+    def get_absolute_url(self):
+        return reverse("locations:wraith:freehold", kwargs={"pk": self.pk})
+
+    def get_update_url(self):
+        return reverse("locations:wraith:update:freehold", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("locations:wraith:create:freehold")
+
+    def get_heading(self):
+        return "wto_heading"

--- a/locations/models/wraith/nihil.py
+++ b/locations/models/wraith/nihil.py
@@ -1,0 +1,112 @@
+from django.db import models
+from django.urls import reverse
+from locations.models.core import LocationModel
+
+
+class Nihil(LocationModel):
+    """Void in the Tempest where nothing exists - dangerous empty zones."""
+
+    type = "nihil"
+
+    VOID_TYPE_CHOICES = [
+        ("emptiness", "Pure Emptiness - Complete void"),
+        ("corruption", "Corruption Zone - Tainted by Oblivion"),
+        ("maelstrom_scar", "Maelstrom Scar - Remnant of great storm"),
+        ("spectre_nest", "Spectre Nest - Spawning ground"),
+        ("forgotten", "Forgotten Place - Erased from memory"),
+        ("transition", "Transition Zone - Between realms"),
+        ("other", "Other"),
+    ]
+
+    STABILITY_CHOICES = [
+        ("permanent", "Permanent - Fixed void"),
+        ("expanding", "Expanding - Growing larger"),
+        ("contracting", "Contracting - Shrinking"),
+        ("unstable", "Unstable - Constantly shifting"),
+        ("ephemeral", "Ephemeral - Temporary phenomenon"),
+    ]
+
+    void_type = models.CharField(
+        max_length=20, choices=VOID_TYPE_CHOICES, default="emptiness"
+    )
+
+    stability = models.CharField(
+        max_length=20, choices=STABILITY_CHOICES, default="permanent"
+    )
+
+    # Hazard ratings
+    hazard_level = models.IntegerField(
+        default=10, help_text="Overall danger level (1-10, higher = more dangerous)"
+    )
+    oblivion_proximity = models.IntegerField(
+        default=5,
+        help_text="Proximity to Oblivion itself (1-10, higher = closer)",
+    )
+    entropy_rating = models.IntegerField(
+        default=5,
+        help_text="Rate of entropy and dissolution (1-10)",
+    )
+
+    # Size and scope
+    estimated_size = models.CharField(
+        max_length=200,
+        blank=True,
+        help_text="Approximate dimensions (e.g., '100 yards across', 'infinite')",
+    )
+
+    # Effects on travelers
+    corpus_drain = models.BooleanField(
+        default=True, help_text="Drains Corpus from wraiths who enter"
+    )
+    pathos_drain = models.BooleanField(
+        default=True, help_text="Drains Pathos from wraiths who enter"
+    )
+    memory_loss = models.BooleanField(
+        default=False, help_text="Causes memory loss or disorientation"
+    )
+    shadow_attraction = models.BooleanField(
+        default=False, help_text="Attracts and empowers Shadows"
+    )
+
+    # Navigation
+    avoidable = models.BooleanField(
+        default=True, help_text="Can be navigated around with knowledge"
+    )
+    marked = models.BooleanField(
+        default=False, help_text="Marked or charted by travelers"
+    )
+
+    # Phenomena
+    spectral_activity = models.IntegerField(
+        default=0, help_text="Level of Spectre presence (0-10)"
+    )
+    contains_relics = models.BooleanField(
+        default=False, help_text="May contain lost relics or artifacts"
+    )
+
+    # Origin (optional narrative)
+    origin_story = models.TextField(
+        blank=True,
+        help_text="How this void came to be (e.g., 'Destroyed Necropolis', 'Ancient battle site')",
+    )
+
+    class Meta:
+        verbose_name = "Nihil"
+        verbose_name_plural = "Nihils"
+        ordering = ["name"]
+
+    def __str__(self):
+        return f"{self.name} (Nihil)"
+
+    def get_absolute_url(self):
+        return reverse("locations:wraith:nihil", kwargs={"pk": self.pk})
+
+    def get_update_url(self):
+        return reverse("locations:wraith:update:nihil", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("locations:wraith:create:nihil")
+
+    def get_heading(self):
+        return "wto_heading"

--- a/locations/templates/locations/wraith/byway/detail.html
+++ b/locations/templates/locations/wraith/byway/detail.html
@@ -1,0 +1,95 @@
+{% extends "locations/core/location/detail.html" %}
+{% load sanitize_text dots %}
+{% block objectname %}
+    <!-- Page Header with Wraith styling -->
+    <div class="tg-card header-card mb-4" data-gameline="wto">
+        <div class="tg-card-header">
+            <h1 class="tg-card-title wto_heading">
+                {{ object.name }}
+            </h1>
+            {% if object.origin and object.destination %}
+                <p class="tg-card-subtitle mb-0">
+                    Route: {{ object.origin }} → {{ object.destination }}
+                </p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock objectname %}
+{% block model_specific %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h5 class="tg-card-title wto_heading">Byway Details</h5>
+        </div>
+        <div class="tg-card-body" style="padding: 24px;">
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Danger Level:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_danger_level_display }}</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Stability:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_stability_display }}</span>
+                    </div>
+                </div>
+            </div>
+            {% if object.origin or object.destination or object.travel_time %}
+                <div class="row">
+                    {% if object.origin %}
+                        <div class="col-md-4 mb-3">
+                            <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                                <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Origin:</span>
+                                <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.origin }}</span>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if object.destination %}
+                        <div class="col-md-4 mb-3">
+                            <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                                <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Destination:</span>
+                                <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.destination }}</span>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if object.travel_time %}
+                        <div class="col-md-4 mb-3">
+                            <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                                <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Travel Time:</span>
+                                <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.travel_time }}</span>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Maelstrom Proximity:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.maelstrom_proximity }}/10</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Spectral Activity:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.spectral_activity }}/10</span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-12">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Features</div>
+                        <ul style="margin-bottom: 0;">
+                            {% if object.has_waystation %}<li>Contains waystation for rest</li>{% endif %}
+                            {% if object.patrolled %}<li>Patrolled by Hierarchy forces</li>{% endif %}
+                            {% if object.haunted %}<li>Haunted by dangerous entities</li>{% endif %}
+                            {% if not object.has_waystation and not object.patrolled and not object.haunted %}<li>No special features</li>{% endif %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock model_specific %}

--- a/locations/templates/locations/wraith/byway/form.html
+++ b/locations/templates/locations/wraith/byway/form.html
@@ -1,0 +1,26 @@
+{% extends "locations/core/location/form.html" %}
+{% block creation_title %}
+    Create Byway
+{% endblock creation_title %}
+{% block other %}
+    <div class="row">
+        <div class="col-sm">{{ form.danger_level }}</div>
+        <div class="col-sm">{{ form.stability }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.origin }}</div>
+        <div class="col-sm">{{ form.destination }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.travel_time }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.maelstrom_proximity }}</div>
+        <div class="col-sm">{{ form.spectral_activity }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.has_waystation }}</div>
+        <div class="col-sm">{{ form.patrolled }}</div>
+        <div class="col-sm">{{ form.haunted }}</div>
+    </div>
+{% endblock other %}

--- a/locations/templates/locations/wraith/byway/list.html
+++ b/locations/templates/locations/wraith/byway/list.html
@@ -1,0 +1,36 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Byways
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wto_heading">Byways</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="text-center mb-4">
+                    <a href="{% url 'locations:wraith:create:byway' %}" class="btn btn-primary">Create New Byway</a>
+                </div>
+                <div class="row">
+                    {% for obj in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                                    <div style="font-size: 0.85rem; color: var(--theme-text-secondary); margin-top: 4px;">
+                                        {{ obj.get_danger_level_display }}{% if obj.origin and obj.destination %} - {{ obj.origin }} to {{ obj.destination }}{% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No byways found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/wraith/citadel/detail.html
+++ b/locations/templates/locations/wraith/citadel/detail.html
@@ -1,0 +1,79 @@
+{% extends "locations/core/location/detail.html" %}
+{% load sanitize_text dots %}
+{% block objectname %}
+    <!-- Page Header with Wraith styling -->
+    <div class="tg-card header-card mb-4" data-gameline="wto">
+        <div class="tg-card-header">
+            <h1 class="tg-card-title wto_heading">
+                {{ object.name }}
+            </h1>
+            {% if object.parent %}
+                <p class="tg-card-subtitle mb-0">
+                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock objectname %}
+{% block model_specific %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h5 class="tg-card-title wto_heading">Citadel Details</h5>
+        </div>
+        <div class="tg-card-body" style="padding: 24px;">
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Purpose:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_purpose_display }}</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Defense Rating:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.defense_rating }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Garrison Size:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.garrison_size }}</span>
+                    </div>
+                </div>
+                {% if object.commander %}
+                    <div class="col-md-6 mb-3">
+                        <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                            <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Commander:</span>
+                            <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.commander }}</span>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+            {% if object.controlling_faction %}
+                <div class="row">
+                    <div class="col-12 mb-3">
+                        <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                            <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Controlling Faction:</span>
+                            <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.controlling_faction }}</span>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            <div class="row">
+                <div class="col-12">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Special Features</div>
+                        <ul style="margin-bottom: 0;">
+                            {% if object.has_soulforges %}<li>Contains soulforging facilities</li>{% endif %}
+                            {% if object.has_prison %}<li>Contains prison/oubliette</li>{% endif %}
+                            {% if object.has_gateway %}<li>Contains gateway to other realms</li>{% endif %}
+                            {% if not object.has_soulforges and not object.has_prison and not object.has_gateway %}<li>No special features</li>{% endif %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock model_specific %}

--- a/locations/templates/locations/wraith/citadel/form.html
+++ b/locations/templates/locations/wraith/citadel/form.html
@@ -1,0 +1,22 @@
+{% extends "locations/core/location/form.html" %}
+{% block creation_title %}
+    Create Citadel
+{% endblock creation_title %}
+{% block other %}
+    <div class="row">
+        <div class="col-sm">{{ form.purpose }}</div>
+        <div class="col-sm">{{ form.defense_rating }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.garrison_size }}</div>
+        <div class="col-sm">{{ form.commander }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.controlling_faction }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.has_soulforges }}</div>
+        <div class="col-sm">{{ form.has_prison }}</div>
+        <div class="col-sm">{{ form.has_gateway }}</div>
+    </div>
+{% endblock other %}

--- a/locations/templates/locations/wraith/citadel/list.html
+++ b/locations/templates/locations/wraith/citadel/list.html
@@ -1,0 +1,36 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Citadels
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wto_heading">Citadels</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="text-center mb-4">
+                    <a href="{% url 'locations:wraith:create:citadel' %}" class="btn btn-primary">Create New Citadel</a>
+                </div>
+                <div class="row">
+                    {% for obj in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                                    <div style="font-size: 0.85rem; color: var(--theme-text-secondary); margin-top: 4px;">
+                                        {{ obj.get_purpose_display }}{% if obj.controlling_faction %} - {{ obj.controlling_faction }}{% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No citadels found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/wraith/freehold/detail.html
+++ b/locations/templates/locations/wraith/freehold/detail.html
@@ -1,0 +1,96 @@
+{% extends "locations/core/location/detail.html" %}
+{% load sanitize_text dots %}
+{% block objectname %}
+    <!-- Page Header with Wraith styling -->
+    <div class="tg-card header-card mb-4" data-gameline="wto">
+        <div class="tg-card-header">
+            <h1 class="tg-card-title wto_heading">
+                {{ object.name }}
+            </h1>
+            {% if object.leader %}
+                <p class="tg-card-subtitle mb-0">
+                    Led by: {{ object.leader }}
+                </p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock objectname %}
+{% block model_specific %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h5 class="tg-card-title wto_heading">Freehold Details</h5>
+        </div>
+        <div class="tg-card-body" style="padding: 24px;">
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Population:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.population }}</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Government:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_government_type_display }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Hierarchy Relation:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_hierarchy_relation_display }}</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Defense Rating:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.defense_rating }}/10</span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Resource Level:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.resource_level }}/10</span>
+                    </div>
+                </div>
+            </div>
+            {% if object.allied_factions %}
+                <div class="row">
+                    <div class="col-12 mb-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Allied Factions</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.allied_factions|sanitize_html }}</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            {% if object.founding_principle %}
+                <div class="row">
+                    <div class="col-12 mb-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Founding Principle</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.founding_principle|sanitize_html }}</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            <div class="row">
+                <div class="col-12">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Features</div>
+                        <ul style="margin-bottom: 0;">
+                            {% if object.has_soulforges %}<li>Contains soulforging facilities</li>{% endif %}
+                            {% if object.has_library %}<li>Contains significant library or archives</li>{% endif %}
+                            {% if object.has_safe_passage %}<li>Offers safe passage through territory</li>{% endif %}
+                            {% if object.hidden %}<li>Location is hidden or secret</li>{% endif %}
+                            {% if not object.has_soulforges and not object.has_library and not object.has_safe_passage and not object.hidden %}<li>No special features</li>{% endif %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock model_specific %}

--- a/locations/templates/locations/wraith/freehold/form.html
+++ b/locations/templates/locations/wraith/freehold/form.html
@@ -1,0 +1,32 @@
+{% extends "locations/core/location/form.html" %}
+{% block creation_title %}
+    Create Wraith Freehold
+{% endblock creation_title %}
+{% block other %}
+    <div class="row">
+        <div class="col-sm">{{ form.population }}</div>
+        <div class="col-sm">{{ form.government_type }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.leader }}</div>
+        <div class="col-sm">{{ form.hierarchy_relation }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.defense_rating }}</div>
+        <div class="col-sm">{{ form.resource_level }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.allied_factions }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.founding_principle }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.has_soulforges }}</div>
+        <div class="col-sm">{{ form.has_library }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.has_safe_passage }}</div>
+        <div class="col-sm">{{ form.hidden }}</div>
+    </div>
+{% endblock other %}

--- a/locations/templates/locations/wraith/freehold/list.html
+++ b/locations/templates/locations/wraith/freehold/list.html
@@ -1,0 +1,36 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Wraith Freeholds
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wto_heading">Wraith Freeholds</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="text-center mb-4">
+                    <a href="{% url 'locations:wraith:create:freehold' %}" class="btn btn-primary">Create New Freehold</a>
+                </div>
+                <div class="row">
+                    {% for obj in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                                    <div style="font-size: 0.85rem; color: var(--theme-text-secondary); margin-top: 4px;">
+                                        {{ obj.get_government_type_display }} - Pop: {{ obj.population }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No freeholds found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/wraith/nihil/detail.html
+++ b/locations/templates/locations/wraith/nihil/detail.html
@@ -1,0 +1,126 @@
+{% extends "locations/core/location/detail.html" %}
+{% load sanitize_text dots %}
+{% block objectname %}
+    <!-- Page Header with Wraith styling -->
+    <div class="tg-card header-card mb-4" data-gameline="wto">
+        <div class="tg-card-header">
+            <h1 class="tg-card-title wto_heading">
+                {{ object.name }}
+            </h1>
+            <p class="tg-card-subtitle mb-0">
+                {{ object.get_void_type_display }}
+            </p>
+        </div>
+    </div>
+{% endblock objectname %}
+{% block model_specific %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h5 class="tg-card-title wto_heading">Nihil Details</h5>
+        </div>
+        <div class="tg-card-body" style="padding: 24px;">
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Void Type:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_void_type_display }}</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Stability:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.get_stability_display }}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-4 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Hazard Level:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.hazard_level }}/10</span>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Oblivion Proximity:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.oblivion_proximity }}/10</span>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Entropy Rating:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.entropy_rating }}/10</span>
+                    </div>
+                </div>
+            </div>
+            {% if object.estimated_size %}
+                <div class="row">
+                    <div class="col-12 mb-3">
+                        <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                            <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Estimated Size:</span>
+                            <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.estimated_size }}</span>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            <div class="row">
+                <div class="col-12 mb-3">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Effects on Travelers</div>
+                        <ul style="margin-bottom: 0;">
+                            {% if object.corpus_drain %}<li>Drains Corpus from wraiths</li>{% endif %}
+                            {% if object.pathos_drain %}<li>Drains Pathos from wraiths</li>{% endif %}
+                            {% if object.memory_loss %}<li>Causes memory loss or disorientation</li>{% endif %}
+                            {% if object.shadow_attraction %}<li>Attracts and empowers Shadows</li>{% endif %}
+                            {% if not object.corpus_drain and not object.pathos_drain and not object.memory_loss and not object.shadow_attraction %}<li>No known effects</li>{% endif %}
+                        </ul>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Avoidable:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{% if object.avoidable %}Yes{% else %}No{% endif %}</span>
+                    </div>
+                </div>
+                <div class="col-md-6 mb-3">
+                    <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                        <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Marked:</span>
+                        <span style="font-weight: 700; color: var(--theme-text-primary);">{% if object.marked %}Yes{% else %}No{% endif %}</span>
+                    </div>
+                </div>
+            </div>
+            {% if object.spectral_activity > 0 %}
+                <div class="row">
+                    <div class="col-12 mb-3">
+                        <div style="display: inline-block; padding: 10px 24px; border-radius: 6px; background-color: rgba(0,0,0,0.05);">
+                            <span style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-right: 8px;">Spectral Activity:</span>
+                            <span style="font-weight: 700; color: var(--theme-text-primary);">{{ object.spectral_activity }}/10</span>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            {% if object.contains_relics %}
+                <div class="row">
+                    <div class="col-12 mb-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Note</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">May contain lost relics or artifacts</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            {% if object.origin_story %}
+                <div class="row">
+                    <div class="col-12">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 8px;">Origin</div>
+                            <div style="line-height: 1.6; color: var(--theme-text-primary);">{{ object.origin_story|sanitize_html }}</div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock model_specific %}

--- a/locations/templates/locations/wraith/nihil/form.html
+++ b/locations/templates/locations/wraith/nihil/form.html
@@ -1,0 +1,35 @@
+{% extends "locations/core/location/form.html" %}
+{% block creation_title %}
+    Create Nihil
+{% endblock creation_title %}
+{% block other %}
+    <div class="row">
+        <div class="col-sm">{{ form.void_type }}</div>
+        <div class="col-sm">{{ form.stability }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.hazard_level }}</div>
+        <div class="col-sm">{{ form.oblivion_proximity }}</div>
+        <div class="col-sm">{{ form.entropy_rating }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.estimated_size }}</div>
+        <div class="col-sm">{{ form.spectral_activity }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.corpus_drain }}</div>
+        <div class="col-sm">{{ form.pathos_drain }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.memory_loss }}</div>
+        <div class="col-sm">{{ form.shadow_attraction }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.avoidable }}</div>
+        <div class="col-sm">{{ form.marked }}</div>
+        <div class="col-sm">{{ form.contains_relics }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">{{ form.origin_story }}</div>
+    </div>
+{% endblock other %}

--- a/locations/templates/locations/wraith/nihil/list.html
+++ b/locations/templates/locations/wraith/nihil/list.html
@@ -1,0 +1,36 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Nihils
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wto_heading">Nihils</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="text-center mb-4">
+                    <a href="{% url 'locations:wraith:create:nihil' %}" class="btn btn-primary">Create New Nihil</a>
+                </div>
+                <div class="row">
+                    {% for obj in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                                    <div style="font-size: 0.85rem; color: var(--theme-text-secondary); margin-top: 4px;">
+                                        {{ obj.get_void_type_display }} - Hazard {{ obj.hazard_level }}/10
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No nihils found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/urls/wraith/create.py
+++ b/locations/urls/wraith/create.py
@@ -4,6 +4,21 @@ from locations import views
 app_name = "wraith:create"
 urls = [
     path(
+        "byway/",
+        views.wraith.BywayCreateView.as_view(),
+        name="byway",
+    ),
+    path(
+        "citadel/",
+        views.wraith.CitadelCreateView.as_view(),
+        name="citadel",
+    ),
+    path(
+        "freehold/",
+        views.wraith.WraithFreeholdCreateView.as_view(),
+        name="freehold",
+    ),
+    path(
         "haunt/",
         views.wraith.HauntCreateView.as_view(),
         name="haunt",
@@ -12,5 +27,10 @@ urls = [
         "necropolis/",
         views.wraith.NecropolisCreateView.as_view(),
         name="necropolis",
+    ),
+    path(
+        "nihil/",
+        views.wraith.NihilCreateView.as_view(),
+        name="nihil",
     ),
 ]

--- a/locations/urls/wraith/detail.py
+++ b/locations/urls/wraith/detail.py
@@ -3,10 +3,14 @@ from locations import views
 
 app_name = "locations:detail"
 urls = [
+    path("byway/<pk>/", views.wraith.BywayDetailView.as_view(), name="byway"),
+    path("citadel/<pk>/", views.wraith.CitadelDetailView.as_view(), name="citadel"),
+    path("freehold/<pk>/", views.wraith.WraithFreeholdDetailView.as_view(), name="freehold"),
     path("haunt/<pk>/", views.wraith.HauntDetailView.as_view(), name="haunt"),
     path(
         "necropolis/<pk>/",
         views.wraith.NecropolisDetailView.as_view(),
         name="necropolis",
     ),
+    path("nihil/<pk>/", views.wraith.NihilDetailView.as_view(), name="nihil"),
 ]

--- a/locations/urls/wraith/index.py
+++ b/locations/urls/wraith/index.py
@@ -2,6 +2,10 @@ from django.urls import path
 from locations import views
 
 urls = [
+    path("byway/", views.wraith.BywayListView.as_view(), name="byway"),
+    path("citadel/", views.wraith.CitadelListView.as_view(), name="citadel"),
+    path("freehold/", views.wraith.WraithFreeholdListView.as_view(), name="freehold"),
     path("haunt/", views.wraith.HauntListView.as_view(), name="haunt"),
     path("necropolis/", views.wraith.NecropolisListView.as_view(), name="necropolis"),
+    path("nihil/", views.wraith.NihilListView.as_view(), name="nihil"),
 ]

--- a/locations/urls/wraith/update.py
+++ b/locations/urls/wraith/update.py
@@ -4,6 +4,21 @@ from locations import views
 app_name = "locations:update"
 urls = [
     path(
+        "byway/<pk>/",
+        views.wraith.BywayUpdateView.as_view(),
+        name="byway",
+    ),
+    path(
+        "citadel/<pk>/",
+        views.wraith.CitadelUpdateView.as_view(),
+        name="citadel",
+    ),
+    path(
+        "freehold/<pk>/",
+        views.wraith.WraithFreeholdUpdateView.as_view(),
+        name="freehold",
+    ),
+    path(
         "haunt/<pk>/",
         views.wraith.HauntUpdateView.as_view(),
         name="haunt",
@@ -12,5 +27,10 @@ urls = [
         "necropolis/<pk>/",
         views.wraith.NecropolisUpdateView.as_view(),
         name="necropolis",
+    ),
+    path(
+        "nihil/<pk>/",
+        views.wraith.NihilUpdateView.as_view(),
+        name="nihil",
     ),
 ]

--- a/locations/views/wraith/__init__.py
+++ b/locations/views/wraith/__init__.py
@@ -1,3 +1,16 @@
+from .byway import BywayCreateView, BywayDetailView, BywayListView, BywayUpdateView
+from .citadel import (
+    CitadelCreateView,
+    CitadelDetailView,
+    CitadelListView,
+    CitadelUpdateView,
+)
+from .freehold import (
+    WraithFreeholdCreateView,
+    WraithFreeholdDetailView,
+    WraithFreeholdListView,
+    WraithFreeholdUpdateView,
+)
 from .haunt import HauntCreateView, HauntDetailView, HauntListView, HauntUpdateView
 from .necropolis import (
     NecropolisCreateView,
@@ -5,3 +18,4 @@ from .necropolis import (
     NecropolisListView,
     NecropolisUpdateView,
 )
+from .nihil import NihilCreateView, NihilDetailView, NihilListView, NihilUpdateView

--- a/locations/views/wraith/byway.py
+++ b/locations/views/wraith/byway.py
@@ -1,0 +1,63 @@
+from core.mixins import (
+    EditPermissionMixin,
+    MessageMixin,
+    ViewPermissionMixin,
+)
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.models.wraith import Byway
+
+
+class BywayDetailView(ViewPermissionMixin, DetailView):
+    model = Byway
+    template_name = "locations/wraith/byway/detail.html"
+
+
+class BywayCreateView(LoginRequiredMixin, MessageMixin, CreateView):
+    model = Byway
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "danger_level",
+        "stability",
+        "origin",
+        "destination",
+        "travel_time",
+        "maelstrom_proximity",
+        "spectral_activity",
+        "has_waystation",
+        "patrolled",
+        "haunted",
+    ]
+    template_name = "locations/wraith/byway/form.html"
+    success_message = "Byway '{name}' created successfully!"
+    error_message = "Failed to create byway. Please correct the errors below."
+
+
+class BywayUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
+    model = Byway
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "danger_level",
+        "stability",
+        "origin",
+        "destination",
+        "travel_time",
+        "maelstrom_proximity",
+        "spectral_activity",
+        "has_waystation",
+        "patrolled",
+        "haunted",
+    ]
+    template_name = "locations/wraith/byway/form.html"
+    success_message = "Byway '{name}' updated successfully!"
+    error_message = "Failed to update byway. Please correct the errors below."
+
+
+class BywayListView(ListView):
+    model = Byway
+    ordering = ["name"]
+    template_name = "locations/wraith/byway/list.html"

--- a/locations/views/wraith/citadel.py
+++ b/locations/views/wraith/citadel.py
@@ -1,0 +1,59 @@
+from core.mixins import (
+    EditPermissionMixin,
+    MessageMixin,
+    ViewPermissionMixin,
+)
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.models.wraith import Citadel
+
+
+class CitadelDetailView(ViewPermissionMixin, DetailView):
+    model = Citadel
+    template_name = "locations/wraith/citadel/detail.html"
+
+
+class CitadelCreateView(LoginRequiredMixin, MessageMixin, CreateView):
+    model = Citadel
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "purpose",
+        "defense_rating",
+        "garrison_size",
+        "commander",
+        "controlling_faction",
+        "has_soulforges",
+        "has_prison",
+        "has_gateway",
+    ]
+    template_name = "locations/wraith/citadel/form.html"
+    success_message = "Citadel '{name}' created successfully!"
+    error_message = "Failed to create citadel. Please correct the errors below."
+
+
+class CitadelUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
+    model = Citadel
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "purpose",
+        "defense_rating",
+        "garrison_size",
+        "commander",
+        "controlling_faction",
+        "has_soulforges",
+        "has_prison",
+        "has_gateway",
+    ]
+    template_name = "locations/wraith/citadel/form.html"
+    success_message = "Citadel '{name}' updated successfully!"
+    error_message = "Failed to update citadel. Please correct the errors below."
+
+
+class CitadelListView(ListView):
+    model = Citadel
+    ordering = ["name"]
+    template_name = "locations/wraith/citadel/list.html"

--- a/locations/views/wraith/freehold.py
+++ b/locations/views/wraith/freehold.py
@@ -1,0 +1,67 @@
+from core.mixins import (
+    EditPermissionMixin,
+    MessageMixin,
+    ViewPermissionMixin,
+)
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.models.wraith import WraithFreehold
+
+
+class WraithFreeholdDetailView(ViewPermissionMixin, DetailView):
+    model = WraithFreehold
+    template_name = "locations/wraith/freehold/detail.html"
+
+
+class WraithFreeholdCreateView(LoginRequiredMixin, MessageMixin, CreateView):
+    model = WraithFreehold
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "population",
+        "government_type",
+        "leader",
+        "hierarchy_relation",
+        "allied_factions",
+        "defense_rating",
+        "resource_level",
+        "has_soulforges",
+        "has_library",
+        "has_safe_passage",
+        "hidden",
+        "founding_principle",
+    ]
+    template_name = "locations/wraith/freehold/form.html"
+    success_message = "Wraith Freehold '{name}' created successfully!"
+    error_message = "Failed to create freehold. Please correct the errors below."
+
+
+class WraithFreeholdUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
+    model = WraithFreehold
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "population",
+        "government_type",
+        "leader",
+        "hierarchy_relation",
+        "allied_factions",
+        "defense_rating",
+        "resource_level",
+        "has_soulforges",
+        "has_library",
+        "has_safe_passage",
+        "hidden",
+        "founding_principle",
+    ]
+    template_name = "locations/wraith/freehold/form.html"
+    success_message = "Wraith Freehold '{name}' updated successfully!"
+    error_message = "Failed to update freehold. Please correct the errors below."
+
+
+class WraithFreeholdListView(ListView):
+    model = WraithFreehold
+    ordering = ["name"]
+    template_name = "locations/wraith/freehold/list.html"

--- a/locations/views/wraith/nihil.py
+++ b/locations/views/wraith/nihil.py
@@ -1,0 +1,73 @@
+from core.mixins import (
+    EditPermissionMixin,
+    MessageMixin,
+    ViewPermissionMixin,
+)
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.models.wraith import Nihil
+
+
+class NihilDetailView(ViewPermissionMixin, DetailView):
+    model = Nihil
+    template_name = "locations/wraith/nihil/detail.html"
+
+
+class NihilCreateView(LoginRequiredMixin, MessageMixin, CreateView):
+    model = Nihil
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "void_type",
+        "stability",
+        "hazard_level",
+        "oblivion_proximity",
+        "entropy_rating",
+        "estimated_size",
+        "corpus_drain",
+        "pathos_drain",
+        "memory_loss",
+        "shadow_attraction",
+        "avoidable",
+        "marked",
+        "spectral_activity",
+        "contains_relics",
+        "origin_story",
+    ]
+    template_name = "locations/wraith/nihil/form.html"
+    success_message = "Nihil '{name}' created successfully!"
+    error_message = "Failed to create nihil. Please correct the errors below."
+
+
+class NihilUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
+    model = Nihil
+    fields = [
+        "name",
+        "description",
+        "parent",
+        "void_type",
+        "stability",
+        "hazard_level",
+        "oblivion_proximity",
+        "entropy_rating",
+        "estimated_size",
+        "corpus_drain",
+        "pathos_drain",
+        "memory_loss",
+        "shadow_attraction",
+        "avoidable",
+        "marked",
+        "spectral_activity",
+        "contains_relics",
+        "origin_story",
+    ]
+    template_name = "locations/wraith/nihil/form.html"
+    success_message = "Nihil '{name}' updated successfully!"
+    error_message = "Failed to update nihil. Please correct the errors below."
+
+
+class NihilListView(ListView):
+    model = Nihil
+    ordering = ["name"]
+    template_name = "locations/wraith/nihil/list.html"

--- a/populate_db/objects.py
+++ b/populate_db/objects.py
@@ -144,8 +144,12 @@ ObjectType.objects.get_or_create(name="artifact", type="obj", gameline="wto")
 ObjectType.objects.get_or_create(name="relic", type="obj", gameline="wto")
 
 # WtO Location Objects
+ObjectType.objects.get_or_create(name="byway", type="loc", gameline="wto")
+ObjectType.objects.get_or_create(name="citadel", type="loc", gameline="wto")
 ObjectType.objects.get_or_create(name="haunt", type="loc", gameline="wto")
 ObjectType.objects.get_or_create(name="necropolis", type="loc", gameline="wto")
+ObjectType.objects.get_or_create(name="nihil", type="loc", gameline="wto")
+ObjectType.objects.get_or_create(name="wraith_freehold", type="loc", gameline="wto")
 
 # DtF Character Objects
 demon = ObjectType.objects.get_or_create(name="demon", type="char", gameline="dtf")[0]


### PR DESCRIPTION
Implemented comprehensive location types for Wraith: the Oblivion:

Models:
- Citadel: Fortified strongholds with defense ratings, garrison size,
  faction control, and special features (soulforges, prisons, gateways)
- Byway: Tempest paths with danger levels, stability, travel routes,
  maelstrom proximity, and spectral activity ratings
- WraithFreehold: Independent territories with population, government
  types, Hierarchy relations, defense/resource ratings, and features
- Nihil: Void zones with hazard levels, Oblivion proximity, entropy
  ratings, traveler effects (corpus/pathos drain, memory loss), and
  navigation properties

Each location type includes:
- Full CRUD views (Detail, Create, Update, List)
- Custom templates following WtO styling guidelines
- URL routing integrated into existing wraith location structure
- ObjectType registration in populate_db/objects.py
- Comprehensive field choices for gameplay-relevant attributes

All implementations follow project patterns:
- Polymorphic inheritance from LocationModel
- Permission mixins (ViewPermission, EditPermission)
- Message mixins for user feedback
- wto_heading CSS class for consistent theming
- Proper get_absolute_url() and get_update_url() methods