### PR TITLE
Add Demesne and Periapt types for Mage: the Ascension

### DIFF
--- a/items/forms/mage/__init__.py
+++ b/items/forms/mage/__init__.py
@@ -1,2 +1,3 @@
+from .periapt import PeriaptForm
 from .sorcerer_artifact import SorcererArtifactForm
 from .wonder import WonderForm

--- a/items/forms/mage/periapt.py
+++ b/items/forms/mage/periapt.py
@@ -1,0 +1,151 @@
+from characters.forms.mage.effect import EffectCreateOrSelectFormSet
+from characters.models.mage.effect import Effect
+from characters.models.mage.resonance import Resonance
+from django import forms
+from items.models.mage.periapt import Periapt
+from items.models.mage.wonder import WonderResonanceRating
+
+
+class WonderResonanceRatingForm(forms.ModelForm):
+    class Meta:
+        model = WonderResonanceRating
+        fields = ["resonance", "rating"]
+
+    rating = forms.IntegerField(min_value=0, max_value=5, initial=0)
+    resonance = forms.ModelChoiceField(
+        queryset=Resonance.objects.all(), required=False
+    )
+
+
+class BaseWonderResonanceRatingFormSet(forms.BaseInlineFormSet):
+    pass
+
+
+PeriaptResonanceRatingFormSet = forms.inlineformset_factory(
+    Periapt,
+    WonderResonanceRating,
+    form=WonderResonanceRatingForm,
+    formset=BaseWonderResonanceRatingFormSet,
+    extra=1,
+    can_delete=False,
+)
+
+
+class PeriaptForm(forms.ModelForm):
+    class Meta:
+        model = Periapt
+        fields = (
+            "name",
+            "description",
+            "rank",
+            "arete",
+            "max_charges",
+            "current_charges",
+            "is_consumable",
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
+        self.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description here"}
+        )
+
+        self.resonance_formset = PeriaptResonanceRatingFormSet(
+            instance=self.instance if self.instance.pk else None,
+            data=self.data if self.is_bound else None,
+            prefix="resonance",
+        )
+
+        self.effect_formset = EffectCreateOrSelectFormSet(
+            queryset=Effect.objects.none(),
+            data=self.data if self.is_bound else None,
+            prefix="effects",
+        )
+
+    def is_valid(self):
+        valid = super().is_valid()
+        valid = valid and self.resonance_formset.is_valid()
+        valid = valid and self.effect_formset.is_valid()
+        return valid
+
+    def save(self, commit=True):
+        periapt = super().save(commit=False)
+
+        if commit:
+            periapt.save()
+
+            self.resonance_formset.instance = periapt
+            self.resonance_formset.save()
+
+            effects = self.effect_formset.save()
+            if effects:
+                periapt.power = effects[0]
+                periapt.save()
+
+        return periapt
+
+    def clean(self):
+        cleaned_data = super().clean()
+        rank = cleaned_data.get("rank", None)
+        arete = cleaned_data.get("arete", None)
+        max_charges = cleaned_data.get("max_charges", 1)
+        current_charges = cleaned_data.get("current_charges", 1)
+
+        if rank is None:
+            raise forms.ValidationError("Rank cannot be none")
+
+        if arete is None:
+            raise forms.ValidationError("Periapts must have an Arete rating")
+
+        if arete < rank:
+            raise forms.ValidationError(
+                "Periapt Arete rating must be at least equal to rank"
+            )
+
+        if current_charges > max_charges:
+            raise forms.ValidationError(
+                "Current charges cannot exceed maximum charges"
+            )
+
+        if not self.resonance_formset.is_valid():
+            return cleaned_data
+
+        total_resonance_rating = sum(
+            form.cleaned_data.get("rating", 0)
+            for form in self.resonance_formset
+            if form.cleaned_data and not form.cleaned_data.get("DELETE", False)
+        )
+
+        if total_resonance_rating < rank:
+            raise forms.ValidationError("Resonance total must match or exceed rank")
+
+        if not self.effect_formset.is_valid():
+            raise forms.ValidationError("Effects invalid!")
+
+        num_powers = len(
+            [form.cleaned_data for form in self.effect_formset if form.cleaned_data]
+        )
+
+        if num_powers > 1:
+            raise forms.ValidationError("Periapts can only have one power")
+
+        max_cost = rank
+        for form in self.effect_formset:
+            if form.cost() > max_cost:
+                raise forms.ValidationError(
+                    f"Effect too expensive, maximum cost is {max_cost}"
+                )
+
+        points = rank * 3
+        total_cost = total_resonance_rating - rank
+        total_cost += arete - rank
+        for form in self.effect_formset:
+            total_cost += form.cost()
+
+        if total_cost > points:
+            raise forms.ValidationError(
+                "Extra Resonance, Arete, and Effects must be less than 3 times the rank of the Periapt"
+            )
+
+        return cleaned_data

--- a/items/models/mage/__init__.py
+++ b/items/models/mage/__init__.py
@@ -1,6 +1,7 @@
 from .artifact import Artifact
 from .charm import Charm
 from .grimoire import Grimoire
+from .periapt import Periapt
 from .sorcerer_artifact import SorcererArtifact
 from .talisman import Talisman
 from .wonder import Wonder, WonderResonanceRating

--- a/items/models/mage/periapt.py
+++ b/items/models/mage/periapt.py
@@ -1,0 +1,87 @@
+from django.core.validators import MaxValueValidator, MinValueValidator
+from django.db import models
+from django.db.models import CheckConstraint, Q
+from django.urls import reverse
+
+from .wonder import Wonder
+
+
+class Periapt(Wonder):
+    type = "periapt"
+
+    arete = models.IntegerField(default=0)
+    power = models.ForeignKey(
+        "characters.Effect", blank=True, null=True, on_delete=models.SET_NULL
+    )
+    max_charges = models.IntegerField(
+        default=1,
+        validators=[MinValueValidator(1), MaxValueValidator(100)],
+        help_text="Maximum number of charges the periapt can hold",
+    )
+    current_charges = models.IntegerField(
+        default=1,
+        validators=[MinValueValidator(0), MaxValueValidator(100)],
+        help_text="Current number of charges remaining",
+    )
+    is_consumable = models.BooleanField(
+        default=True, help_text="Whether the periapt is destroyed when charges are depleted"
+    )
+
+    class Meta:
+        verbose_name = "Periapt"
+        verbose_name_plural = "Periapts"
+        constraints = [
+            CheckConstraint(
+                check=Q(arete__gte=0, arete__lte=10),
+                name="items_periapt_arete_range",
+                violation_error_message="Periapt arete must be between 0 and 10",
+            ),
+            CheckConstraint(
+                check=Q(max_charges__gte=1, max_charges__lte=100),
+                name="items_periapt_max_charges_range",
+                violation_error_message="Periapt max charges must be between 1 and 100",
+            ),
+            CheckConstraint(
+                check=Q(current_charges__gte=0, current_charges__lte=100),
+                name="items_periapt_current_charges_range",
+                violation_error_message="Periapt current charges must be between 0 and 100",
+            ),
+        ]
+
+    def get_update_url(self):
+        return reverse("items:mage:update:periapt", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("items:mage:create:periapt")
+
+    def set_power(self, power):
+        self.power = power
+        self.save()
+        return True
+
+    def has_power(self):
+        return self.power is not None
+
+    def use_charge(self):
+        """Use one charge from the periapt. Returns True if successful, False if no charges remain."""
+        if self.current_charges > 0:
+            self.current_charges -= 1
+            self.save()
+            return True
+        return False
+
+    def recharge(self, amount=1):
+        """Recharge the periapt by the specified amount. Cannot exceed max_charges."""
+        new_charges = min(self.current_charges + amount, self.max_charges)
+        self.current_charges = new_charges
+        self.save()
+        return True
+
+    def is_depleted(self):
+        """Check if the periapt has no charges remaining."""
+        return self.current_charges == 0
+
+    def charges_remaining(self):
+        """Return the number of charges remaining."""
+        return self.current_charges

--- a/items/templates/items/mage/periapt/detail.html
+++ b/items/templates/items/mage/periapt/detail.html
@@ -1,0 +1,52 @@
+{% extends "items/mage/wonder/detail.html" %}
+{% load sanitize_text dots %}
+
+{% block model_specific %}
+    {{ block.super }}
+    <!-- Periapt-specific information -->
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h6 class="mta_heading mb-0">Periapt Properties</h6>
+        </div>
+        <div class="tg-card-body" style="padding: 20px;">
+            <div class="row">
+                <div class="col-md-4 mb-3">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 4px;">Arete</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--theme-text-primary);">{{ object.arete }}</div>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 4px;">Charges</div>
+                        <div style="font-size: 1.5rem; font-weight: 700; color: var(--theme-text-primary);">{{ object.current_charges }}/{{ object.max_charges }}</div>
+                    </div>
+                </div>
+                <div class="col-md-4 mb-3">
+                    <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                        <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 4px;">Type</div>
+                        <div style="font-weight: 700; color: var(--theme-text-primary);">{% if object.is_consumable %}Consumable{% else %}Rechargeable{% endif %}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock model_specific %}
+
+{% block powers %}
+    {% if object.power %}
+        <div class="tg-card mb-4">
+            <div class="tg-card-header">
+                <h6 class="mta_heading mb-0">Power</h6>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                    <a href="{{ object.power.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ object.power.name }}</a>
+                    {% if object.power.description %}
+                        <p class="mt-2 mb-0" style="color: var(--theme-text-secondary);">{{ object.power.description|sanitize_html }}</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock powers %}

--- a/items/templates/items/mage/periapt/form.html
+++ b/items/templates/items/mage/periapt/form.html
@@ -1,0 +1,29 @@
+{% extends "items/mage/wonder/form.html" %}
+{% block creation_title %}
+    Create Periapt
+{% endblock creation_title %}
+{% block powers %}
+    <div class="col-sm mta_heading">
+        <h2>Powers</h2>
+    </div>
+    <div class="row">
+        <div class="col-sm">Arete</div>
+        <div class="col-sm">{{ form.arete }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Max Charges</div>
+        <div class="col-sm">{{ form.max_charges }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Current Charges</div>
+        <div class="col-sm">{{ form.current_charges }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Is Consumable</div>
+        <div class="col-sm">{{ form.is_consumable }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Power</div>
+        <div class="col-sm">{{ form.power }}</div>
+    </div>
+{% endblock powers %}

--- a/items/templates/items/mage/periapt/list.html
+++ b/items/templates/items/mage/periapt/list.html
@@ -1,0 +1,30 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Periapts
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title mta_heading">Periapts</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="row">
+                    {% for obj in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No periapts found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/items/urls/mage/create.py
+++ b/items/urls/mage/create.py
@@ -23,6 +23,11 @@ urls = [
         name="talisman",
     ),
     path(
+        "periapt/",
+        views.mage.PeriaptCreateView.as_view(),
+        name="periapt",
+    ),
+    path(
         "grimoire/",
         views.mage.GrimoireCreateView.as_view(),
         name="grimoire",

--- a/items/urls/mage/detail.py
+++ b/items/urls/mage/detail.py
@@ -7,6 +7,7 @@ urls = [
     path("charm/<pk>/", views.mage.CharmDetailView.as_view(), name="charm"),
     path("artifact/<pk>/", views.mage.ArtifactDetailView.as_view(), name="artifact"),
     path("talisman/<pk>/", views.mage.TalismanDetailView.as_view(), name="talisman"),
+    path("periapt/<pk>/", views.mage.PeriaptDetailView.as_view(), name="periapt"),
     path("grimoire/<pk>/", views.mage.GrimoireDetailView.as_view(), name="grimoire"),
     path(
         "sorcerer_artifact/<pk>/",

--- a/items/urls/mage/index.py
+++ b/items/urls/mage/index.py
@@ -6,6 +6,7 @@ urls = [
     path("charm/", views.mage.CharmListView.as_view(), name="charm"),
     path("artifact/", views.mage.ArtifactListView.as_view(), name="artifact"),
     path("talisman/", views.mage.TalismanListView.as_view(), name="talisman"),
+    path("periapt/", views.mage.PeriaptListView.as_view(), name="periapt"),
     path("grimoire/", views.mage.GrimoireListView.as_view(), name="grimoire"),
     path(
         "sorcerer_artifact/",

--- a/items/urls/mage/update.py
+++ b/items/urls/mage/update.py
@@ -23,6 +23,11 @@ urls = [
         name="talisman",
     ),
     path(
+        "periapt/<pk>/",
+        views.mage.PeriaptUpdateView.as_view(),
+        name="periapt",
+    ),
+    path(
         "grimoire/<pk>/",
         views.mage.GrimoireUpdateView.as_view(),
         name="grimoire",

--- a/items/views/mage/__init__.py
+++ b/items/views/mage/__init__.py
@@ -11,6 +11,12 @@ from .grimoire import (
     GrimoireListView,
     GrimoireUpdateView,
 )
+from .periapt import (
+    PeriaptCreateView,
+    PeriaptDetailView,
+    PeriaptListView,
+    PeriaptUpdateView,
+)
 from .sorcerer_artifact import (
     SorcererArtifactCreateView,
     SorcererArtifactDetailView,

--- a/items/views/mage/periapt.py
+++ b/items/views/mage/periapt.py
@@ -1,0 +1,78 @@
+from typing import Any
+
+from core.mixins import MessageMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from items.models.mage import Periapt, WonderResonanceRating
+
+
+class PeriaptDetailView(DetailView):
+    model = Periapt
+    template_name = "items/mage/periapt/detail.html"
+
+    def get_context_data(self, **kwargs) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context["resonance"] = WonderResonanceRating.objects.filter(
+            wonder=self.object
+        ).order_by("resonance__name")
+        return context
+
+
+class PeriaptListView(ListView):
+    model = Periapt
+    ordering = ["name"]
+    template_name = "items/mage/periapt/list.html"
+
+
+class PeriaptCreateView(LoginRequiredMixin, MessageMixin, CreateView):
+    model = Periapt
+    fields = [
+        "name",
+        "rank",
+        "background_cost",
+        "quintessence_max",
+        "description",
+        "power",
+        "arete",
+        "max_charges",
+        "current_charges",
+        "is_consumable",
+    ]
+    template_name = "items/mage/periapt/form.html"
+    success_message = "Periapt '{name}' created successfully!"
+    error_message = "Failed to create Periapt. Please correct the errors below."
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
+        form.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description here"}
+        )
+        return form
+
+
+class PeriaptUpdateView(MessageMixin, UpdateView):
+    model = Periapt
+    fields = [
+        "name",
+        "rank",
+        "background_cost",
+        "quintessence_max",
+        "description",
+        "power",
+        "arete",
+        "max_charges",
+        "current_charges",
+        "is_consumable",
+    ]
+    template_name = "items/mage/periapt/form.html"
+    success_message = "Periapt '{name}' updated successfully!"
+    error_message = "Failed to update Periapt. Please correct the errors below."
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
+        form.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description here"}
+        )
+        return form

--- a/locations/forms/mage/__init__.py
+++ b/locations/forms/mage/__init__.py
@@ -1,3 +1,4 @@
+from .demesne import DemesneForm
 from .node import NodeForm
 from .paradox_realm import ParadoxRealmForm
 from .reality_zone import (

--- a/locations/forms/mage/demesne.py
+++ b/locations/forms/mage/demesne.py
@@ -1,0 +1,86 @@
+from django import forms
+from locations.forms.mage.reality_zone import RealityZonePracticeRatingFormSet
+from locations.models.mage.demesne import Demesne
+from locations.models.mage.reality_zone import RealityZone
+
+
+class DemesneForm(forms.ModelForm):
+    class Meta:
+        model = Demesne
+        fields = ("name", "parent", "description", "rank", "size", "accessibility")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
+        self.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description here"}
+        )
+        self.fields["size"].widget.attrs.update(
+            {"placeholder": "e.g., Small chamber, Expansive realm"}
+        )
+        self.fields["parent"].required = False
+        if self.instance.pk and self.instance.reality_zone:
+            self.reality_zone = self.instance.reality_zone
+        else:
+            self.reality_zone = RealityZone()
+
+        self.reality_zone_formset = RealityZonePracticeRatingFormSet(
+            instance=self.reality_zone,
+            data=self.data if self.is_bound else None,
+            prefix="reality_zone",
+        )
+
+    def is_valid(self):
+        valid = super().is_valid()
+        valid = valid and self.reality_zone_formset.is_valid()
+        return valid
+
+    def save(self, commit=True):
+        demesne = super().save(commit=False)
+        demesne.rank = self.cleaned_data.get("rank")
+        if commit:
+            demesne.save()
+            self.reality_zone.name = demesne.name
+            self.reality_zone.save()
+            demesne.reality_zone = self.reality_zone
+            demesne.save()
+
+            # Save the RealityZonePracticeRatingFormSet
+            self.reality_zone_formset.instance = self.reality_zone
+            self.reality_zone_formset.save()
+
+        return demesne
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        rank = cleaned_data.get("rank", None)
+        if rank is None:
+            raise forms.ValidationError("Rank cannot be none")
+
+        if not self.reality_zone_formset.is_valid():
+            return cleaned_data
+
+        total_rz_rating = sum(
+            form.cleaned_data.get("rating", 0)
+            for form in self.reality_zone_formset
+            if form.cleaned_data and not form.cleaned_data.get("DELETE", False)
+        )
+
+        total_positive_rz_rating = sum(
+            form.cleaned_data.get("rating", 0)
+            for form in self.reality_zone_formset
+            if form.cleaned_data
+            and not form.cleaned_data.get("DELETE", False)
+            and form.cleaned_data.get("rating", 0) > 0
+        )
+
+        if total_rz_rating != 0:
+            raise forms.ValidationError("Reality Zone Ratings must total 0")
+
+        if total_positive_rz_rating != rank:
+            raise forms.ValidationError(
+                "Positive Reality Zone Ratings must sum to Demesne rating"
+            )
+
+        return cleaned_data

--- a/locations/models/mage/__init__.py
+++ b/locations/models/mage/__init__.py
@@ -1,4 +1,5 @@
 from .chantry import Chantry
+from .demesne import Demesne
 from .library import Library
 from .node import Node, NodeMeritFlawRating, NodeResonanceRating
 from .paradox_realm import ParadoxAtmosphere, ParadoxObstacle, ParadoxRealm

--- a/locations/models/mage/demesne.py
+++ b/locations/models/mage/demesne.py
@@ -1,0 +1,43 @@
+from django.db import models
+from django.urls import reverse
+from locations.models.core.location import LocationModel
+from locations.models.mage.reality_zone import RealityZone
+
+
+class Demesne(LocationModel):
+    type = "demesne"
+
+    rank = models.IntegerField(default=0)
+    reality_zone = models.ForeignKey(
+        RealityZone, blank=True, null=True, on_delete=models.SET_NULL
+    )
+    size = models.CharField(
+        max_length=100,
+        blank=True,
+        help_text="Approximate size of the demesne (e.g., 'Small chamber', 'Expansive realm')",
+    )
+    accessibility = models.CharField(
+        max_length=20,
+        choices=[
+            ("easy", "Easy to Enter"),
+            ("moderate", "Moderate Difficulty"),
+            ("difficult", "Difficult to Enter"),
+            ("private", "Private/Restricted"),
+        ],
+        default="moderate",
+        help_text="How accessible the demesne is to outsiders",
+    )
+
+    class Meta:
+        verbose_name = "Demesne"
+        verbose_name_plural = "Demesnes"
+
+    def get_update_url(self):
+        return reverse("locations:mage:update:demesne", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("locations:mage:create:demesne")
+
+    def get_heading(self):
+        return "mta_heading"

--- a/locations/templates/locations/mage/demesne/detail.html
+++ b/locations/templates/locations/mage/demesne/detail.html
@@ -1,0 +1,53 @@
+{% extends "locations/core/location/detail.html" %}
+{% load sanitize_text dots %}
+{% block objectname %}
+    <!-- Page Header with Mage styling -->
+    <div class="tg-card header-card mb-4" data-gameline="mta">
+        <div class="tg-card-header">
+            <h1 class="tg-card-title mta_heading">
+                {{ object.name }}
+                {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
+            </h1>
+            {% if object.parent %}
+                <p class="tg-card-subtitle mb-0">
+                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                </p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock objectname %}
+
+{% block model_specific %}
+    <!-- Demesne-specific information -->
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h6 class="mta_heading mb-0">Demesne Properties</h6>
+        </div>
+        <div class="tg-card-body" style="padding: 20px;">
+            <div class="row">
+                {% if object.size %}
+                    <div class="col-md-6 mb-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 4px;">Size</div>
+                            <div style="color: var(--theme-text-primary);">{{ object.size }}</div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if object.accessibility %}
+                    <div class="col-md-6 mb-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary); margin-bottom: 4px;">Accessibility</div>
+                            <div style="color: var(--theme-text-primary);">{{ object.get_accessibility_display }}</div>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock model_specific %}
+
+{% block reality_zone %}
+    {% if object.reality_zone %}
+        {% include "locations/mage/reality_zone/display_includes/reality_zone.html" with object=object.reality_zone %}
+    {% endif %}
+{% endblock reality_zone %}

--- a/locations/templates/locations/mage/demesne/form.html
+++ b/locations/templates/locations/mage/demesne/form.html
@@ -1,0 +1,7 @@
+{% extends "locations/core/location/form.html" %}
+{% block creation_title %}
+    Create Demesne
+{% endblock creation_title %}
+{% block contents %}
+    {% include "locations/mage/demesne/form_include.html" %}
+{% endblock contents %}

--- a/locations/templates/locations/mage/demesne/form_include.html
+++ b/locations/templates/locations/mage/demesne/form_include.html
@@ -1,0 +1,43 @@
+{% load widget_tweaks %}
+<div class="row">
+    <div class="col-sm">
+        <h2 class="mta_heading">Basic Information</h2>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm">Name</div>
+    <div class="col-sm">{{ form.name }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Description</div>
+    <div class="col-sm">{{ form.description }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Parent Location</div>
+    <div class="col-sm">{{ form.parent }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Rank</div>
+    <div class="col-sm">{{ form.rank }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Size</div>
+    <div class="col-sm">{{ form.size }}</div>
+</div>
+<div class="row">
+    <div class="col-sm">Accessibility</div>
+    <div class="col-sm">{{ form.accessibility }}</div>
+</div>
+
+<div class="row mt-4">
+    <div class="col-sm">
+        <h2 class="mta_heading">Reality Zone</h2>
+    </div>
+</div>
+{{ form.reality_zone_formset.management_form }}
+{% for form_item in form.reality_zone_formset %}
+    <div class="row">
+        <div class="col-sm">{{ form_item.practice }}</div>
+        <div class="col-sm">{{ form_item.rating }}</div>
+    </div>
+{% endfor %}

--- a/locations/templates/locations/mage/demesne/list.html
+++ b/locations/templates/locations/mage/demesne/list.html
@@ -1,0 +1,30 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Demesnes
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title mta_heading">Demesnes</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <div class="row">
+                    {% for obj in object_list %}
+                        <div class="col-sm-6 col-md-4 mb-3">
+                            <div class="tg-card h-100">
+                                <div class="tg-card-body text-center" style="padding: 16px;">
+                                    <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                                </div>
+                            </div>
+                        </div>
+                    {% empty %}
+                        <div class="col-12 text-center">
+                            <p class="text-muted">No demesnes found.</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/urls/mage/create.py
+++ b/locations/urls/mage/create.py
@@ -29,6 +29,11 @@ urls = [
         name="sanctum",
     ),
     path(
+        "demesne/",
+        views.mage.DemesneCreateView.as_view(),
+        name="demesne",
+    ),
+    path(
         "library/",
         views.mage.LibraryCreateView.as_view(),
         name="library",

--- a/locations/urls/mage/detail.py
+++ b/locations/urls/mage/detail.py
@@ -18,6 +18,7 @@ urls = [
         name="paradox_realm",
     ),
     path("sanctum/<pk>/", views.mage.SanctumDetailView.as_view(), name="sanctum"),
+    path("demesne/<pk>/", views.mage.DemesneDetailView.as_view(), name="demesne"),
     path(
         "reality_zone/<pk>/",
         views.mage.RealityZoneDetailView.as_view(),

--- a/locations/urls/mage/index.py
+++ b/locations/urls/mage/index.py
@@ -13,6 +13,7 @@ urls = [
         name="paradox_realm",
     ),
     path("sanctum/", views.mage.SanctumListView.as_view(), name="sanctum"),
+    path("demesne/", views.mage.DemesneListView.as_view(), name="demesne"),
     path(
         "reality_zone/",
         views.mage.RealityZoneListView.as_view(),

--- a/locations/urls/mage/update.py
+++ b/locations/urls/mage/update.py
@@ -34,6 +34,11 @@ urls = [
         name="sanctum",
     ),
     path(
+        "demesne/<pk>/",
+        views.mage.DemesneUpdateView.as_view(),
+        name="demesne",
+    ),
+    path(
         "chantry/<pk>/",
         views.mage.ChantryUpdateView.as_view(),
         name="chantry",

--- a/locations/views/mage/__init__.py
+++ b/locations/views/mage/__init__.py
@@ -6,6 +6,12 @@ from .chantry import (
     ChantryListView,
     ChantryUpdateView,
 )
+from .demesne import (
+    DemesneCreateView,
+    DemesneDetailView,
+    DemesneListView,
+    DemesneUpdateView,
+)
 from .library import (
     LibraryCreateView,
     LibraryDetailView,

--- a/locations/views/mage/demesne.py
+++ b/locations/views/mage/demesne.py
@@ -1,0 +1,47 @@
+from core.mixins import EditPermissionMixin, MessageMixin, ViewPermissionMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import DetailView, FormView, ListView, UpdateView
+from locations.forms.mage.demesne import DemesneForm
+from locations.models.mage.demesne import Demesne
+
+
+class DemesneDetailView(ViewPermissionMixin, DetailView):
+    model = Demesne
+    template_name = "locations/mage/demesne/detail.html"
+
+
+class DemesneListView(ListView):
+    model = Demesne
+    ordering = ["name"]
+    template_name = "locations/mage/demesne/list.html"
+
+
+class DemesneCreateView(LoginRequiredMixin, MessageMixin, FormView):
+    form_class = DemesneForm
+    template_name = "locations/mage/demesne/form.html"
+    success_message = "Demesne '{name}' created successfully!"
+    error_message = "Failed to create demesne. Please correct the errors below."
+
+    def form_valid(self, form):
+        self.object = form.save()
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
+
+class DemesneUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
+    model = Demesne
+    fields = ["name", "description", "parent", "size", "accessibility"]
+    template_name = "locations/mage/demesne/form.html"
+    success_message = "Demesne '{name}' updated successfully!"
+    error_message = "Failed to update demesne. Please correct the errors below."
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
+        form.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description here"}
+        )
+        form.fields["parent"].empty_label = "Parent Location"
+        return form


### PR DESCRIPTION
Implemented two new types for the Mage gameline:

**Demesne (Location):**
- Personal spirit realm/pocket dimension location type
- Fields: rank, reality_zone, size, accessibility
- Includes reality zone integration for practice ratings
- Complete CRUD views and templates

**Periapt (Item):**
- Temporary/consumable charged magic item type
- Fields: arete, power, max_charges, current_charges, is_consumable
- Extends Wonder with charge tracking functionality
- Helper methods: use_charge(), recharge(), is_depleted()
- Complete CRUD views and templates

Both types include:
- Model definitions with proper validation constraints
- Forms with reality zone/resonance/effect formsets
- Full CRUD views (create, read, update, list)
- Styled templates following project conventions
- URL patterns integrated into mage routing
- Proper imports in __init__.py files