### PR TITLE
Consolidate XP tracking from JSONField to model-based system

### DIFF
--- a/XP_CONSOLIDATION_PLAN.md
+++ b/XP_CONSOLIDATION_PLAN.md
@@ -1,0 +1,222 @@
+# XP Tracking Consolidation Plan
+
+## Overview
+Consolidating dual XP tracking systems from JSONField to model-based XPSpendingRequest.
+
+## Current State Analysis
+
+### Files Using Old JSONField System
+
+1. **characters/models/core/character.py** (lines 294-374, 491-530)
+   - `spent_xp = models.JSONField(default=list)` (line 117)
+   - Methods to remove:
+     - `xp_spend_record()` (294-303)
+     - `waiting_for_xp_spend()` (305-309)
+     - `add_to_spend()` (320-330)
+     - `spend_xp()` (332-374) - UPDATE: This atomically handles XP deduction + record creation
+     - `approve_xp_spend()` (376-408) - UPDATE: This atomically approves and applies trait changes
+   - Compatibility methods to remove (491-530):
+     - `has_pending_xp_or_model_requests()`
+     - `total_spent_xp_combined()`
+
+2. **characters/views/mage/mage.py** (lines 430-763)
+   - MageDetailView uses old system for:
+     - Creating XP spend records (lines 430-512)
+     - Checking duplicate spends (line 513)
+     - Approving XP spends (lines 605-743)
+     - Rejecting XP spends (lines 744-762)
+
+3. **Templates** (5 files)
+   - `characters/templates/characters/mage/companion/companion_xp_form.html`
+   - `characters/templates/characters/mage/mage/mage_xp_form.html`
+   - `characters/templates/characters/mage/sorcerer/sorcerer_xp_form.html`
+   - `characters/templates/characters/werewolf/garou/detail.html`
+   - `characters/templates/characters/werewolf/garou/form.html`
+
+4. **accounts/models.py** (line 286)
+   - `Profile.objects_pending_approval()` uses `waiting_for_xp_spend()`
+
+5. **Other character models** (potentially)
+   - changeling, demon, vampire, werewolf, wraith models may have similar patterns
+
+### New Model-Based System (Already Implemented)
+
+**game/models.py** (lines 925-975):
+- `XPSpendingRequest` model with fields:
+  - character, trait_name, trait_type, trait_value, cost
+  - approved (Pending/Approved/Denied)
+  - created_at, approved_at, approved_by
+
+**character.py** (lines 412-489):
+- `create_xp_spending_request()` - CREATE new XP spend request
+- `get_pending_xp_requests()` - GET pending requests
+- `get_xp_spending_history()` - GET all requests
+- `approve_xp_request()` - APPROVE request (sets status only)
+- `deny_xp_request()` - DENY request (sets status only)
+
+**Migration Command** (already exists):
+- `game/management/commands/migrate_jsonfield_to_models.py`
+- Converts JSONField data to XPSpendingRequest records
+
+## Implementation Plan
+
+### Phase 1: Update Character Model Methods
+
+**CRITICAL INSIGHT**: The old `spend_xp()` and `approve_xp_spend()` methods do TWO things:
+1. Track the request (in JSONField) - TO BE REPLACED
+2. Deduct XP / Apply trait changes - MUST BE PRESERVED
+
+**Action**: Refactor to use new XPSpendingRequest model for tracking while preserving atomic XP handling.
+
+1. **Update `spend_xp()` method** (lines 332-374):
+   - Replace JSONField append with `create_xp_spending_request()`
+   - Keep atomic XP deduction logic
+   - Return XPSpendingRequest instance instead of dict
+
+2. **Update `approve_xp_spend()` method** (lines 376-408):
+   - Change signature to accept XPSpendingRequest ID instead of index
+   - Use `approve_xp_request()` instead of JSONField manipulation
+   - Keep atomic trait application logic
+
+3. **Remove deprecated methods**:
+   - `xp_spend_record()` (294-303) - no longer needed
+   - `waiting_for_xp_spend()` (305-309) - replace with `get_pending_xp_requests().exists()`
+   - `add_to_spend()` (320-330) - replace with `create_xp_spending_request()`
+
+4. **Remove compatibility methods** (491-530):
+   - `has_pending_xp_or_model_requests()` → `get_pending_xp_requests().exists()`
+   - `total_spent_xp_combined()` → calculate from XPSpendingRequest only
+
+### Phase 2: Update Views
+
+**characters/views/mage/mage.py**:
+
+1. **Update XP spending logic** (lines 430-526):
+   - Replace `xp_spend_record()` calls with `create_xp_spending_request()`
+   - Replace `spend_xp()` calls with updated method
+   - Replace duplicate check `if d not in self.object.spent_xp` with query check
+
+2. **Update approval logic** (lines 605-743):
+   - Parse request ID instead of JSONField index
+   - Call `approve_xp_request(request_id, request.user)` to update status
+   - Keep all trait application logic (background creation, sphere increases, etc.)
+
+3. **Update rejection logic** (lines 744-762):
+   - Get XPSpendingRequest by ID
+   - Call `deny_xp_request(request_id, request.user)`
+   - Refund XP atomically
+   - Delete or mark as denied
+
+### Phase 3: Update Templates
+
+Update all templates to iterate over `object.get_xp_spending_history` instead of `object.spent_xp`:
+
+```html
+<!-- OLD -->
+{% for item in object.spent_xp %}
+    {{ item.trait }} - {{ item.cost }} XP - {{ item.approved }}
+    <input type="submit" name="{{ item.index }}_approve" value="Approve" />
+{% endfor %}
+
+<!-- NEW -->
+{% for request in object.get_xp_spending_history %}
+    {{ request.trait_name }} - {{ request.cost }} XP - {{ request.approved }}
+    <input type="submit" name="xp_request_{{ request.id }}_approve" value="Approve" />
+{% endfor %}
+```
+
+Files to update:
+- `characters/templates/characters/mage/companion/companion_xp_form.html`
+- `characters/templates/characters/mage/mage/mage_xp_form.html`
+- `characters/templates/characters/mage/sorcerer/sorcerer_xp_form.html`
+- `characters/templates/characters/werewolf/garou/detail.html`
+- `characters/templates/characters/werewolf/garou/form.html`
+
+### Phase 4: Update accounts/models.py
+
+Replace `waiting_for_xp_spend()` call:
+
+```python
+# OLD (line 286)
+return [x for x in chars if x.waiting_for_xp_spend()]
+
+# NEW
+return Character.objects.filter(
+    xp_spendings__approved='Pending'
+).distinct()
+```
+
+### Phase 5: Remove spent_xp Field
+
+1. **Remove field** from `characters/models/core/character.py` (line 117):
+   ```python
+   # DELETE THIS LINE
+   spent_xp = models.JSONField(default=list)
+   ```
+
+2. **Create Django migration**:
+   ```bash
+   python manage.py makemigrations characters --name remove_spent_xp_field
+   ```
+
+   The migration should:
+   - Remove `spent_xp` field from Character model
+   - Include a data migration check to ensure all data is migrated
+
+### Phase 6: Testing
+
+1. Run existing transaction tests:
+   - `characters/tests/core/test_transaction_integration.py`
+   - Update tests to verify XPSpendingRequest creation instead of JSONField
+
+2. Run XP/freebie migration tests:
+   - `game/tests_xp_freebie_migration.py`
+
+3. Manual testing:
+   - Create character
+   - Spend XP on various traits
+   - Approve/deny as ST
+   - Verify XP balance accuracy
+
+## Migration Strategy
+
+1. **Pre-deployment**: Run `python manage.py migrate_jsonfield_to_models` to convert existing data
+2. **Deploy code** with new model-based system
+3. **Verify** all old JSONField data is in XPSpendingRequest table
+4. **Remove field** via migration after verification period
+
+## Files to Modify
+
+### Python Files
+1. `characters/models/core/character.py` - Update methods, remove field
+2. `characters/views/mage/mage.py` - Update XP spending/approval logic
+3. `accounts/models.py` - Update pending approval query
+4. Other character model files (changeling, demon, vampire, werewolf, wraith) - Check for similar patterns
+
+### Template Files
+1. `characters/templates/characters/mage/companion/companion_xp_form.html`
+2. `characters/templates/characters/mage/mage/mage_xp_form.html`
+3. `characters/templates/characters/mage/sorcerer/sorcerer_xp_form.html`
+4. `characters/templates/characters/werewolf/garou/detail.html`
+5. `characters/templates/characters/werewolf/garou/form.html`
+
+### Migration Files
+1. New migration to remove `spent_xp` field
+
+## Rollback Plan
+
+If issues arise:
+1. Revert code deployment
+2. JSONField data remains intact (not deleted, just not updated)
+3. Re-run `migrate_jsonfield_to_models` to sync any new records
+4. Investigate and fix issues
+5. Redeploy
+
+## Success Criteria
+
+- [ ] All XP spending creates XPSpendingRequest records
+- [ ] No code references `spent_xp` JSONField
+- [ ] All ST approvals update XPSpendingRequest status
+- [ ] XP balances remain accurate
+- [ ] All existing tests pass
+- [ ] Migration successfully removes `spent_xp` field

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -306,11 +306,12 @@ class Profile(models.Model):
     def xp_spend_requests(self):
         """Get all characters waiting for XP spend approval.
 
-        Returns a list of characters that have pending XP spending requests
+        Returns a queryset of characters that have pending XP spending requests
         awaiting storyteller approval.
+
+        UPDATED: Optimized to use a single database query instead of N+1 queries.
         """
-        chars = Character.objects.all()
-        return [x for x in chars if x.waiting_for_xp_spend()]
+        return Character.objects.filter(xp_spendings__approved="Pending").distinct()
 
     def unread_scenes(self):
         return Scene.objects.filter(

--- a/characters/templates/characters/mage/companion/companion_xp_form.html
+++ b/characters/templates/characters/mage/companion/companion_xp_form.html
@@ -5,9 +5,10 @@
     <div class="col-sm">XP Remaining</div>
     <div class="col-sm">{{ object.xp }}</div>
 </div>
-{% for item in object.spent_xp %}
+{% for request in object.get_xp_spending_history %}
     <div class="row">
-        <div class="col-sm">{{ item.trait }} {{ item.value }}</div>
-        <div class="col-sm">{{ item.cost }} freebies</div>
+        <div class="col-sm">{{ request.trait_name }} {% if request.trait_value %}({{ request.trait_value }}){% endif %}</div>
+        <div class="col-sm">{{ request.cost }} XP</div>
+        <div class="col-sm">{{ request.approved }}</div>
     </div>
 {% endfor %}

--- a/characters/templates/characters/mage/mage/mage_xp_form.html
+++ b/characters/templates/characters/mage/mage/mage_xp_form.html
@@ -133,19 +133,19 @@
     </div>
     <form action="" enctype="multipart/form-data" method="post">
         {% csrf_token %}
-        {% for item in object.spent_xp %}
+        {% for request in object.get_xp_spending_history %}
             <div class="row">
                 <div class="col-sm">
-                    {{ item.trait }}
-                    {% if item.value %}{{ item.value }}{% endif %}
+                    {{ request.trait_name }}
+                    {% if request.trait_value %}({{ request.trait_value }}){% endif %}
                 </div>
-                <div class="col-sm">{{ item.cost }} XP</div>
-                <div class="col-sm">{{ item.approved }}</div>
-                {% if request.user.profile.is_st %}
-                    {% if item.approved != "Approved" %}
+                <div class="col-sm">{{ request.cost }} XP</div>
+                <div class="col-sm">{{ request.approved }}</div>
+                {% if user.profile.is_st %}
+                    {% if request.approved != "Approved" %}
                         <div class="col-sm">
-                            <input type="submit" name="{{ item.index }}_approve" value="Approve" />
-                            <input type="submit" name="{{ item.index }}_approve" value="Reject" />
+                            <input type="submit" name="xp_request_{{ request.id }}_approve" value="Approve" />
+                            <input type="submit" name="xp_request_{{ request.id }}_reject" value="Reject" />
                         </div>
                     {% else %}
                         <div class="col-sm"></div>

--- a/characters/templates/characters/mage/sorcerer/sorcerer_xp_form.html
+++ b/characters/templates/characters/mage/sorcerer/sorcerer_xp_form.html
@@ -5,9 +5,10 @@
     <div class="col-sm">XP Remaining</div>
     <div class="col-sm">{{ object.xp }}</div>
 </div>
-{% for item in object.spent_xp %}
+{% for request in object.get_xp_spending_history %}
     <div class="row">
-        <div class="col-sm">{{ item.trait }} {{ item.value }}</div>
-        <div class="col-sm">{{ item.cost }} freebies</div>
+        <div class="col-sm">{{ request.trait_name }} {% if request.trait_value %}({{ request.trait_value }}){% endif %}</div>
+        <div class="col-sm">{{ request.cost }} XP</div>
+        <div class="col-sm">{{ request.approved }}</div>
     </div>
 {% endfor %}

--- a/characters/templates/characters/werewolf/garou/detail.html
+++ b/characters/templates/characters/werewolf/garou/detail.html
@@ -257,7 +257,7 @@
                         <div class="col-sm-3">
                             <strong>Spent XP:</strong>
                         </div>
-                        <div class="col-sm-3">{{ object.total_spent_xp_combined }}</div>
+                        <div class="col-sm-3">{{ object.total_spent_xp }}</div>
                     </div>
                 </div>
             </div>

--- a/characters/templates/characters/werewolf/garou/form.html
+++ b/characters/templates/characters/werewolf/garou/form.html
@@ -188,7 +188,7 @@
         <div class="col-sm">Experience Points</div>
         <div class="col-sm">{{ form.xp }}</div>
         <div class="col-sm">Spent XP</div>
-        <div class="col-sm">{{ form.spent_xp }}</div>
+        <div class="col-sm">{{ object.total_spent_xp }}</div>
     </div>
     <div class="row">
         <h2 class="col-sm {{ form.get_heading }}">Renown Incidents</h2>


### PR DESCRIPTION
This commit completes the consolidation of the dual XP tracking systems
by migrating from the JSONField-based spent_xp to the model-based
XPSpendingRequest system.

## Changes Made

### 1. Character Model (characters/models/core/character.py)
- Updated `waiting_for_xp_spend()` to query XPSpendingRequest model
- Updated `spend_xp()` to create XPSpendingRequest instead of JSONField
- Updated `approve_xp_spend()` to accept request_id and use model
- Removed `xp_spend_record()` method (no longer needed)
- Removed `add_to_spend()` method (replaced by spend_xp)
- Removed compatibility methods:
  - `has_pending_xp_or_model_requests()` → use `waiting_for_xp_spend()`
  - `total_spent_xp_combined()` → use `total_spent_xp()`
- Added `total_spent_xp()` to calculate from XPSpendingRequest only
- Removed `spent_xp` JSONField (commented out for migration safety)

### 2. Accounts Model (accounts/models.py)
- Optimized `xp_spend_requests()` to use single database query
- Changed from N+1 queries to efficient .filter() with distinct()

### 3. Templates
Updated all XP display templates to use `get_xp_spending_history`:
- characters/mage/mage/mage_xp_form.html
- characters/mage/companion/companion_xp_form.html
- characters/mage/sorcerer/sorcerer_xp_form.html
- characters/werewolf/garou/detail.html
- characters/werewolf/garou/form.html

Changed button naming from `{{ item.index }}_approve` to
`xp_request_{{ request.id }}_approve` for model-based lookup.

### 4. Views (characters/views/mage/mage.py)
**XP Spending (lines 392-581):**
- Removed all `xp_spend_record()` calls
- Updated all categories to use `spend_xp()` directly
- Added success messages for each category
- Removed duplicate check code (`if d not in self.object.spent_xp`)

**XP Approval (lines 605-756):**
- Parse new format `xp_request_<id>_approve` instead of old index
- Fetch XPSpendingRequest by ID
- Update request status AND apply trait changes atomically
- Added comprehensive error handling

**XP Rejection (lines 757-786):**
- Parse new format `xp_request_<id>_reject`
- Refund XP and mark request as Denied
- Atomic transaction for safety

### 5. Documentation
- Added XP_CONSOLIDATION_PLAN.md with comprehensive migration guide

## Migration Path

**IMPORTANT**: Before deploying, run:
```bash
python manage.py migrate_jsonfield_to_models
```

This will convert all existing JSONField data to XPSpendingRequest records.

After verifying data migration succeeded, generate and apply migration:
```bash
python manage.py makemigrations characters --name remove_spent_xp_field
python manage.py migrate characters
```

## Benefits
- Single source of truth for XP spending
- Efficient database queries (no JSONField parsing)
- Better data integrity with foreign keys
- Easier to audit and report on XP spending
- Supports concurrent access with proper locking

## Addresses
Resolves TODO.md item #3: "Dual XP Tracking Systems"