### PR TITLE
Refactor SpecialUserMixin to use canonical is_st() method

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -11,7 +11,6 @@ from core.permissions import Permission, PermissionManager, VisibilityTier
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from game.models import STRelationship
 
 
 class PermissionRequiredMixin:
@@ -247,7 +246,7 @@ class SpecialUserMixin:
             return True
         if not user.is_authenticated:
             return False
-        if STRelationship.objects.filter(user=user).count() > 0:
+        if user.profile.is_st():
             return True
         return False
 


### PR DESCRIPTION
## Summary
- Refactors SpecialUserMixin to use the canonical `is_st()` method from the Profile model
- Simplifies the check logic by delegating to the single source of truth

## Test plan
- [ ] Verify all views using SpecialUserMixin still work correctly
- [ ] Test ST access controls are properly enforced
- [ ] Confirm no regression in user permission checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)