### PR TITLE
Centralize hardcoded choices in settings

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,6 +1,7 @@
 from characters.models.core.character import Character
 from characters.models.mage.mage import Mage
 from characters.models.mage.rote import Rote
+from core.constants import HeadingChoices, ThemeChoices
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -33,37 +34,15 @@ class Profile(models.Model):
 
     preferred_heading = models.CharField(
         max_length=30,
-        choices=zip(
-            [
-                "wod_heading",
-                "vtm_heading",
-                "wta_heading",
-                "mta_heading",
-                "ctd_heading",
-                "wto_heading",
-            ],
-            [
-                "World of Darkness",
-                "Vampire: the Masquerade",
-                "Werewolf: the Apocalypse",
-                "Mage: the Ascension",
-                "Changeling: the Dreaming",
-                "Wraith: the Oblivion",
-            ],
-        ),
-        default="wod_heading",
+        choices=HeadingChoices.CHOICES,
+        default=HeadingChoices.WOD,
         help_text="Choose the game system font style for headings",
     )
 
-    theme_list = ["light", "dark"]
-
     theme = models.CharField(
         max_length=100,
-        choices=zip(
-            theme_list,
-            [x.replace("_", " ").title() for x in theme_list],
-        ),
-        default="light",
+        choices=ThemeChoices.CHOICES,
+        default=ThemeChoices.LIGHT,
         help_text="Choose a color scheme",
     )
 

--- a/core/constants.py
+++ b/core/constants.py
@@ -62,15 +62,17 @@ class HeadingChoices:
     MTA = "mta_heading"
     CTD = "ctd_heading"
     WTO = "wto_heading"
+    DTF = "dtf_heading"
     WOD = "wod_heading"
 
     CHOICES = [
-        (WOD, "World of Darkness"),
         (VTM, "Vampire: the Masquerade"),
         (WTA, "Werewolf: the Apocalypse"),
         (MTA, "Mage: the Ascension"),
         (CTD, "Changeling: the Dreaming"),
         (WTO, "Wraith: the Oblivion"),
+        (DTF, "Demon: the Fallen"),
+        (WOD, "World of Darkness"),
     ]
 
 
@@ -155,3 +157,16 @@ class AbilityFields:
 
     # Combined list of all primary abilities (talents + skills + knowledges)
     PRIMARY_ABILITIES = TALENTS + SKILLS + KNOWLEDGES
+
+class XPApprovalStatus:
+    """XP spending approval status choices."""
+
+    PENDING = "Pending"
+    APPROVED = "Approved"
+    DENIED = "Denied"
+
+    CHOICES = [
+        (PENDING, "Pending"),
+        (APPROVED, "Approved"),
+        (DENIED, "Denied"),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -1,3 +1,4 @@
+from core.constants import CharacterStatus, GameLine, ImageStatus
 from core.utils import filepath
 from django.apps import apps
 from django.conf import settings
@@ -315,16 +316,11 @@ class Model(PermissionMixin, PolymorphicModel):
 
     objects = ModelManager()
 
-    status_keys = ["Un", "Sub", "App", "Ret", "Dec"]
-    statuses = [
-        "Unfinished",
-        "Submitted",
-        "Approved",
-        "Retired",
-        "Deceased",
-    ]
     status = models.CharField(
-        max_length=3, choices=zip(status_keys, statuses), default="Un", db_index=True
+        max_length=3,
+        choices=CharacterStatus.CHOICES,
+        default=CharacterStatus.UNAPPROVED,
+        db_index=True,
     )
     display = models.BooleanField(default=True)
     sources = models.ManyToManyField(BookReference, blank=True)
@@ -333,8 +329,8 @@ class Model(PermissionMixin, PolymorphicModel):
     image = models.ImageField(upload_to=filepath, blank=True, null=True)
     image_status = models.CharField(
         max_length=3,
-        choices=zip(["sub", "app"], ["Submitted", "Approved"]),
-        default="sub",
+        choices=ImageStatus.CHOICES,
+        default=ImageStatus.SUBMITTED,
     )
     freebies_approved = models.BooleanField(default=False)
 
@@ -619,16 +615,8 @@ class CharacterTemplate(Model):
     # Template-specific fields
     gameline = models.CharField(
         max_length=3,
-        choices=[
-            ("wod", "World of Darkness"),
-            ("vtm", "Vampire: the Masquerade"),
-            ("wta", "Werewolf: the Apocalypse"),
-            ("mta", "Mage: the Ascension"),
-            ("wto", "Wraith: the Oblivion"),
-            ("ctd", "Changeling: the Dreaming"),
-            ("dtf", "Demon: the Fallen"),
-        ],
-        default="wod",
+        choices=GameLine.CHOICES,
+        default=GameLine.WOD,
     )
     character_type = models.CharField(
         max_length=50,

--- a/game/models.py
+++ b/game/models.py
@@ -1,6 +1,12 @@
 import re
 from datetime import datetime, timedelta
 
+from core.constants import (
+    GameLine,
+    HeadingChoices,
+    ObjectTypeChoices,
+    XPApprovalStatus,
+)
 from core.utils import dice
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -17,24 +23,12 @@ class ObjectType(models.Model):
     type = models.CharField(
         default="",
         max_length=100,
-        choices=[
-            ("char", "Character"),
-            ("loc", "Location"),
-            ("obj", "Item"),
-        ],
+        choices=ObjectTypeChoices.CHOICES,
     )
     gameline = models.CharField(
         default="",
         max_length=100,
-        choices=[
-            ("wod", "World of Darkness"),
-            ("vtm", "Vampire: the Masquerade"),
-            ("wta", "Werewolf: the Apocalypse"),
-            ("mta", "Mage: the Ascension"),
-            ("wto", "Wraith: the Oblivion"),
-            ("ctd", "Changeling: the Dreaming"),
-            ("dtf", "Demon: the Fallen"),
-        ],
+        choices=GameLine.CHOICES,
     )
 
     class Meta:
@@ -161,15 +155,7 @@ class Chronicle(models.Model):
     headings = models.CharField(
         default="",
         max_length=100,
-        choices=[
-            ("vtm_heading", "Vampire: the Masquerade"),
-            ("wta_heading", "Werewolf: the Apocalypse"),
-            ("mta_heading", "Mage: the Ascension"),
-            ("ctd_heading", "Changeling: the Dreaming"),
-            ("wto_heading", "Wraith: the Oblivion"),
-            ("dtf_heading", "Demon: the Fallen"),
-            ("wod_heading", "World of Darkness"),
-        ],
+        choices=HeadingChoices.CHOICES,
     )
 
     allowed_objects = models.ManyToManyField(ObjectType, blank=True)
@@ -1140,12 +1126,8 @@ class XPSpendingRequest(models.Model):
     cost = models.IntegerField(help_text="XP cost")
     approved = models.CharField(
         max_length=20,
-        choices=[
-            ("Pending", "Pending"),
-            ("Approved", "Approved"),
-            ("Denied", "Denied"),
-        ],
-        default="Pending",
+        choices=XPApprovalStatus.CHOICES,
+        default=XPApprovalStatus.PENDING,
     )
     created_at = models.DateTimeField(auto_now_add=True)
     approved_at = models.DateTimeField(null=True, blank=True)


### PR DESCRIPTION
## Summary
- Moves hardcoded choice tuples to centralized settings configuration
- Improves maintainability by having a single source of truth
- Makes it easier to modify choices across the application

## Test plan
- [ ] Verify all forms still display correct choices
- [ ] Test that validation still works properly
- [ ] Check that no hardcoded choices remain scattered in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)