### PR TITLE
Add list views for Pack, Cabal, and Motley groups

### DIFF
--- a/characters/templates/characters/changeling/motley/list.html
+++ b/characters/templates/characters/changeling/motley/list.html
@@ -1,0 +1,44 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Motleys
+{% endblock title %}
+{% block content %}
+    <div class="container" style="max-width: 1200px; margin: 0 auto;">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="tg-card">
+                    <div class="tg-card-header text-center">
+                        <h3 class="tg-card-title ctd_heading">Motleys</h3>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% for obj in object_list %}
+            <div class="row mb-2">
+                <div class="col-12">
+                    <div class="tg-card">
+                        <div class="tg-card-body" style="padding: 16px;">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; font-size: 1.1rem;">{{ obj.name }}</a>
+                                <div class="d-flex gap-3">
+                                    {% if obj.leader %}
+                                        <span style="font-size: 0.9rem; color: var(--theme-text-secondary);">
+                                            Leader: {{ obj.leader.name }}
+                                        </span>
+                                    {% endif %}
+                                    <span class="tg-badge badge-pill badge-secondary">{{ obj.members.count }} member{{ obj.members.count|pluralize }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% empty %}
+            <div class="row">
+                <div class="col-12">
+                    <p class="text-center" style="color: var(--theme-text-secondary);">No motleys found.</p>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/characters/templates/characters/mage/cabal/list.html
+++ b/characters/templates/characters/mage/cabal/list.html
@@ -1,0 +1,47 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Cabals
+{% endblock title %}
+{% block content %}
+    <div class="container" style="max-width: 1200px; margin: 0 auto;">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="tg-card">
+                    <div class="tg-card-header text-center">
+                        <h3 class="tg-card-title mta_heading">Cabals</h3>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% for obj in object_list %}
+            <div class="row mb-2">
+                <div class="col-12">
+                    <div class="tg-card">
+                        <div class="tg-card-body" style="padding: 16px;">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; font-size: 1.1rem;">{{ obj.name }}</a>
+                                <div class="d-flex gap-3">
+                                    <span style="font-size: 0.9rem; color: var(--theme-text-secondary);">
+                                        {{ obj.get_display_type }}
+                                    </span>
+                                    {% if obj.leader %}
+                                        <span style="font-size: 0.9rem; color: var(--theme-text-secondary);">
+                                            Leader: {{ obj.leader.name }}
+                                        </span>
+                                    {% endif %}
+                                    <span class="tg-badge badge-pill badge-secondary">{{ obj.members.count }} member{{ obj.members.count|pluralize }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% empty %}
+            <div class="row">
+                <div class="col-12">
+                    <p class="text-center" style="color: var(--theme-text-secondary);">No cabals found.</p>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/characters/templates/characters/werewolf/pack/list.html
+++ b/characters/templates/characters/werewolf/pack/list.html
@@ -1,0 +1,49 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Packs
+{% endblock title %}
+{% block content %}
+    <div class="container" style="max-width: 1200px; margin: 0 auto;">
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="tg-card">
+                    <div class="tg-card-header text-center">
+                        <h3 class="tg-card-title wta_heading">Packs</h3>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% for obj in object_list %}
+            <div class="row mb-2">
+                <div class="col-12">
+                    <div class="tg-card">
+                        <div class="tg-card-body" style="padding: 16px;">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <a href="{{ obj.get_absolute_url }}" style="font-weight: 600; font-size: 1.1rem;">{{ obj.name }}</a>
+                                <div class="d-flex gap-3">
+                                    {% if obj.totem %}
+                                        <span style="font-size: 0.9rem; color: var(--theme-text-secondary);">
+                                            Totem: {{ obj.totem.name }}
+                                        </span>
+                                    {% endif %}
+                                    {% if obj.leader %}
+                                        <span style="font-size: 0.9rem; color: var(--theme-text-secondary);">
+                                            Leader: {{ obj.leader.name }}
+                                        </span>
+                                    {% endif %}
+                                    <span class="tg-badge badge-pill badge-secondary">{{ obj.members.count }} member{{ obj.members.count|pluralize }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% empty %}
+            <div class="row">
+                <div class="col-12">
+                    <p class="text-center" style="color: var(--theme-text-secondary);">No packs found.</p>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/characters/tests/changeling/motley.py
+++ b/characters/tests/changeling/motley.py
@@ -3,6 +3,7 @@ from characters.models.changeling.motley import Motley
 from characters.tests.utils import changeling_setup
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
 
 class TestMotley(TestCase):
@@ -86,3 +87,28 @@ class TestMotleyUpdateView(TestCase):
         self.motley.refresh_from_db()
         self.assertEqual(self.motley.name, "Motley Updated")
         self.assertEqual(self.motley.description, "Test")
+
+
+class TestMotleyListView(TestCase):
+    def setUp(self):
+        self.motley1 = Motley.objects.create(name="Motley Alpha")
+        self.motley2 = Motley.objects.create(name="Motley Beta")
+        self.url = reverse("characters:changeling:list:motley")
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/changeling/motley/list.html")
+
+    def test_list_view_contains_motleys(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Motley Alpha")
+        self.assertContains(response, "Motley Beta")
+
+    def test_list_view_ordering(self):
+        response = self.client.get(self.url)
+        motleys = response.context["object_list"]
+        self.assertEqual(list(motleys), [self.motley1, self.motley2])

--- a/characters/tests/mage/cabal.py
+++ b/characters/tests/mage/cabal.py
@@ -3,6 +3,7 @@ from characters.models.mage.mage import Mage
 from characters.tests.utils import mage_setup
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
 
 class TestCabal(TestCase):
@@ -89,3 +90,28 @@ class TestCabalUpdateView(TestCase):
         self.cabal.refresh_from_db()
         self.assertEqual(self.cabal.name, "Test Cabal Updated")
         self.assertEqual(self.cabal.description, "Test")
+
+
+class TestCabalListView(TestCase):
+    def setUp(self):
+        self.cabal1 = Cabal.objects.create(name="Cabal Alpha")
+        self.cabal2 = Cabal.objects.create(name="Cabal Beta")
+        self.url = reverse("characters:mage:list:cabal")
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/cabal/list.html")
+
+    def test_list_view_contains_cabals(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Cabal Alpha")
+        self.assertContains(response, "Cabal Beta")
+
+    def test_list_view_ordering(self):
+        response = self.client.get(self.url)
+        cabals = response.context["object_list"]
+        self.assertEqual(list(cabals), [self.cabal1, self.cabal2])

--- a/characters/tests/werewolf/pack.py
+++ b/characters/tests/werewolf/pack.py
@@ -4,6 +4,7 @@ from characters.models.werewolf.totem import Totem
 from characters.tests.utils import werewolf_setup
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
 
 class TestPack(TestCase):
@@ -112,3 +113,28 @@ class TestPackUpdateView(TestCase):
         self.pack.refresh_from_db()
         self.assertEqual(self.pack.name, "Pack Updated")
         self.assertEqual(self.pack.description, "Test")
+
+
+class TestPackListView(TestCase):
+    def setUp(self):
+        self.pack1 = Pack.objects.create(name="Pack Alpha")
+        self.pack2 = Pack.objects.create(name="Pack Beta")
+        self.url = reverse("characters:werewolf:list:pack")
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/werewolf/pack/list.html")
+
+    def test_list_view_contains_packs(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Pack Alpha")
+        self.assertContains(response, "Pack Beta")
+
+    def test_list_view_ordering(self):
+        response = self.client.get(self.url)
+        packs = response.context["object_list"]
+        self.assertEqual(list(packs), [self.pack1, self.pack2])

--- a/characters/urls/changeling/index.py
+++ b/characters/urls/changeling/index.py
@@ -2,6 +2,7 @@ from characters.views.changeling.house import HouseListView
 from characters.views.changeling.house_faction import HouseFactionListView
 from characters.views.changeling.kith import KithListView
 from characters.views.changeling.legacy import LegacyListView
+from characters.views.changeling.motley import MotleyListView
 from django.urls import path
 
 urls = [
@@ -24,5 +25,10 @@ urls = [
         "legacy/",
         LegacyListView.as_view(),
         name="legacy",
+    ),
+    path(
+        "motley/",
+        MotleyListView.as_view(),
+        name="motley",
     ),
 ]

--- a/characters/urls/mage/index.py
+++ b/characters/urls/mage/index.py
@@ -44,4 +44,5 @@ urls = [
         name="sorcerer_fellowship",
     ),
     path("rotes/", views.mage.RoteListView.as_view(), name="rote"),
+    path("cabal/", views.mage.CabalListView.as_view(), name="cabal"),
 ]

--- a/characters/urls/werewolf/index.py
+++ b/characters/urls/werewolf/index.py
@@ -35,4 +35,5 @@ urls = [
         views.werewolf.FomoriPowerListView.as_view(),
         name="fomoripower",
     ),
+    path("pack/", views.werewolf.PackListView.as_view(), name="pack"),
 ]

--- a/characters/views/changeling/__init__.py
+++ b/characters/views/changeling/__init__.py
@@ -24,4 +24,4 @@ from .house_faction import HouseFactionListView as ChangelingFactionListView
 from .house_faction import HouseFactionUpdateView as ChangelingFactionUpdateView
 from .kith import KithCreateView, KithDetailView, KithListView, KithUpdateView
 from .legacy import LegacyCreateView, LegacyDetailView, LegacyListView, LegacyUpdateView
-from .motley import MotleyCreateView, MotleyDetailView, MotleyUpdateView
+from .motley import MotleyCreateView, MotleyDetailView, MotleyListView, MotleyUpdateView

--- a/characters/views/changeling/motley.py
+++ b/characters/views/changeling/motley.py
@@ -1,6 +1,6 @@
 from characters.models.changeling.motley import Motley
 from core.mixins import MessageMixin
-from django.views.generic import CreateView, DetailView, UpdateView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 
 class MotleyDetailView(DetailView):
@@ -22,3 +22,9 @@ class MotleyUpdateView(MessageMixin, UpdateView):
     template_name = "characters/changeling/motley/form.html"
     success_message = "Motley updated successfully."
     error_message = "There was an error updating the Motley."
+
+
+class MotleyListView(ListView):
+    model = Motley
+    ordering = ["name"]
+    template_name = "characters/changeling/motley/list.html"

--- a/characters/views/mage/__init__.py
+++ b/characters/views/mage/__init__.py
@@ -1,5 +1,5 @@
 from .advantage import AdvantageDetailView
-from .cabal import CabalCreateView, CabalDetailView, CabalUpdateView
+from .cabal import CabalCreateView, CabalDetailView, CabalListView, CabalUpdateView
 from .companion import (
     CompanionBasicsView,
     CompanionCreateView,

--- a/characters/views/mage/cabal.py
+++ b/characters/views/mage/cabal.py
@@ -3,7 +3,7 @@ from characters.models.core.human import Human
 from characters.models.mage.cabal import Cabal
 from core.mixins import MessageMixin
 from django import forms
-from django.views.generic import CreateView, DetailView, UpdateView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 
 class CabalDetailView(DetailView):
@@ -65,3 +65,9 @@ class CabalUpdateView(MessageMixin, UpdateView):
         kwargs = super().get_form_kwargs()
         kwargs["user"] = self.request.user
         return kwargs
+
+
+class CabalListView(ListView):
+    model = Cabal
+    ordering = ["name"]
+    template_name = "characters/mage/cabal/list.html"

--- a/characters/views/werewolf/__init__.py
+++ b/characters/views/werewolf/__init__.py
@@ -60,7 +60,7 @@ from .kinfolk import (
     KinfolkDetailView,
     KinfolkUpdateView,
 )
-from .pack import PackCreateView, PackDetailView, PackUpdateView
+from .pack import PackCreateView, PackDetailView, PackListView, PackUpdateView
 from .renownincident import (
     RenownIncidentCreateView,
     RenownIncidentDetailView,

--- a/characters/views/werewolf/pack.py
+++ b/characters/views/werewolf/pack.py
@@ -1,6 +1,6 @@
 from characters.models.werewolf.pack import Pack
 from core.mixins import MessageMixin
-from django.views.generic import CreateView, DetailView, UpdateView
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 
 class PackDetailView(DetailView):
@@ -22,3 +22,9 @@ class PackUpdateView(MessageMixin, UpdateView):
     template_name = "characters/werewolf/pack/form.html"
     success_message = "Pack updated successfully."
     error_message = "There was an error updating the Pack."
+
+
+class PackListView(ListView):
+    model = Pack
+    ordering = ["name"]
+    template_name = "characters/werewolf/pack/list.html"


### PR DESCRIPTION
## Summary
- Adds `PackListView` for Werewolf packs at `/characters/werewolf/list/pack/`
- Adds `CabalListView` for Mage cabals at `/characters/mage/list/cabal/`
- Adds `MotleyListView` for Changeling motleys at `/characters/changeling/list/motley/`

Each list view follows the existing Coterie list view pattern with gameline-specific styling and displays:
- Group name (linked to detail view)
- Leader name (if set)
- Member count
- Pack-specific: Totem name
- Cabal-specific: Type display (Cabal vs Amalgam based on leader affiliation)

## Test plan
- [x] All 12 new list view tests pass
- [x] Existing create/update view tests for all three groups still pass
- [x] Coterie list view tests still pass (reference implementation)

Fixes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)