### PR TITLE
Fix image_status validation to use ImageStatus.CHOICES

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -470,6 +470,11 @@ class Model(PermissionMixin, PolymorphicModel):
         """Return valid status keys from CharacterStatus."""
         return [key for key, _ in CharacterStatus.CHOICES]
 
+    @property
+    def image_status_keys(self):
+        """Return valid image status keys from ImageStatus."""
+        return [key for key, _ in ImageStatus.CHOICES]
+
     def clean(self):
         """Validate model data before saving."""
         super().clean()
@@ -486,10 +491,9 @@ class Model(PermissionMixin, PolymorphicModel):
             )
 
         # Validate image_status is in valid choices
-        valid_image_statuses = ["sub", "app"]
-        if self.image_status not in valid_image_statuses:
+        if self.image_status not in self.image_status_keys:
             errors["image_status"] = (
-                f"Invalid image status '{self.image_status}'. Must be one of: {', '.join(valid_image_statuses)}"
+                f"Invalid image status '{self.image_status}'. Must be one of: {', '.join(self.image_status_keys)}"
             )
 
         if errors:


### PR DESCRIPTION
## Summary
- Fixed `Model.clean()` validation that was incorrectly rejecting the valid `"un"` (unapproved) image_status value
- Added `image_status_keys` property to derive valid values from `ImageStatus.CHOICES` (parallel to existing `status_keys`)
- Updated validation to use the new property instead of hardcoded list `["sub", "app"]`

## Root Cause
The original validation in `core/models.py` used a hardcoded list that was missing `"un"`:
```python
valid_image_statuses = ["sub", "app"]  # Missing "un"!
```

This caused `ValidationError` when saving any model with `image_status="un"` (the unapproved status).

## Test plan
- [x] Added tests verifying `status_keys` and `image_status_keys` properties return correct values
- [x] Added tests verifying `clean()` accepts all valid status and image_status values
- [x] Added tests verifying `clean()` rejects invalid values
- [x] All 20 TestModel tests pass

Fixes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)