### PR TITLE
Fix N+1 query problems in list views

### DIFF
--- a/characters/tests/views/changeling/test_motley.py
+++ b/characters/tests/views/changeling/test_motley.py
@@ -1,5 +1,56 @@
 """Tests for motley module."""
 
-from django.test import TestCase
+from characters.models.changeling.motley import Motley
+from characters.models.core.human import Human
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMotleyListViewQueryOptimization(TestCase):
+    """Test that MotleyListView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+        for i in range(3):
+            leader = Human.objects.create(
+                name=f"Motley Leader {i}",
+                owner=self.user,
+                chronicle=self.chronicle,
+            )
+            motley = Motley.objects.create(
+                name=f"Motley {i}",
+                chronicle=self.chronicle,
+                leader=leader,
+            )
+            for j in range(2):
+                member = Human.objects.create(
+                    name=f"Motley Member {i}-{j}",
+                    owner=self.user,
+                    chronicle=self.chronicle,
+                )
+                motley.members.add(member)
+
+    def test_list_view_query_count_is_bounded(self):
+        """Test that list view query count doesn't scale with number of motleys."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get("/characters/changeling/list/motley/")
+
+        self.assertEqual(response.status_code, 200)
+        query_count = len(context.captured_queries)
+        # Base overhead includes session, user/profile, polymorphic lookups, etc.
+        # The optimization ensures queries don't scale with number of motleys
+        self.assertLessEqual(
+            query_count,
+            20,
+            f"Too many queries ({query_count}). List view may have N+1 issue.",
+        )

--- a/characters/tests/views/mage/test_cabal.py
+++ b/characters/tests/views/mage/test_cabal.py
@@ -1,5 +1,56 @@
 """Tests for cabal module."""
 
-from django.test import TestCase
+from characters.models.core.human import Human
+from characters.models.mage.cabal import Cabal
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestCabalListViewQueryOptimization(TestCase):
+    """Test that CabalListView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+        for i in range(3):
+            leader = Human.objects.create(
+                name=f"Cabal Leader {i}",
+                owner=self.user,
+                chronicle=self.chronicle,
+            )
+            cabal = Cabal.objects.create(
+                name=f"Cabal {i}",
+                chronicle=self.chronicle,
+                leader=leader,
+            )
+            for j in range(2):
+                member = Human.objects.create(
+                    name=f"Cabal Member {i}-{j}",
+                    owner=self.user,
+                    chronicle=self.chronicle,
+                )
+                cabal.members.add(member)
+
+    def test_list_view_query_count_is_bounded(self):
+        """Test that list view query count doesn't scale with number of cabals."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get("/characters/mage/list/cabal/")
+
+        self.assertEqual(response.status_code, 200)
+        query_count = len(context.captured_queries)
+        # Base overhead includes session, user/profile, polymorphic lookups, etc.
+        # The optimization ensures queries don't scale with number of cabals
+        self.assertLessEqual(
+            query_count,
+            20,
+            f"Too many queries ({query_count}). List view may have N+1 issue.",
+        )

--- a/characters/tests/views/vampire/test_coterie.py
+++ b/characters/tests/views/vampire/test_coterie.py
@@ -1,5 +1,60 @@
 """Tests for coterie module."""
 
-from django.test import TestCase
+from characters.models.core.human import Human
+from characters.models.vampire.coterie import Coterie
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestCoterieListViewQueryOptimization(TestCase):
+    """Test that CoterieListView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+        # Create multiple coteries with leaders and members
+        for i in range(3):
+            leader = Human.objects.create(
+                name=f"Leader {i}",
+                owner=self.user,
+                chronicle=self.chronicle,
+            )
+            coterie = Coterie.objects.create(
+                name=f"Coterie {i}",
+                chronicle=self.chronicle,
+                leader=leader,
+            )
+            # Add some members
+            for j in range(2):
+                member = Human.objects.create(
+                    name=f"Member {i}-{j}",
+                    owner=self.user,
+                    chronicle=self.chronicle,
+                )
+                coterie.members.add(member)
+
+    def test_list_view_query_count_is_bounded(self):
+        """Test that list view query count doesn't scale with number of coteries."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get("/characters/vampire/list/coterie/")
+
+        self.assertEqual(response.status_code, 200)
+        # Should have a bounded number of queries (session, user, coteries with prefetches)
+        # Not one per coterie for leader/members
+        query_count = len(context.captured_queries)
+        # Base overhead includes session, user/profile, polymorphic lookups, etc.
+        # The optimization ensures queries don't scale with number of coteries
+        self.assertLessEqual(
+            query_count,
+            20,
+            f"Too many queries ({query_count}). List view may have N+1 issue.",
+        )

--- a/characters/tests/views/vampire/test_revenant.py
+++ b/characters/tests/views/vampire/test_revenant.py
@@ -2,4 +2,5 @@
 
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+# RevenantListView has optimized queries but no URL is registered for it.
+# The optimization will be tested when a URL is added.

--- a/characters/tests/views/werewolf/test_pack.py
+++ b/characters/tests/views/werewolf/test_pack.py
@@ -1,5 +1,60 @@
 """Tests for pack module."""
 
-from django.test import TestCase
+from characters.models.core.human import Human
+from characters.models.werewolf.pack import Pack
+from characters.models.werewolf.totem import Totem
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestPackListViewQueryOptimization(TestCase):
+    """Test that PackListView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+        # Create totems and packs
+        for i in range(3):
+            totem = Totem.objects.create(name=f"Totem {i}")
+            leader = Human.objects.create(
+                name=f"Alpha {i}",
+                owner=self.user,
+                chronicle=self.chronicle,
+            )
+            pack = Pack.objects.create(
+                name=f"Pack {i}",
+                chronicle=self.chronicle,
+                leader=leader,
+                totem=totem,
+            )
+            for j in range(2):
+                member = Human.objects.create(
+                    name=f"Packmate {i}-{j}",
+                    owner=self.user,
+                    chronicle=self.chronicle,
+                )
+                pack.members.add(member)
+
+    def test_list_view_query_count_is_bounded(self):
+        """Test that list view query count doesn't scale with number of packs."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get("/characters/werewolf/list/pack/")
+
+        self.assertEqual(response.status_code, 200)
+        query_count = len(context.captured_queries)
+        # Base overhead includes session, user/profile, polymorphic lookups, etc.
+        # The optimization ensures queries don't scale with number of packs
+        self.assertLessEqual(
+            query_count,
+            20,
+            f"Too many queries ({query_count}). List view may have N+1 issue.",
+        )

--- a/characters/tests/views/wraith/test_circle.py
+++ b/characters/tests/views/wraith/test_circle.py
@@ -2,4 +2,5 @@
 
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+# CircleListView has optimized queries but no URL is registered for it.
+# The optimization will be tested when a URL is added.

--- a/characters/views/changeling/motley.py
+++ b/characters/views/changeling/motley.py
@@ -28,3 +28,6 @@ class MotleyListView(ListView):
     model = Motley
     ordering = ["name"]
     template_name = "characters/changeling/motley/list.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("leader").prefetch_related("members")

--- a/characters/views/core/character.py
+++ b/characters/views/core/character.py
@@ -91,7 +91,7 @@ class CharacterListView(VisibilityFilterMixin, ListView):
         """Get filtered queryset based on permissions."""
         qs = super().get_queryset()
         # Additional filtering can be added here (e.g., by status, chronicle, etc.)
-        return qs.order_by("name")
+        return qs.select_related("owner", "chronicle").order_by("name")
 
 
 class CharacterCreateView(LoginRequiredMixin, CreateView):

--- a/characters/views/mage/cabal.py
+++ b/characters/views/mage/cabal.py
@@ -71,3 +71,6 @@ class CabalListView(ListView):
     model = Cabal
     ordering = ["name"]
     template_name = "characters/mage/cabal/list.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("leader").prefetch_related("members")

--- a/characters/views/vampire/coterie.py
+++ b/characters/views/vampire/coterie.py
@@ -28,3 +28,6 @@ class CoterieListView(ListView):
     model = Coterie
     ordering = ["name"]
     template_name = "characters/vampire/coterie/list.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("leader").prefetch_related("members")

--- a/characters/views/vampire/revenant.py
+++ b/characters/views/vampire/revenant.py
@@ -73,3 +73,6 @@ class RevenantListView(ListView):
     model = Revenant
     ordering = ["name"]
     template_name = "characters/vampire/revenant/list.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("family")

--- a/characters/views/werewolf/pack.py
+++ b/characters/views/werewolf/pack.py
@@ -28,3 +28,6 @@ class PackListView(ListView):
     model = Pack
     ordering = ["name"]
     template_name = "characters/werewolf/pack/list.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("totem", "leader").prefetch_related("members")

--- a/characters/views/wraith/circle.py
+++ b/characters/views/wraith/circle.py
@@ -60,3 +60,6 @@ class CircleListView(ListView):
     model = Circle
     ordering = ["name"]
     template_name = "characters/wraith/circle/list.html"
+
+    def get_queryset(self):
+        return super().get_queryset().select_related("leader").prefetch_related("members")

--- a/game/templates/game/week/list.html
+++ b/game/templates/game/week/list.html
@@ -21,7 +21,7 @@
                                 <div class="tg-card-body text-center" style="padding: 16px;">
                                     <a href="{{ week.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">{{ week }}</a>
                                     <div style="font-size: 0.75rem; color: var(--theme-text-secondary); margin-top: 8px;">
-                                        {{ week.finished_scenes.count }} scenes
+                                        {{ week.cached_scene_count }} scene{{ week.cached_scene_count|pluralize }}
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- Add `select_related()` and `prefetch_related()` optimizations to 10 list views
- Optimize CharacterIndexView to fetch all characters in one query instead of N queries per chronicle
- Pre-compute finished scene counts in WeekListView to avoid N+1 template queries
- Add regression tests for query count optimization

Closes #1098

## Test plan
- [x] Run `python manage.py test` - all tests pass
- [x] Query count tests verify bounded number of queries
- [x] Manual verification that list views render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)