### PR TITLE
Fix N+1 query problems in detail views

### DIFF
--- a/items/tests/views/mage/test_artifact.py
+++ b/items/tests/views/mage/test_artifact.py
@@ -1,5 +1,51 @@
-"""Tests for artifact module."""
+"""Tests for artifact views."""
 
-from django.test import TestCase
+from characters.models.mage.resonance import Resonance
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from items.models.mage import WonderResonanceRating
+from items.models.mage.artifact import Artifact
 
-# TODO: Move relevant tests from existing test files here
+
+class TestArtifactDetailViewQueryOptimization(TestCase):
+    """Test that ArtifactDetailView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.artifact = Artifact.objects.create(name="Test Artifact", rank=3)
+        for i in range(5):
+            resonance = Resonance.objects.create(name=f"Resonance {i}")
+            WonderResonanceRating.objects.create(
+                wonder=self.artifact, resonance=resonance, rating=i + 1
+            )
+
+    def test_detail_view_query_count_is_bounded(self):
+        """Test that detail view query count doesn't scale with number of resonances."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get(f"/items/mage/artifact/{self.artifact.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        query_count = len(context.captured_queries)
+        # With select_related on resonance, queries should be bounded
+        # regardless of number of resonance ratings
+        self.assertLessEqual(
+            query_count,
+            15,
+            f"Too many queries ({query_count}). Detail view may have N+1 issue.",
+        )
+
+    def test_resonance_is_in_context(self):
+        """Test that resonance ratings are included in context."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(f"/items/mage/artifact/{self.artifact.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("resonance", response.context)
+        self.assertEqual(response.context["resonance"].count(), 5)

--- a/items/tests/views/mage/test_wonder.py
+++ b/items/tests/views/mage/test_wonder.py
@@ -1,5 +1,50 @@
-"""Tests for wonder module."""
+"""Tests for wonder views."""
 
-from django.test import TestCase
+from characters.models.mage.resonance import Resonance
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from items.models.mage import Wonder, WonderResonanceRating
 
-# TODO: Move relevant tests from existing test files here
+
+class TestWonderDetailViewQueryOptimization(TestCase):
+    """Test that WonderDetailView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.wonder = Wonder.objects.create(name="Test Wonder", rank=3)
+        for i in range(5):
+            resonance = Resonance.objects.create(name=f"Resonance {i}")
+            WonderResonanceRating.objects.create(
+                wonder=self.wonder, resonance=resonance, rating=i + 1
+            )
+
+    def test_detail_view_query_count_is_bounded(self):
+        """Test that detail view query count doesn't scale with number of resonances."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get(f"/items/mage/wonder/{self.wonder.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        query_count = len(context.captured_queries)
+        # With select_related on resonance, queries should be bounded
+        # regardless of number of resonance ratings
+        self.assertLessEqual(
+            query_count,
+            15,
+            f"Too many queries ({query_count}). Detail view may have N+1 issue.",
+        )
+
+    def test_resonance_is_in_context(self):
+        """Test that resonance ratings are included in context."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(f"/items/mage/wonder/{self.wonder.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("resonance", response.context)
+        self.assertEqual(response.context["resonance"].count(), 5)

--- a/items/views/mage/artifact.py
+++ b/items/views/mage/artifact.py
@@ -12,8 +12,10 @@ class ArtifactDetailView(DetailView):
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["resonance"] = WonderResonanceRating.objects.filter(wonder=self.object).order_by(
-            "resonance__name"
+        context["resonance"] = (
+            WonderResonanceRating.objects.filter(wonder=self.object)
+            .select_related("resonance")
+            .order_by("resonance__name")
         )
         return context
 

--- a/items/views/mage/wonder.py
+++ b/items/views/mage/wonder.py
@@ -12,8 +12,10 @@ class WonderDetailView(DetailView):
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["resonance"] = WonderResonanceRating.objects.filter(wonder=self.object).order_by(
-            "resonance__name"
+        context["resonance"] = (
+            WonderResonanceRating.objects.filter(wonder=self.object)
+            .select_related("resonance")
+            .order_by("resonance__name")
         )
         return context
 

--- a/locations/tests/views/mage/test_node.py
+++ b/locations/tests/views/mage/test_node.py
@@ -1,5 +1,70 @@
-"""Tests for node module."""
+"""Tests for node views."""
 
-from django.test import TestCase
+from characters.models.core import MeritFlaw
+from characters.models.mage.resonance import Resonance
+from django.contrib.auth.models import User
+from django.db import connection
+from django.test import Client, TestCase
+from django.test.utils import CaptureQueriesContext
+from game.models import ObjectType
+from locations.models.mage import Node, NodeMeritFlawRating, NodeResonanceRating
 
-# TODO: Move relevant tests from existing test files here
+
+class TestNodeDetailViewQueryOptimization(TestCase):
+    """Test that NodeDetailView uses optimized queries."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.node = Node.objects.create(name="Test Node", rank=3)
+
+        for i in range(5):
+            resonance = Resonance.objects.create(name=f"Resonance {i}")
+            NodeResonanceRating.objects.create(node=self.node, resonance=resonance, rating=i + 1)
+
+        node_type = ObjectType.objects.create(name="node", type="loc", gameline="mta")
+        for i in range(3):
+            mf = MeritFlaw.objects.create(
+                name=f"Merit {i}",
+                max_rating=i + 1,
+                min_rating=i + 1,
+            )
+            mf.allowed_types.add(node_type)
+            NodeMeritFlawRating.objects.create(node=self.node, mf=mf, rating=i + 1)
+
+    def test_detail_view_query_count_is_bounded(self):
+        """Test that detail view query count doesn't scale with related objects."""
+        self.client.login(username="testuser", password="password")
+
+        with CaptureQueriesContext(connection) as context:
+            response = self.client.get(f"/locations/mage/node/{self.node.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        query_count = len(context.captured_queries)
+        # With select_related on resonance and mf, queries should be bounded
+        # Base queries include session, user, permissions checks, and template rendering
+        self.assertLessEqual(
+            query_count,
+            35,
+            f"Too many queries ({query_count}). Detail view may have N+1 issue.",
+        )
+
+    def test_resonance_is_in_context(self):
+        """Test that resonance ratings are included in context."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(f"/locations/mage/node/{self.node.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("resonance", response.context)
+        self.assertEqual(response.context["resonance"].count(), 5)
+
+    def test_merits_and_flaws_is_in_context(self):
+        """Test that merits and flaws are included in context."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(f"/locations/mage/node/{self.node.pk}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("merits_and_flaws", response.context)
+        self.assertEqual(response.context["merits_and_flaws"].count(), 3)

--- a/locations/views/mage/node.py
+++ b/locations/views/mage/node.py
@@ -14,11 +14,15 @@ class NodeDetailView(ViewPermissionMixin, DetailView):
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["resonance"] = NodeResonanceRating.objects.filter(node=self.object).order_by(
-            "resonance__name"
+        context["resonance"] = (
+            NodeResonanceRating.objects.filter(node=self.object)
+            .select_related("resonance")
+            .order_by("resonance__name")
         )
-        context["merits_and_flaws"] = NodeMeritFlawRating.objects.filter(node=self.object).order_by(
-            "mf__name"
+        context["merits_and_flaws"] = (
+            NodeMeritFlawRating.objects.filter(node=self.object)
+            .select_related("mf")
+            .order_by("mf__name")
         )
         return context
 


### PR DESCRIPTION
## Summary

- Add `select_related('resonance')` to WonderDetailView and ArtifactDetailView to prevent N+1 queries when displaying resonance ratings
- Add `select_related('resonance')` and `select_related('mf')` to NodeDetailView to prevent N+1 queries when displaying resonance and merit/flaw ratings
- Add tests to verify query counts remain bounded for these views

## Test plan

- [x] Run `python manage.py test items.tests.views.mage.test_wonder items.tests.views.mage.test_artifact locations.tests.views.mage.test_node`
- [x] Verify all 7 tests pass
- [ ] Manual testing: Visit Wonder, Artifact, and Node detail pages with multiple resonances/merits and verify no performance degradation

Closes #1061

🤖 Generated with [Claude Code](https://claude.com/claude-code)