### PR TITLE
Fix 37 failing integration tests for validation and XP systems

### DIFF
--- a/game/tests/views/test_views.py
+++ b/game/tests/views/test_views.py
@@ -76,6 +76,7 @@ class SceneTest(TestCase):
         initial_xp = self.char.xp
         self.scene.award_xp({self.char: True})
         self.char.refresh_from_db()
+        self.scene.refresh_from_db()  # Refresh to see updated xp_given
         self.assertEqual(self.char.xp, initial_xp + 1)
         self.assertTrue(self.scene.xp_given)
 


### PR DESCRIPTION
## Summary
- Update integration tests to reflect API and architecture changes from XP system migration
- Skip SQLite-incompatible DB constraint tests (run on PostgreSQL)
- Remove obsolete JSONField-based dual XP system tests
- Fix XP spending tests to use current XPSpendingRequest model API

## Changes Made

### DB Constraint Tests (22 tests)
Added `@skipIf(USING_SQLITE)` decorator since SQLite doesn't enforce check constraints. Tests still work on PostgreSQL.

### XP Transaction Tests (7 tests)
- Updated to use `XPSpendingRequest` model API instead of removed `spent_xp` JSONField
- Fixed `approve_xp_spend()` signature: `(request_id, trait_property_name, new_value, approver)`
- Use `Character.spend_xp()` directly since `Human.spend_xp()` has different signature

### Dual System Tests (6 tests)
Removed tests for deprecated JSONField-based dual XP system. Rewrote as `TestXPSpendingSystem` to test current model-only approach.

### Migration Edge Cases (3 tests)
Rewrote `TestMigrationEdgeCases` as `TestXPSpendingEdgeCases` covering current model-only system edge cases.

### XP Request Tests (3 tests)
- Fixed `__str__` assertion to match actual format: `"{name} - {trait} ({status})"`
- Fixed `test_get_pending_xp_requests` to use explicit request references

### Scene XP Awards (1 test)
Added `scene.refresh_from_db()` after `award_xp()` to see updated `xp_given`.

## Test Plan
- [x] Run `python manage.py test characters.tests.integration.test_integration` - All pass (22 skipped on SQLite)
- [x] Run `python manage.py test game.tests.integration.test_integration` - All pass

Closes #1158

🤖 Generated with [Claude Code](https://claude.com/claude-code)