### PR TITLE
Fix 28 failing mage item model tests (#1155)

### DIFF
--- a/items/tests/models/mage/test_grimoire.py
+++ b/items/tests/models/mage/test_grimoire.py
@@ -1,4 +1,5 @@
 from characters.models.core.ability_block import Ability
+from characters.models.core.attribute_block import Attribute
 from characters.models.mage import Effect
 from characters.models.mage.faction import MageFaction
 from characters.models.mage.focus import Instrument, Practice
@@ -29,8 +30,15 @@ class TestGrimoire(TestCase):
         self.cover_material = Material.objects.create(name="Test Cover Material")
         self.inner_material = Material.objects.create(name="Test Inner Material")
         self.medium = Medium.objects.create(name="Test Medium")
+        # Create an attribute and ability for Rote requirements
+        attribute = Attribute.objects.create(name="Intelligence", property_name="intelligence")
         self.rotes = [
-            Rote.objects.create(effect=Effect.objects.create(name=f"Test Effect {i}"))
+            Rote.objects.create(
+                name=f"Test Rote {i}",
+                effect=Effect.objects.create(name=f"Test Effect {i}"),
+                attribute=attribute,
+                ability=science,
+            )
             for i in range(4)
         ]
         correspondence = Sphere.objects.create(

--- a/items/tests/models/mage/test_talisman.py
+++ b/items/tests/models/mage/test_talisman.py
@@ -15,7 +15,7 @@ class TestTalisman(TestCase):
         self.effect3 = Effect.objects.create(name="Effect 3", time=3)
 
     def test_add_power(self):
-        talisman = Talisman.objects.create(rank=2)
+        talisman = Talisman.objects.create(name="Test Talisman", rank=2)
         self.assertEqual(talisman.powers.count(), 0)
         talisman.add_power(self.effect1)
         self.assertEqual(talisman.powers.count(), 1)
@@ -23,7 +23,7 @@ class TestTalisman(TestCase):
         self.assertEqual(talisman.powers.count(), 2)
 
     def test_has_powers(self):
-        talisman = Talisman.objects.create(rank=2)
+        talisman = Talisman.objects.create(name="Test Talisman 2", rank=2)
         self.assertFalse(talisman.has_powers())
         talisman.add_power(self.effect1)
         self.assertFalse(talisman.has_powers())

--- a/items/tests/models/mage/test_wonder.py
+++ b/items/tests/models/mage/test_wonder.py
@@ -12,13 +12,13 @@ class TestWonder(TestCase):
         self.wonder = Wonder.objects.create(name="Test Wonder")
 
     def test_set_rank(self):
-        g = Wonder.objects.create(name="")
+        g = Wonder.objects.create(name="Test Wonder for Rank")
         self.assertFalse(g.has_rank())
         self.assertTrue(g.set_rank(3))
         self.assertEqual(g.rank, 3)
 
     def test_has_rank(self):
-        g = Wonder.objects.create(name="")
+        g = Wonder.objects.create(name="Test Wonder for Has Rank")
         self.assertFalse(g.has_rank())
         g.set_rank(3)
         self.assertTrue(g.has_rank())

--- a/items/tests/models/werewolf/test_fetish.py
+++ b/items/tests/models/werewolf/test_fetish.py
@@ -4,7 +4,7 @@ from items.models.werewolf.fetish import Fetish
 
 class TestFetish(TestCase):
     def test_save(self):
-        fetish = Fetish.objects.create(rank=2)
+        fetish = Fetish.objects.create(name="Test Fetish", rank=2)
         self.assertEqual(fetish.background_cost, 2)
 
 


### PR DESCRIPTION
## Summary
- Fixed 28 failing tests in mage item model tests by providing required fields
- Updated test_grimoire.py setUp to create Rotes with required `name`, `attribute`, and `ability` fields
- Updated test_talisman.py, test_wonder.py, and test_fetish.py to provide `name` when creating model instances

## Root Cause
The tests were written before the base Model class added validation requiring the `name` field. Similarly, Rote now requires `attribute` and `ability` fields.

## Test plan
- [x] Run `python manage.py test items.tests.models.mage.test_grimoire` - all 31 tests pass
- [x] Run `python manage.py test items.tests.models.mage.test_talisman` - all 9 tests pass
- [x] Run `python manage.py test items.tests.models.mage.test_wonder` - all 14 tests pass
- [x] Run `python manage.py test items.tests.models.werewolf.test_fetish` - all 9 tests pass

Fixes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)