### PR TITLE
Refactor Node to use MeritFlawBlock (#847)

### DIFF
--- a/characters/models/core/merit_flaw_block.py
+++ b/characters/models/core/merit_flaw_block.py
@@ -94,14 +94,59 @@ class MeritFlawRating(models.Model):
 
 
 class MeritFlawBlock(models.Model):
-    merits_and_flaws = models.ManyToManyField(
-        MeritFlaw, blank=True, through=MeritFlawRating, related_name="flawed"
-    )
+    """
+    Abstract mixin providing merit/flaw functionality for any model.
+
+    Subclasses must define:
+    - merits_and_flaws: ManyToManyField to MeritFlaw with a through model
+    - type: str - the object type for ObjectType filtering
+    - gameline: str - the gameline for ObjectType filtering
+
+    The through model must have:
+    - A ForeignKey to the parent model (detected automatically)
+    - A ForeignKey to MeritFlaw named 'mf'
+    - A rating field
+    """
 
     class Meta:
         abstract = True
 
+    def _get_through_model(self):
+        """Get the through model for the merits_and_flaws relationship."""
+        return self._meta.get_field("merits_and_flaws").remote_field.through
+
+    def _get_parent_fk_name(self):
+        """
+        Get the FK field name pointing to this model in the through model.
+        E.g., 'character' for MeritFlawRating, 'node' for NodeMeritFlawRating.
+        """
+        through_model = self._get_through_model()
+        for field in through_model._meta.get_fields():
+            related_model = getattr(field, "related_model", None)
+            if related_model is not None and isinstance(self, related_model):
+                return field.name
+        # Fallback to the model name in lowercase
+        return self.__class__.__name__.lower()
+
+    def _get_object_type(self):
+        """Get or create the ObjectType for this object type."""
+        object_type = self.type
+        # Handle special cases
+        if object_type in ["fomor"]:
+            object_type = "human"
+
+        # Determine type category ('char' for characters, 'loc' for locations)
+        from locations.models.core import LocationModel
+
+        type_category = "loc" if isinstance(self, LocationModel) else "char"
+
+        return ObjectType.objects.get_or_create(
+            name=object_type,
+            defaults={"type": type_category, "gameline": getattr(self, "gameline", "wod")},
+        )[0]
+
     def num_languages(self):
+        """Character-specific method to count languages."""
         mf_list = self.merits_and_flaws.all().values_list("name", flat=True)
         if "Language" not in mf_list:
             return 0
@@ -111,62 +156,98 @@ class MeritFlawBlock(models.Model):
         return language_rating
 
     def get_mf_and_rating_list(self):
+        """Return list of (MeritFlaw, rating) tuples."""
         return [(x, self.mf_rating(x)) for x in self.merits_and_flaws.all()]
 
     def add_mf(self, mf, rating):
-        if rating in mf.get_ratings():
-            mfr, _ = MeritFlawRating.objects.get_or_create(character=self, mf=mf)
-            mfr.rating = rating
-            mfr.save()
-            return True
-        return False
+        """
+        Add or update a merit/flaw.
+
+        Args:
+            mf: MeritFlaw instance
+            rating: int - the rating value
+
+        Returns:
+            bool - True if successfully added/updated, False otherwise
+        """
+        if rating not in mf.get_ratings():
+            return False
+
+        through_model = self._get_through_model()
+        fk_name = self._get_parent_fk_name()
+
+        mfr, _ = through_model.objects.get_or_create(**{fk_name: self, "mf": mf})
+        mfr.rating = rating
+        mfr.save()
+        return True
 
     def filter_mfs(self):
-        character_type = self.type
-        if character_type in ["fomor"]:
-            character_type = "human"
+        """
+        Filter available merits/flaws for this object.
+
+        Returns:
+            QuerySet of MeritFlaw objects that can be added
+        """
+        through_model = self._get_through_model()
+        fk_name = self._get_parent_fk_name()
 
         new_mfs = MeritFlaw.objects.exclude(pk__in=self.merits_and_flaws.all())
 
-        non_max_mf = MeritFlawRating.objects.filter(character=self).exclude(
+        non_max_mf = through_model.objects.filter(**{fk_name: self}).exclude(
             Q(rating=F("mf__max_rating"))
         )
 
-        had_mfs = MeritFlaw.objects.filter(pk__in=non_max_mf)
+        had_mfs = MeritFlaw.objects.filter(pk__in=non_max_mf.values_list("mf", flat=True))
         mf = new_mfs | had_mfs
         if self.has_max_flaws():
             mf = mf.filter(max_rating__gt=0)
-        character_type_object, _ = ObjectType.objects.get_or_create(
-            name=character_type, defaults={"type": "char", "gameline": "wod"}
-        )
-        return mf.filter(allowed_types=character_type_object)
+
+        object_type = self._get_object_type()
+        return mf.filter(allowed_types=object_type)
 
     def mf_rating(self, mf):
+        """Get the rating for a specific merit/flaw."""
+        through_model = self._get_through_model()
+        fk_name = self._get_parent_fk_name()
         try:
-            return MeritFlawRating.objects.get(character=self, mf=mf).rating
-        except MeritFlawRating.DoesNotExist:
+            return through_model.objects.get(**{fk_name: self, "mf": mf}).rating
+        except through_model.DoesNotExist:
             return 0
 
     def has_max_flaws(self):
+        """Check if max flaws limit reached (-7 points)."""
         return self.total_flaws() <= -7
 
     def total_flaws(self):
+        """Get the sum of all negative flaw ratings."""
         from django.db.models import Sum
 
-        result = MeritFlawRating.objects.filter(character=self, rating__lt=0).aggregate(
+        through_model = self._get_through_model()
+        fk_name = self._get_parent_fk_name()
+        result = through_model.objects.filter(**{fk_name: self, "rating__lt": 0}).aggregate(
             Sum("rating")
         )
         return result["rating__sum"] or 0
 
     def total_merits(self):
+        """Get the sum of all positive merit ratings."""
         from django.db.models import Sum
 
-        result = MeritFlawRating.objects.filter(character=self, rating__gt=0).aggregate(
+        through_model = self._get_through_model()
+        fk_name = self._get_parent_fk_name()
+        result = through_model.objects.filter(**{fk_name: self, "rating__gt": 0}).aggregate(
             Sum("rating")
         )
         return result["rating__sum"] or 0
 
+    def total_mf(self):
+        """Get the total of all merit/flaw ratings (merits minus flaws)."""
+        through_model = self._get_through_model()
+        fk_name = self._get_parent_fk_name()
+        return sum(r.rating for r in through_model.objects.filter(**{fk_name: self}))
+
     def meritflaw_freebies(self, form):
+        """Character-specific method for spending freebies on merits/flaws."""
         trait = form.cleaned_data["example"]
         value = int(form.data["value"])
         cost = value


### PR DESCRIPTION
## Summary
- Refactored `MeritFlawBlock` to be generic, supporting both character and location models
- `Node` now inherits from `MeritFlawBlock`, eliminating duplicate merit/flaw code
- Added `total_mf()` method to `MeritFlawBlock` for consistency
- Node's `filter_mf()` now wraps the base `filter_mfs()` with additional min/max filtering

## Implementation Details
- Made `MeritFlawBlock` detect its through model and FK field name dynamically using Django's meta API
- This allows any model with a `merits_and_flaws` M2M field to use the block
- Removed ~50 lines of duplicate code from Node model
- Added 4 new tests to verify inherited functionality works correctly

## Test plan
- [x] All 28 Node model tests pass
- [x] All 10 MeritFlawBlock tests pass
- [x] All 221 location and human tests pass
- [x] Full test suite (1386 tests) passes

Fixes #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)