### PR TITLE
Add comprehensive tests for core template tags

### DIFF
--- a/core/tests/templatetags/test_field.py
+++ b/core/tests/templatetags/test_field.py
@@ -1,5 +1,161 @@
-"""Tests for field module."""
+"""Tests for field template tags."""
 
+from core.templatetags.field import add_attr, add_class, field
+from django import forms
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class MockForm(forms.Form):
+    """Mock form for testing field template tags."""
+
+    name = forms.CharField(max_length=100)
+    email = forms.EmailField()
+    description = forms.CharField(widget=forms.Textarea)
+
+
+class FieldFilterTest(TestCase):
+    """Tests for field filter."""
+
+    def test_returns_field_by_name(self):
+        """Test filter returns correct field by name."""
+        form = MockForm()
+        result = field(form, "name")
+        self.assertEqual(result.name, "name")
+
+    def test_returns_different_fields(self):
+        """Test filter returns different fields correctly."""
+        form = MockForm()
+
+        name_field = field(form, "name")
+        email_field = field(form, "email")
+
+        self.assertEqual(name_field.name, "name")
+        self.assertEqual(email_field.name, "email")
+        self.assertNotEqual(name_field, email_field)
+
+    def test_returns_empty_string_for_nonexistent_field(self):
+        """Test filter returns empty string for nonexistent field name."""
+        form = MockForm()
+        result = field(form, "nonexistent")
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_for_invalid_form(self):
+        """Test filter returns empty string for invalid form object."""
+        result = field(None, "name")
+        self.assertEqual(result, "")
+
+        result = field("not a form", "name")
+        self.assertEqual(result, "")
+
+
+class AddClassFilterTest(TestCase):
+    """Tests for add_class filter."""
+
+    def test_adds_css_class_to_field(self):
+        """Test filter adds CSS class to form field."""
+        form = MockForm()
+        form_field = form["name"]
+
+        result = add_class(form_field, "my-class")
+
+        self.assertIn('class="my-class"', str(result))
+
+    def test_adds_multiple_classes(self):
+        """Test filter can add multiple CSS classes."""
+        form = MockForm()
+        form_field = form["name"]
+
+        result = add_class(form_field, "class1 class2")
+
+        self.assertIn('class="class1 class2"', str(result))
+
+    def test_returns_field_unchanged_if_no_as_widget(self):
+        """Test filter returns field unchanged if no as_widget method."""
+        result = add_class("not a field", "my-class")
+        self.assertEqual(result, "not a field")
+
+    def test_works_with_textarea(self):
+        """Test filter works with textarea widget."""
+        form = MockForm()
+        form_field = form["description"]
+
+        result = add_class(form_field, "textarea-class")
+
+        self.assertIn('class="textarea-class"', str(result))
+        self.assertIn("<textarea", str(result))
+
+
+class AddAttrFilterTest(TestCase):
+    """Tests for add_attr filter."""
+
+    def test_adds_attribute_to_field(self):
+        """Test filter adds attribute to form field."""
+        form = MockForm()
+        form_field = form["name"]
+
+        result = add_attr(form_field, "placeholder:Enter name")
+
+        self.assertIn('placeholder="Enter name"', str(result))
+
+    def test_adds_rows_attribute_to_textarea(self):
+        """Test filter adds rows attribute to textarea."""
+        form = MockForm()
+        form_field = form["description"]
+
+        result = add_attr(form_field, "rows:5")
+
+        self.assertIn('rows="5"', str(result))
+
+    def test_returns_field_unchanged_if_no_as_widget(self):
+        """Test filter returns field unchanged if no as_widget method."""
+        result = add_attr("not a field", "attr:value")
+        self.assertEqual(result, "not a field")
+
+    def test_returns_field_unchanged_for_invalid_attr_string(self):
+        """Test filter returns field unchanged for invalid attribute string."""
+        form = MockForm()
+        form_field = form["name"]
+
+        # Missing colon separator
+        result = add_attr(form_field, "invalid")
+
+        # Should return the field unchanged (as widget without added attr)
+        self.assertIsNotNone(result)
+
+    def test_handles_colon_in_value(self):
+        """Test filter handles colons in attribute value."""
+        form = MockForm()
+        form_field = form["name"]
+
+        result = add_attr(form_field, "data-url:http://example.com")
+
+        self.assertIn('data-url="http://example.com"', str(result))
+
+    def test_can_chain_with_add_class(self):
+        """Test filter can be chained with add_class."""
+        form = MockForm()
+        form_field = form["name"]
+
+        # First add class, then add attribute
+        result = add_class(form_field, "form-control")
+        # Note: add_attr returns a new widget, so we test separately
+        form_field2 = form["name"]
+        result2 = add_attr(form_field2, "placeholder:Enter text")
+
+        self.assertIn('class="form-control"', str(result))
+        self.assertIn('placeholder="Enter text"', str(result2))
+
+    def test_preserves_existing_widget_attrs(self):
+        """Test filter preserves existing widget attributes."""
+
+        class FormWithAttrs(forms.Form):
+            name = forms.CharField(widget=forms.TextInput(attrs={"data-existing": "value"}))
+
+        form = FormWithAttrs()
+        form_field = form["name"]
+
+        result = add_attr(form_field, "placeholder:New attr")
+
+        result_str = str(result)
+        self.assertIn('data-existing="value"', result_str)
+        self.assertIn('placeholder="New attr"', result_str)

--- a/core/tests/templatetags/test_json_filters.py
+++ b/core/tests/templatetags/test_json_filters.py
@@ -1,5 +1,187 @@
-"""Tests for json_filters module."""
+"""Tests for json_filters template tags."""
 
+from core.templatetags.json_filters import get_item, pprint
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class PPrintFilterTest(TestCase):
+    """Tests for pprint filter."""
+
+    def test_pretty_prints_dict(self):
+        """Test filter pretty prints dictionary."""
+        data = {"name": "Test", "value": 123}
+        result = pprint(data)
+
+        # Should have proper indentation
+        self.assertIn('"name"', result)
+        self.assertIn('"value"', result)
+        self.assertIn("123", result)
+        # Check for indentation (2 spaces)
+        self.assertIn("  ", result)
+
+    def test_pretty_prints_list(self):
+        """Test filter pretty prints list."""
+        data = [1, 2, 3]
+        result = pprint(data)
+
+        self.assertIn("1", result)
+        self.assertIn("2", result)
+        self.assertIn("3", result)
+
+    def test_pretty_prints_nested_structure(self):
+        """Test filter pretty prints nested structures."""
+        data = {"outer": {"inner": "value"}}
+        result = pprint(data)
+
+        self.assertIn('"outer"', result)
+        self.assertIn('"inner"', result)
+        self.assertIn('"value"', result)
+
+    def test_handles_json_string_input(self):
+        """Test filter handles JSON string input."""
+        json_str = '{"key": "value"}'
+        result = pprint(json_str)
+
+        # Should parse and re-format the JSON string
+        self.assertIn('"key"', result)
+        self.assertIn('"value"', result)
+
+    def test_handles_invalid_json_string(self):
+        """Test filter handles invalid JSON string gracefully."""
+        invalid_json = "not valid json"
+        result = pprint(invalid_json)
+
+        # Should return string representation
+        self.assertEqual(result, invalid_json)
+
+    def test_handles_none(self):
+        """Test filter handles None value."""
+        result = pprint(None)
+        self.assertEqual(result, "null")
+
+    def test_handles_integer(self):
+        """Test filter handles integer value."""
+        result = pprint(42)
+        self.assertEqual(result, "42")
+
+    def test_handles_boolean(self):
+        """Test filter handles boolean values."""
+        result = pprint(True)
+        self.assertEqual(result, "true")
+
+        result = pprint(False)
+        self.assertEqual(result, "false")
+
+    def test_preserves_unicode(self):
+        """Test filter preserves unicode characters."""
+        data = {"name": "Teszt"}
+        result = pprint(data)
+
+        self.assertIn("Teszt", result)
+
+    def test_handles_empty_dict(self):
+        """Test filter handles empty dictionary."""
+        result = pprint({})
+        self.assertEqual(result, "{}")
+
+    def test_handles_empty_list(self):
+        """Test filter handles empty list."""
+        result = pprint([])
+        self.assertEqual(result, "[]")
+
+    def test_handles_type_error(self):
+        """Test filter handles objects that can't be serialized."""
+
+        class NonSerializable:
+            pass
+
+        result = pprint(NonSerializable())
+
+        # Should return string representation
+        self.assertIn("NonSerializable", result)
+
+
+class GetItemFilterTest(TestCase):
+    """Tests for get_item filter."""
+
+    def test_gets_item_from_dict(self):
+        """Test filter gets item from dictionary by key."""
+        data = {"name": "Test", "value": 123}
+
+        result = get_item(data, "name")
+        self.assertEqual(result, "Test")
+
+        result = get_item(data, "value")
+        self.assertEqual(result, 123)
+
+    def test_returns_none_for_missing_key(self):
+        """Test filter returns None for missing key."""
+        data = {"name": "Test"}
+
+        result = get_item(data, "missing")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_none_dict(self):
+        """Test filter returns None when dictionary is None."""
+        result = get_item(None, "key")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_non_dict(self):
+        """Test filter returns None for non-dictionary values."""
+        result = get_item("not a dict", "key")
+        self.assertIsNone(result)
+
+        result = get_item([1, 2, 3], "key")
+        self.assertIsNone(result)
+
+        result = get_item(123, "key")
+        self.assertIsNone(result)
+
+    def test_handles_nested_dict(self):
+        """Test filter handles nested dictionary access."""
+        data = {"outer": {"inner": "value"}}
+
+        outer = get_item(data, "outer")
+        self.assertEqual(outer, {"inner": "value"})
+
+        # Can then get inner value
+        inner = get_item(outer, "inner")
+        self.assertEqual(inner, "value")
+
+    def test_handles_various_key_types(self):
+        """Test filter handles various key types."""
+        data = {"string_key": 1, 123: 2, (1, 2): 3}
+
+        result = get_item(data, "string_key")
+        self.assertEqual(result, 1)
+
+        result = get_item(data, 123)
+        self.assertEqual(result, 2)
+
+    def test_handles_none_value_in_dict(self):
+        """Test filter correctly returns None when value is None."""
+        data = {"key": None}
+
+        result = get_item(data, "key")
+        self.assertIsNone(result)
+
+    def test_handles_empty_dict(self):
+        """Test filter handles empty dictionary."""
+        result = get_item({}, "key")
+        self.assertIsNone(result)
+
+    def test_handles_falsy_values(self):
+        """Test filter correctly returns falsy values."""
+        data = {"zero": 0, "empty_str": "", "false": False, "empty_list": []}
+
+        result = get_item(data, "zero")
+        self.assertEqual(result, 0)
+
+        result = get_item(data, "empty_str")
+        self.assertEqual(result, "")
+
+        result = get_item(data, "false")
+        self.assertFalse(result)
+
+        result = get_item(data, "empty_list")
+        self.assertEqual(result, [])

--- a/core/tests/templatetags/test_permissions.py
+++ b/core/tests/templatetags/test_permissions.py
@@ -1,5 +1,591 @@
-"""Tests for permissions module."""
+"""Tests for permissions template tags."""
 
-from django.test import TestCase
+from core.permissions import Permission, VisibilityTier
+from core.templatetags.permissions import (
+    is_full,
+    is_game_st,
+    is_none,
+    is_owner,
+    is_partial,
+    is_st,
+    user_can_edit,
+    user_can_spend_freebies,
+    user_can_spend_xp,
+    user_can_view,
+    user_has_permission,
+    user_roles,
+    visibility_tier,
+)
+from django.contrib.auth.models import User
+from django.test import RequestFactory, TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class MockObject:
+    """Mock object for testing permission checks."""
+
+    def __init__(self, owner=None, chronicle=None, visibility_tier=None):
+        self.owner = owner
+        self.chronicle = chronicle
+        self._visibility_tier = visibility_tier or VisibilityTier.FULL
+        self._can_view = True
+        self._can_edit = True
+        self._can_spend_xp = True
+        self._can_spend_freebies = True
+        self._roles = set()
+
+    def user_can_view(self, user):
+        return self._can_view
+
+    def user_can_edit(self, user):
+        return self._can_edit
+
+    def user_can_spend_xp(self, user):
+        return self._can_spend_xp
+
+    def user_can_spend_freebies(self, user):
+        return self._can_spend_freebies
+
+    def get_visibility_tier(self, user):
+        return self._visibility_tier
+
+    def get_user_roles(self, user):
+        return self._roles
+
+
+class MockChronicle:
+    """Mock chronicle for testing ST relationships."""
+
+    def __init__(self):
+        self._game_storytellers = []
+
+    @property
+    def game_storytellers(self):
+        return MockQuerySet(self._game_storytellers)
+
+
+class MockQuerySet:
+    """Mock queryset for testing filter/exists."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def filter(self, **kwargs):
+        id_val = kwargs.get("id")
+        if id_val is not None:
+            return MockQuerySet([i for i in self._items if i.id == id_val])
+        return self
+
+    def exists(self):
+        return len(self._items) > 0
+
+
+class UserCanViewTagTest(TestCase):
+    """Tests for user_can_view template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_true_when_user_can_view(self):
+        """Test tag returns True when object allows viewing."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_view = True
+
+        result = user_can_view(context, obj)
+        self.assertTrue(result)
+
+    def test_returns_false_when_user_cannot_view(self):
+        """Test tag returns False when object denies viewing."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_view = False
+
+        result = user_can_view(context, obj)
+        self.assertFalse(result)
+
+
+class UserCanEditTagTest(TestCase):
+    """Tests for user_can_edit template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_true_when_user_can_edit(self):
+        """Test tag returns True when object allows editing."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_edit = True
+
+        result = user_can_edit(context, obj)
+        self.assertTrue(result)
+
+    def test_returns_false_when_user_cannot_edit(self):
+        """Test tag returns False when object denies editing."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_edit = False
+
+        result = user_can_edit(context, obj)
+        self.assertFalse(result)
+
+
+class UserCanSpendXPTagTest(TestCase):
+    """Tests for user_can_spend_xp template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_true_when_user_can_spend_xp(self):
+        """Test tag returns True when object allows XP spending."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_spend_xp = True
+
+        result = user_can_spend_xp(context, obj)
+        self.assertTrue(result)
+
+    def test_returns_false_when_user_cannot_spend_xp(self):
+        """Test tag returns False when object denies XP spending."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_spend_xp = False
+
+        result = user_can_spend_xp(context, obj)
+        self.assertFalse(result)
+
+
+class UserCanSpendFreebiesTagTest(TestCase):
+    """Tests for user_can_spend_freebies template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_true_when_user_can_spend_freebies(self):
+        """Test tag returns True when object allows freebie spending."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_spend_freebies = True
+
+        result = user_can_spend_freebies(context, obj)
+        self.assertTrue(result)
+
+    def test_returns_false_when_user_cannot_spend_freebies(self):
+        """Test tag returns False when object denies freebie spending."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._can_spend_freebies = False
+
+        result = user_can_spend_freebies(context, obj)
+        self.assertFalse(result)
+
+
+class UserHasPermissionTagTest(TestCase):
+    """Tests for user_has_permission template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+        self.admin = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="password"
+        )
+
+    def test_returns_true_for_valid_permission(self):
+        """Test tag returns True for valid permission the user has."""
+        request = self.factory.get("/")
+        request.user = self.admin
+        context = {"request": request}
+
+        obj = MockObject(owner=self.user)
+
+        result = user_has_permission(context, obj, "EDIT_FULL")
+        self.assertTrue(result)
+
+    def test_returns_false_for_permission_user_lacks(self):
+        """Test tag returns False for permission user doesn't have."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        # Object not owned by user, no admin rights
+        obj = MockObject()
+
+        result = user_has_permission(context, obj, "DELETE")
+        self.assertFalse(result)
+
+    def test_returns_false_for_invalid_permission_name(self):
+        """Test tag returns False for invalid permission names."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+
+        result = user_has_permission(context, obj, "INVALID_PERMISSION")
+        self.assertFalse(result)
+
+    def test_handles_various_permission_names(self):
+        """Test tag handles various permission name formats."""
+        request = self.factory.get("/")
+        request.user = self.admin
+        context = {"request": request}
+
+        obj = MockObject()
+
+        # Valid permission names
+        for perm in ["VIEW_FULL", "VIEW_PARTIAL", "EDIT_FULL", "EDIT_LIMITED"]:
+            result = user_has_permission(context, obj, perm)
+            self.assertIsInstance(result, bool)
+
+
+class VisibilityTierTagTest(TestCase):
+    """Tests for visibility_tier template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_full_visibility_tier(self):
+        """Test tag returns FULL visibility tier."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._visibility_tier = VisibilityTier.FULL
+
+        result = visibility_tier(context, obj)
+        self.assertEqual(result, VisibilityTier.FULL)
+
+    def test_returns_partial_visibility_tier(self):
+        """Test tag returns PARTIAL visibility tier."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._visibility_tier = VisibilityTier.PARTIAL
+
+        result = visibility_tier(context, obj)
+        self.assertEqual(result, VisibilityTier.PARTIAL)
+
+    def test_returns_none_visibility_tier(self):
+        """Test tag returns NONE visibility tier."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._visibility_tier = VisibilityTier.NONE
+
+        result = visibility_tier(context, obj)
+        self.assertEqual(result, VisibilityTier.NONE)
+
+
+class UserRolesTagTest(TestCase):
+    """Tests for user_roles template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_user_roles(self):
+        """Test tag returns set of user roles."""
+        from core.permissions import Role
+
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._roles = {Role.OWNER, Role.AUTHENTICATED}
+
+        result = user_roles(context, obj)
+        self.assertEqual(result, {Role.OWNER, Role.AUTHENTICATED})
+
+    def test_returns_empty_set_when_no_roles(self):
+        """Test tag returns empty set when user has no roles."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject()
+        obj._roles = set()
+
+        result = user_roles(context, obj)
+        self.assertEqual(result, set())
+
+
+class IsFullFilterTest(TestCase):
+    """Tests for is_full filter."""
+
+    def test_returns_true_for_full_tier(self):
+        """Test filter returns True for FULL tier."""
+        self.assertTrue(is_full(VisibilityTier.FULL))
+
+    def test_returns_false_for_partial_tier(self):
+        """Test filter returns False for PARTIAL tier."""
+        self.assertFalse(is_full(VisibilityTier.PARTIAL))
+
+    def test_returns_false_for_none_tier(self):
+        """Test filter returns False for NONE tier."""
+        self.assertFalse(is_full(VisibilityTier.NONE))
+
+
+class IsPartialFilterTest(TestCase):
+    """Tests for is_partial filter."""
+
+    def test_returns_true_for_partial_tier(self):
+        """Test filter returns True for PARTIAL tier."""
+        self.assertTrue(is_partial(VisibilityTier.PARTIAL))
+
+    def test_returns_false_for_full_tier(self):
+        """Test filter returns False for FULL tier."""
+        self.assertFalse(is_partial(VisibilityTier.FULL))
+
+    def test_returns_false_for_none_tier(self):
+        """Test filter returns False for NONE tier."""
+        self.assertFalse(is_partial(VisibilityTier.NONE))
+
+
+class IsNoneFilterTest(TestCase):
+    """Tests for is_none filter."""
+
+    def test_returns_true_for_none_tier(self):
+        """Test filter returns True for NONE tier."""
+        self.assertTrue(is_none(VisibilityTier.NONE))
+
+    def test_returns_false_for_full_tier(self):
+        """Test filter returns False for FULL tier."""
+        self.assertFalse(is_none(VisibilityTier.FULL))
+
+    def test_returns_false_for_partial_tier(self):
+        """Test filter returns False for PARTIAL tier."""
+        self.assertFalse(is_none(VisibilityTier.PARTIAL))
+
+
+class IsOwnerTagTest(TestCase):
+    """Tests for is_owner template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+        self.other_user = User.objects.create_user(
+            username="otheruser", email="other@example.com", password="password"
+        )
+
+    def test_returns_true_when_user_is_owner(self):
+        """Test tag returns True when user is owner of object."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject(owner=self.user)
+
+        result = is_owner(context, obj)
+        self.assertTrue(result)
+
+    def test_returns_false_when_user_is_not_owner(self):
+        """Test tag returns False when user is not owner of object."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject(owner=self.other_user)
+
+        result = is_owner(context, obj)
+        self.assertFalse(result)
+
+    def test_returns_false_when_object_has_no_owner(self):
+        """Test tag returns False when object has no owner attribute."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        class NoOwnerObject:
+            pass
+
+        obj = NoOwnerObject()
+
+        result = is_owner(context, obj)
+        self.assertFalse(result)
+
+    def test_checks_user_attribute_as_fallback(self):
+        """Test tag checks user attribute if owner not present."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        class UserObject:
+            def __init__(self, user):
+                self.user = user
+
+        obj = UserObject(self.user)
+
+        result = is_owner(context, obj)
+        self.assertTrue(result)
+
+
+class IsSTTagTest(TestCase):
+    """Tests for is_st template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_false_for_anonymous_user(self):
+        """Test tag returns False for anonymous users."""
+        from django.contrib.auth.models import AnonymousUser
+
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+        context = {"request": request}
+
+        result = is_st(context)
+        self.assertFalse(result)
+
+    def test_returns_true_for_superuser(self):
+        """Test tag returns True for superuser."""
+        admin = User.objects.create_superuser(
+            username="admin", email="admin@example.com", password="password"
+        )
+
+        request = self.factory.get("/")
+        request.user = admin
+        context = {"request": request}
+
+        result = is_st(context)
+        self.assertTrue(result)
+
+    def test_returns_true_for_staff_user(self):
+        """Test tag returns True for staff user."""
+        staff = User.objects.create_user(
+            username="staff",
+            email="staff@example.com",
+            password="password",
+            is_staff=True,
+        )
+
+        request = self.factory.get("/")
+        request.user = staff
+        context = {"request": request}
+
+        result = is_st(context)
+        self.assertTrue(result)
+
+    def test_delegates_to_profile_is_st(self):
+        """Test tag delegates to profile.is_st() for regular users."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        # Result depends on user's ST relationships
+        result = is_st(context)
+        self.assertIsInstance(result, bool)
+
+
+class IsGameSTTagTest(TestCase):
+    """Tests for is_game_st template tag."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@example.com", password="password"
+        )
+
+    def test_returns_false_when_no_chronicle(self):
+        """Test tag returns False when object has no chronicle."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        obj = MockObject(chronicle=None)
+
+        result = is_game_st(context, obj)
+        self.assertFalse(result)
+
+    def test_returns_true_when_user_is_game_st(self):
+        """Test tag returns True when user is game ST of chronicle."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        chronicle = MockChronicle()
+        chronicle._game_storytellers = [self.user]
+        obj = MockObject(chronicle=chronicle)
+
+        result = is_game_st(context, obj)
+        self.assertTrue(result)
+
+    def test_returns_false_when_user_is_not_game_st(self):
+        """Test tag returns False when user is not game ST of chronicle."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        chronicle = MockChronicle()
+        chronicle._game_storytellers = []
+        obj = MockObject(chronicle=chronicle)
+
+        result = is_game_st(context, obj)
+        self.assertFalse(result)
+
+    def test_returns_false_when_chronicle_has_no_game_storytellers_attr(self):
+        """Test tag returns False when chronicle lacks game_storytellers."""
+        request = self.factory.get("/")
+        request.user = self.user
+        context = {"request": request}
+
+        class SimpleChronicle:
+            pass
+
+        obj = MockObject()
+        obj.chronicle = SimpleChronicle()
+
+        result = is_game_st(context, obj)
+        self.assertFalse(result)

--- a/core/tests/templatetags/test_sanitize_text.py
+++ b/core/tests/templatetags/test_sanitize_text.py
@@ -1,5 +1,284 @@
-"""Tests for sanitize_text module."""
+"""Tests for sanitize_text template tags."""
 
+from core.templatetags.sanitize_text import (
+    badge_text,
+    quote_tag,
+    sanitize_html,
+    simple_markdown,
+)
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class SanitizeHTMLFilterTest(TestCase):
+    """Tests for sanitize_html filter."""
+
+    def test_returns_empty_string_for_none(self):
+        """Test filter returns empty string for None input."""
+        result = sanitize_html(None)
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_for_empty_string(self):
+        """Test filter returns empty string for empty input."""
+        result = sanitize_html("")
+        self.assertEqual(result, "")
+
+    def test_converts_non_string_to_string(self):
+        """Test filter converts non-string types to string."""
+        result = sanitize_html(123)
+        self.assertEqual(result, "123")
+
+    def test_preserves_allowed_tags(self):
+        """Test filter preserves allowed HTML tags."""
+        allowed_tags = ["a", "b", "i", "em", "strong", "u", "p", "br", "strike", "ul", "li", "span"]
+        for tag in allowed_tags:
+            html = f"<{tag}>content</{tag}>"
+            result = sanitize_html(html)
+            self.assertIn(f"<{tag}>", result, f"Tag {tag} should be preserved")
+
+    def test_allows_anchor_href(self):
+        """Test filter allows href attribute on anchor tags."""
+        html = '<a href="https://example.com">Link</a>'
+        result = sanitize_html(html)
+        self.assertIn('href="https://example.com"', result)
+
+    def test_allows_span_with_quote_class(self):
+        """Test filter allows span with class='quote'."""
+        html = '<span class="quote">Quoted text</span>'
+        result = sanitize_html(html)
+        self.assertIn('class="quote"', result)
+
+    def test_strips_disallowed_span_classes(self):
+        """Test filter strips span classes other than 'quote'."""
+        html = '<span class="danger">Text</span>'
+        result = sanitize_html(html)
+        self.assertNotIn('class="danger"', result)
+        self.assertIn("<span>", result)
+
+    def test_removes_script_tags(self):
+        """Test filter removes script tags."""
+        html = '<script>alert("XSS")</script>Safe text'
+        result = sanitize_html(html)
+        self.assertNotIn("<script>", result)
+        self.assertIn("Safe text", result)
+
+    def test_removes_onclick_attributes(self):
+        """Test filter removes dangerous onclick attributes."""
+        html = '<a href="#" onclick="alert(1)">Click</a>'
+        result = sanitize_html(html)
+        self.assertNotIn("onclick", result)
+
+    def test_allows_http_protocol(self):
+        """Test filter allows http protocol in links."""
+        html = '<a href="http://example.com">Link</a>'
+        result = sanitize_html(html)
+        self.assertIn("http://example.com", result)
+
+    def test_allows_https_protocol(self):
+        """Test filter allows https protocol in links."""
+        html = '<a href="https://example.com">Link</a>'
+        result = sanitize_html(html)
+        self.assertIn("https://example.com", result)
+
+    def test_allows_mailto_protocol(self):
+        """Test filter allows mailto protocol in links."""
+        html = '<a href="mailto:test@example.com">Email</a>'
+        result = sanitize_html(html)
+        self.assertIn("mailto:test@example.com", result)
+
+    def test_strips_javascript_protocol(self):
+        """Test filter strips javascript protocol from links."""
+        html = '<a href="javascript:alert(1)">Click</a>'
+        result = sanitize_html(html)
+        self.assertNotIn("javascript:", result)
+
+    def test_strips_data_protocol(self):
+        """Test filter strips data protocol from links."""
+        html = '<a href="data:text/html,<script>alert(1)</script>">Link</a>'
+        result = sanitize_html(html)
+        self.assertNotIn("data:", result)
+
+    def test_returns_marked_safe_html(self):
+        """Test filter returns marked safe HTML."""
+        from django.utils.safestring import SafeString
+
+        html = "<p>Test</p>"
+        result = sanitize_html(html)
+        self.assertIsInstance(result, SafeString)
+
+    def test_preserves_plain_text(self):
+        """Test filter preserves plain text without HTML."""
+        text = "This is plain text"
+        result = sanitize_html(text)
+        self.assertEqual(result, text)
+
+
+class QuoteTagFilterTest(TestCase):
+    """Tests for quote_tag filter."""
+
+    def test_wraps_quoted_text_in_span(self):
+        """Test filter wraps quoted text in span tags."""
+        text = 'He said "hello" to her.'
+        result = quote_tag(text)
+        self.assertIn('<span class="quote">"hello"</span>', result)
+
+    def test_wraps_multiple_quotes(self):
+        """Test filter wraps multiple quoted sections."""
+        text = '"First" and "Second" quotes.'
+        result = quote_tag(text)
+        self.assertIn('<span class="quote">"First"</span>', result)
+        self.assertIn('<span class="quote">"Second"</span>', result)
+
+    def test_returns_non_string_unchanged(self):
+        """Test filter returns non-string values unchanged."""
+        result = quote_tag(123)
+        self.assertEqual(result, 123)
+
+        result = quote_tag(None)
+        self.assertIsNone(result)
+
+    def test_handles_empty_quotes(self):
+        """Test filter handles empty quotes."""
+        text = 'Empty "" quotes'
+        result = quote_tag(text)
+        self.assertIn('<span class="quote">""</span>', result)
+
+    def test_preserves_text_outside_quotes(self):
+        """Test filter preserves text outside quotes."""
+        text = 'Before "quoted" after'
+        result = quote_tag(text)
+        self.assertIn("Before", result)
+        self.assertIn("after", result)
+
+    def test_handles_text_without_quotes(self):
+        """Test filter handles text without any quotes."""
+        text = "No quotes here"
+        result = quote_tag(text)
+        self.assertEqual(result, text)
+
+
+class SimpleMarkdownFilterTest(TestCase):
+    """Tests for simple_markdown filter."""
+
+    def test_returns_empty_string_for_none(self):
+        """Test filter returns empty string for None input."""
+        result = simple_markdown(None)
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_for_empty_string(self):
+        """Test filter returns empty string for empty input."""
+        result = simple_markdown("")
+        self.assertEqual(result, "")
+
+    def test_converts_non_string_to_string(self):
+        """Test filter converts non-string types to string."""
+        result = simple_markdown(123)
+        self.assertIn("123", result)
+
+    def test_converts_bold_markdown(self):
+        """Test filter converts **bold** to <strong>."""
+        text = "This is **bold** text."
+        result = simple_markdown(text)
+        self.assertIn("<strong>bold</strong>", result)
+
+    def test_converts_italic_markdown(self):
+        """Test filter converts *italic* to <em>."""
+        text = "This is *italic* text."
+        result = simple_markdown(text)
+        self.assertIn("<em>italic</em>", result)
+
+    def test_bold_not_confused_with_italic(self):
+        """Test filter handles bold and italic together correctly."""
+        text = "**bold** and *italic* text"
+        result = simple_markdown(text)
+        self.assertIn("<strong>bold</strong>", result)
+        self.assertIn("<em>italic</em>", result)
+
+    def test_converts_line_breaks(self):
+        """Test filter converts newlines to <br> tags."""
+        text = "Line 1\nLine 2"
+        result = simple_markdown(text)
+        self.assertIn("<br>", result)
+
+    def test_converts_double_newlines_to_paragraphs(self):
+        """Test filter converts double newlines to paragraph breaks."""
+        text = "Paragraph 1\n\nParagraph 2"
+        result = simple_markdown(text)
+        self.assertIn("</p>", result)
+        self.assertIn("<p>", result)
+
+    def test_wraps_in_paragraph_tags(self):
+        """Test filter wraps content in paragraph tags."""
+        text = "Some text"
+        result = simple_markdown(text)
+        self.assertTrue(result.startswith("<p>"))
+        self.assertTrue(result.endswith("</p>"))
+
+    def test_normalizes_windows_line_endings(self):
+        """Test filter normalizes Windows line endings."""
+        text = "Line 1\r\nLine 2"
+        result = simple_markdown(text)
+        self.assertNotIn("\r", result)
+
+    def test_returns_marked_safe_html(self):
+        """Test filter returns marked safe HTML."""
+        from django.utils.safestring import SafeString
+
+        text = "Test"
+        result = simple_markdown(text)
+        self.assertIsInstance(result, SafeString)
+
+
+class BadgeTextFilterTest(TestCase):
+    """Tests for badge_text filter."""
+
+    def test_returns_empty_string_for_none(self):
+        """Test filter returns empty string for None input."""
+        result = badge_text(None)
+        self.assertEqual(result, "")
+
+    def test_returns_empty_string_for_empty_string(self):
+        """Test filter returns empty string for empty input."""
+        result = badge_text("")
+        self.assertEqual(result, "")
+
+    def test_converts_non_string_to_string(self):
+        """Test filter converts non-string types to string."""
+        result = badge_text(123)
+        self.assertEqual(result, "123")
+
+    def test_replaces_underscores_with_spaces(self):
+        """Test filter replaces underscores with spaces."""
+        text = "some_text_here"
+        result = badge_text(text)
+        self.assertNotIn("_", result)
+        self.assertIn(" ", result)
+
+    def test_capitalizes_each_word(self):
+        """Test filter capitalizes each word (title case)."""
+        text = "hello_world"
+        result = badge_text(text)
+        self.assertEqual(result, "Hello World")
+
+    def test_handles_multiple_underscores(self):
+        """Test filter handles multiple underscores."""
+        text = "one_two_three_four"
+        result = badge_text(text)
+        self.assertEqual(result, "One Two Three Four")
+
+    def test_handles_already_capitalized(self):
+        """Test filter handles already capitalized text."""
+        text = "ALREADY_CAPS"
+        result = badge_text(text)
+        self.assertEqual(result, "Already Caps")
+
+    def test_handles_single_word(self):
+        """Test filter handles single word without underscores."""
+        text = "word"
+        result = badge_text(text)
+        self.assertEqual(result, "Word")
+
+    def test_example_autumn_person(self):
+        """Test filter with example from docstring."""
+        text = "autumn_person"
+        result = badge_text(text)
+        self.assertEqual(result, "Autumn Person")


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for core template tags that previously had low coverage:

- **permissions.py** (43% → 100%): Tests all permission template tags (`user_can_view`, `user_can_edit`, `user_can_spend_xp`, `user_has_permission`, `visibility_tier`, `user_roles`, `is_owner`, `is_st`, `is_game_st`) and filters (`is_full`, `is_partial`, `is_none`)
- **sanitize_text.py** (50% → 100%): Tests `sanitize_html`, `quote_tag`, `simple_markdown`, and `badge_text` filters
- **field.py** (48% → 100%): Tests `field`, `add_class`, and `add_attr` filters
- **json_filters.py** (39% → 100%): Tests `pprint` and `get_item` filters

Overall templatetags coverage: **95%**

## Test Plan

- [x] Run `python manage.py test core.tests.templatetags` - all 146 tests pass
- [x] Verify coverage with `coverage run --source=core/templatetags manage.py test core.tests.templatetags && coverage report`
- [x] All four target files have 100% coverage
- [x] Overall templatetags coverage exceeds 80% requirement (95%)

Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)