### PR TITLE
Add comprehensive tests for XP spending forms (#1173)

### DIFF
--- a/characters/tests/forms/core/test_xp.py
+++ b/characters/tests/forms/core/test_xp.py
@@ -1,5 +1,803 @@
-"""Tests for xp module."""
+"""
+Tests for XP spending form validation and processing.
 
+Tests cover:
+- XPForm initialization and field configuration
+- Category validation (valid selection, invalid placeholder)
+- Example field population based on category
+- Value field validation
+- XP cost calculations for different stat types
+- Edge cases (zero XP, maxed stats, etc.)
+"""
+
+from characters.forms.core.xp import CATEGORY_CHOICES, XPForm
+from characters.models.core import Human, MeritFlaw
+from characters.models.core.ability_block import Ability
+from characters.models.core.attribute_block import Attribute
+from characters.models.core.background_block import Background, BackgroundRating
+from core.models import Number
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import ObjectType
 
-# TODO: Move relevant tests from existing test files here
+
+def xp_test_setup():
+    """Set up the minimal test data needed for XP form tests."""
+    ObjectType.objects.get_or_create(name="human", type="char", gameline="wod")
+
+    # Create attributes
+    Attribute.objects.get_or_create(name="Strength", property_name="strength")
+    Attribute.objects.get_or_create(name="Dexterity", property_name="dexterity")
+    Attribute.objects.get_or_create(name="Stamina", property_name="stamina")
+    Attribute.objects.get_or_create(name="Perception", property_name="perception")
+    Attribute.objects.get_or_create(name="Intelligence", property_name="intelligence")
+    Attribute.objects.get_or_create(name="Wits", property_name="wits")
+    Attribute.objects.get_or_create(name="Charisma", property_name="charisma")
+    Attribute.objects.get_or_create(name="Manipulation", property_name="manipulation")
+    Attribute.objects.get_or_create(name="Appearance", property_name="appearance")
+
+    # Create backgrounds
+    Background.objects.get_or_create(name="Contacts", property_name="contacts")
+    Background.objects.get_or_create(name="Mentor", property_name="mentor")
+
+    # Create abilities that match Human.talents, Human.skills, Human.knowledges
+    # Talents
+    Ability.objects.get_or_create(name="Alertness", property_name="alertness")
+    Ability.objects.get_or_create(name="Athletics", property_name="athletics")
+    Ability.objects.get_or_create(name="Brawl", property_name="brawl")
+    Ability.objects.get_or_create(name="Empathy", property_name="empathy")
+    Ability.objects.get_or_create(name="Expression", property_name="expression")
+    Ability.objects.get_or_create(name="Intimidation", property_name="intimidation")
+    Ability.objects.get_or_create(name="Streetwise", property_name="streetwise")
+    Ability.objects.get_or_create(name="Subterfuge", property_name="subterfuge")
+
+    # Skills
+    Ability.objects.get_or_create(name="Crafts", property_name="crafts")
+    Ability.objects.get_or_create(name="Drive", property_name="drive")
+    Ability.objects.get_or_create(name="Etiquette", property_name="etiquette")
+    Ability.objects.get_or_create(name="Firearms", property_name="firearms")
+    Ability.objects.get_or_create(name="Melee", property_name="melee")
+    Ability.objects.get_or_create(name="Stealth", property_name="stealth")
+
+    # Knowledges
+    Ability.objects.get_or_create(name="Academics", property_name="academics")
+    Ability.objects.get_or_create(name="Computer", property_name="computer")
+    Ability.objects.get_or_create(name="Investigation", property_name="investigation")
+    Ability.objects.get_or_create(name="Medicine", property_name="medicine")
+    Ability.objects.get_or_create(name="Science", property_name="science")
+
+
+class TestXPFormBasics(TestCase):
+    """Test basic XPForm initialization and structure."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,  # Plenty of XP for testing
+        )
+        # Create Number objects for value choices
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_form_has_required_fields(self):
+        """Test that form has all required fields."""
+        form = XPForm(character=self.character)
+
+        self.assertIn("category", form.fields)
+        self.assertIn("example", form.fields)
+        self.assertIn("value", form.fields)
+        self.assertIn("note", form.fields)
+        self.assertIn("pooled", form.fields)
+        self.assertIn("image_field", form.fields)
+
+    def test_form_category_has_default_choices(self):
+        """Test that category field has expected default choices."""
+        form = XPForm(character=self.character)
+
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+        # Check for core categories (these depend on whether the character meets requirements)
+        self.assertIn("-----", category_values)
+        self.assertIn("Attribute", category_values)
+        # Ability depends on abilities in DB that match character's talents/skills/knowledges
+        self.assertIn("Ability", category_values)
+        self.assertIn("Willpower", category_values)
+
+    def test_example_field_is_optional(self):
+        """Test that example field is not required."""
+        form = XPForm(character=self.character)
+
+        self.assertFalse(form.fields["example"].required)
+
+    def test_value_field_is_optional(self):
+        """Test that value field is not required."""
+        form = XPForm(character=self.character)
+
+        self.assertFalse(form.fields["value"].required)
+
+    def test_note_field_max_length(self):
+        """Test that note field has max_length of 300."""
+        form = XPForm(character=self.character)
+
+        self.assertEqual(form.fields["note"].max_length, 300)
+
+
+class TestXPFormCategoryValidation(TestCase):
+    """Test category selection validation."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_placeholder_category_is_invalid(self):
+        """Test that selecting '-----' placeholder raises validation error."""
+        form = XPForm(
+            data={"category": "-----"},
+            character=self.character,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("category", form.errors)
+        self.assertIn("Invalid category selected", str(form.errors["category"]))
+
+    def test_attribute_category_is_valid(self):
+        """Test that Attribute category is valid when a valid example is provided."""
+        strength = Attribute.objects.get(property_name="strength")
+
+        form = XPForm(
+            data={"category": "Attribute", "example": strength.id},
+            character=self.character,
+        )
+
+        # Check that category validates correctly (form may have other errors)
+        form.is_valid()
+        self.assertNotIn("category", form.errors)
+
+    def test_ability_category_is_valid(self):
+        """Test that Ability category is valid when a valid example is provided."""
+        alertness = Ability.objects.get(property_name="alertness")
+
+        form = XPForm(
+            data={"category": "Ability", "example": alertness.id},
+            character=self.character,
+        )
+
+        form.is_valid()
+        self.assertNotIn("category", form.errors)
+
+    def test_willpower_category_is_valid(self):
+        """Test that Willpower category is valid."""
+        form = XPForm(
+            data={"category": "Willpower"},
+            character=self.character,
+        )
+
+        # Willpower doesn't require an example
+        form.is_valid()
+        self.assertNotIn("category", form.errors)
+
+
+class TestXPFormCategoryFiltering(TestCase):
+    """Test that categories are filtered based on character state."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_image_category_shown_when_no_image(self):
+        """Test that Image category is shown when character has no image."""
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+
+        form = XPForm(character=self.character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        # Image should be present since character has no image
+        self.assertIn("Image", category_values)
+
+    def test_attribute_category_hidden_when_all_maxed(self):
+        """Test that Attribute category is hidden when all attributes are at 5."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+            strength=5,
+            dexterity=5,
+            stamina=5,
+            perception=5,
+            intelligence=5,
+            wits=5,
+            charisma=5,
+            manipulation=5,
+            appearance=5,
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertNotIn("Attribute", category_values)
+
+    def test_attribute_category_shown_when_affordable(self):
+        """Test that Attribute category is shown when attributes can be raised."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,  # Plenty of XP
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertIn("Attribute", category_values)
+
+    def test_attribute_category_hidden_when_insufficient_xp(self):
+        """Test that Attribute category is hidden when XP is insufficient."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,  # No XP
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertNotIn("Attribute", category_values)
+
+    def test_new_background_category_requires_5_xp(self):
+        """Test that New Background category requires at least 5 XP."""
+        character_with_xp = Human.objects.create(
+            name="Character With XP",
+            owner=self.user,
+            xp=10,
+        )
+        character_no_xp = Human.objects.create(
+            name="Character No XP",
+            owner=self.user,
+            xp=0,
+        )
+
+        form_with_xp = XPForm(character=character_with_xp)
+        form_no_xp = XPForm(character=character_no_xp)
+
+        categories_with_xp = [choice[0] for choice in form_with_xp.fields["category"].choices]
+        categories_no_xp = [choice[0] for choice in form_no_xp.fields["category"].choices]
+
+        self.assertIn("New Background", categories_with_xp)
+        self.assertNotIn("New Background", categories_no_xp)
+
+    def test_willpower_category_hidden_when_insufficient_xp(self):
+        """Test Willpower category is hidden when can't afford to raise it."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,
+            willpower=5,
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertNotIn("Willpower", category_values)
+
+    def test_willpower_category_shown_when_affordable(self):
+        """Test Willpower category is shown when affordable."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+            willpower=5,
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertIn("Willpower", category_values)
+
+    def test_ability_category_hidden_when_insufficient_xp(self):
+        """Test Ability category is hidden when XP is insufficient for any ability."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,  # No XP - can't afford any ability upgrade
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertNotIn("Ability", category_values)
+
+
+class TestXPFormExamplePopulation(TestCase):
+    """Test example field population based on category selection."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_attribute_category_populates_example_with_attributes(self):
+        """Test that selecting Attribute populates example with attribute choices."""
+        form = XPForm(
+            data={"category": "Attribute"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        choice_names = [choice[1] for choice in example_choices]
+
+        # Check for some standard attributes
+        self.assertIn("Strength", choice_names)
+        self.assertIn("Dexterity", choice_names)
+        self.assertIn("Stamina", choice_names)
+
+    def test_ability_category_populates_example_with_abilities(self):
+        """Test that selecting Ability populates example with ability choices."""
+        form = XPForm(
+            data={"category": "Ability"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        choice_names = [choice[1] for choice in example_choices]
+
+        # Check for some standard abilities that should be in Human's abilities
+        self.assertIn("Alertness", choice_names)
+        self.assertIn("Athletics", choice_names)
+
+    def test_new_background_category_populates_example_with_backgrounds(self):
+        """Test that selecting New Background populates example with backgrounds."""
+        form = XPForm(
+            data={"category": "New Background"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        choice_names = [choice[1] for choice in example_choices]
+
+        # Check for some backgrounds
+        self.assertIn("Contacts", choice_names)
+        self.assertIn("Mentor", choice_names)
+
+    def test_existing_background_category_populates_with_character_backgrounds(self):
+        """Test that Existing Background shows character's current backgrounds."""
+        # Add a background to the character
+        bg = Background.objects.get(property_name="contacts")
+        BackgroundRating.objects.create(
+            char=self.character,
+            bg=bg,
+            rating=2,
+            note="My contacts",
+        )
+
+        form = XPForm(
+            data={"category": "Existing Background"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        # Should contain the character's background with its note
+        choice_labels = [choice[1] for choice in example_choices]
+        self.assertTrue(any("Contacts" in label for label in choice_labels))
+
+
+class TestXPFormCleanExample(TestCase):
+    """Test example field cleaning/validation."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_clean_example_returns_attribute_object(self):
+        """Test that clean_example returns Attribute object for Attribute category."""
+        strength = Attribute.objects.get(property_name="strength")
+
+        form = XPForm(
+            data={"category": "Attribute", "example": strength.id},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "example" in form.cleaned_data:
+            self.assertEqual(form.cleaned_data["example"], strength)
+
+    def test_clean_example_returns_ability_object(self):
+        """Test that clean_example returns Ability object for Ability category."""
+        alertness = Ability.objects.get(property_name="alertness")
+
+        form = XPForm(
+            data={"category": "Ability", "example": alertness.id},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "example" in form.cleaned_data:
+            self.assertEqual(form.cleaned_data["example"], alertness)
+
+    def test_clean_example_returns_background_object(self):
+        """Test that clean_example returns Background object for New Background category."""
+        contacts = Background.objects.get(property_name="contacts")
+
+        form = XPForm(
+            data={"category": "New Background", "example": contacts.id},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "example" in form.cleaned_data:
+            self.assertEqual(form.cleaned_data["example"], contacts)
+
+
+class TestXPFormCleanValue(TestCase):
+    """Test value field cleaning/validation."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_clean_value_returns_id_of_number(self):
+        """Test that clean_value returns the Number's id value."""
+        number = Number.objects.get(value=3)
+        strength = Attribute.objects.get(property_name="strength")
+
+        form = XPForm(
+            data={"category": "Attribute", "example": strength.id, "value": number.pk},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "value" in form.cleaned_data and form.cleaned_data["value"] is not None:
+            self.assertEqual(form.cleaned_data["value"], number.id)
+
+    def test_clean_value_handles_none(self):
+        """Test that clean_value handles None gracefully."""
+        form = XPForm(
+            data={"category": "Willpower"},
+            character=self.character,
+        )
+        form.is_valid()
+
+        # Value should be None since not provided
+        self.assertIsNone(form.cleaned_data.get("value"))
+
+
+class TestXPFormValidityChecks(TestCase):
+    """Test the various *_valid() methods that determine category availability."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+
+    def test_image_valid_returns_true_when_no_image(self):
+        """Test image_valid returns True when character has no image."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        form = XPForm(character=character)
+
+        self.assertTrue(form.image_valid())
+
+    def test_attribute_valid_with_available_xp(self):
+        """Test attribute_valid returns True when XP is available for upgrades."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        form = XPForm(character=character)
+
+        self.assertTrue(form.attribute_valid())
+
+    def test_attribute_valid_all_maxed(self):
+        """Test attribute_valid returns False when all attributes are maxed."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+            strength=5,
+            dexterity=5,
+            stamina=5,
+            perception=5,
+            intelligence=5,
+            wits=5,
+            charisma=5,
+            manipulation=5,
+            appearance=5,
+        )
+        form = XPForm(character=character)
+
+        self.assertFalse(form.attribute_valid())
+
+    def test_ability_valid_with_available_xp(self):
+        """Test ability_valid returns True when XP is available for upgrades."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+        form = XPForm(character=character)
+
+        self.assertTrue(form.ability_valid())
+
+    def test_ability_valid_false_when_no_xp(self):
+        """Test ability_valid returns False when XP is insufficient."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,
+        )
+        form = XPForm(character=character)
+
+        self.assertFalse(form.ability_valid())
+
+    def test_new_bg_valid_requires_5_xp(self):
+        """Test new_bg_valid requires at least 5 XP."""
+        character_with_xp = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=5,
+        )
+        character_no_xp = Human.objects.create(
+            name="Test Character 2",
+            owner=self.user,
+            xp=4,
+        )
+
+        form_with = XPForm(character=character_with_xp)
+        form_without = XPForm(character=character_no_xp)
+
+        self.assertTrue(form_with.new_bg_valid())
+        self.assertFalse(form_without.new_bg_valid())
+
+    def test_willpower_valid_checks_cost(self):
+        """Test willpower_valid checks if character can afford to raise willpower."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+            willpower=3,
+        )
+        form = XPForm(character=character)
+
+        self.assertTrue(form.willpower_valid())
+
+    def test_willpower_valid_false_when_insufficient_xp(self):
+        """Test willpower_valid returns False when XP is insufficient."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,
+            willpower=5,  # Cost to raise is 5
+        )
+        form = XPForm(character=character)
+
+        self.assertFalse(form.willpower_valid())
+
+
+class TestXPFormMeritFlawValidation(TestCase):
+    """Test merit/flaw category validation."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+
+        # Create ObjectType for human
+        self.human_type = ObjectType.objects.get_or_create(
+            name="human", type="char", gameline="wod"
+        )[0]
+
+        # Create merit/flaw for testing
+        for i in range(1, 4):
+            mf = MeritFlaw.objects.create(name=f"Test Merit {i}")
+            mf.add_rating(i)
+            mf.allowed_types.add(self.human_type)
+
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+            Number.objects.get_or_create(value=-i)
+
+    def test_mf_valid_when_affordable_mfs_exist(self):
+        """Test mf_valid returns True when affordable merit/flaws exist."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,  # Plenty of XP
+        )
+        form = XPForm(character=character)
+
+        # Should be valid since we have affordable merits
+        self.assertTrue(form.mf_valid())
+
+    def test_mf_valid_false_when_no_xp(self):
+        """Test mf_valid returns False when character has no XP."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,
+        )
+        form = XPForm(character=character)
+
+        self.assertFalse(form.mf_valid())
+
+    def test_meritflaw_category_populates_with_affordable_options(self):
+        """Test MeritFlaw category shows only affordable merits/flaws."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=3,  # Limited XP - only affordable for rating 1 merits (cost: 3)
+        )
+
+        form = XPForm(
+            data={"category": "MeritFlaw"},
+            character=character,
+        )
+
+        example_choices = form.fields["example"].choices
+        # Should have at least one choice (rating 1 merit costs 3 XP)
+        self.assertGreater(len(example_choices), 0)
+
+
+class TestXPFormEdgeCases(TestCase):
+    """Test edge cases and boundary conditions."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_form_with_zero_xp_character(self):
+        """Test form initialization with character having zero XP."""
+        character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=0,
+        )
+
+        form = XPForm(character=character)
+
+        # Form should initialize without errors
+        self.assertIsNotNone(form)
+
+        # Most categories should be filtered out
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+        self.assertIn("-----", category_values)  # Placeholder always present
+
+    def test_form_with_maxed_stats_still_allows_other_categories(self):
+        """Test form with maxed attributes and abilities still allows other options."""
+        character = Human.objects.create(
+            name="Maxed Character",
+            owner=self.user,
+            xp=100,
+            strength=5,
+            dexterity=5,
+            stamina=5,
+            perception=5,
+            intelligence=5,
+            wits=5,
+            charisma=5,
+            manipulation=5,
+            appearance=5,
+            alertness=5,
+            athletics=5,
+            brawl=5,
+            empathy=5,
+            expression=5,
+            intimidation=5,
+            streetwise=5,
+            subterfuge=5,
+            crafts=5,
+            drive=5,
+            etiquette=5,
+            firearms=5,
+            melee=5,
+            stealth=5,
+            academics=5,
+            computer=5,
+            investigation=5,
+            medicine=5,
+            science=5,
+        )
+
+        form = XPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        # Attribute and Ability should be filtered out since all are maxed
+        self.assertNotIn("Attribute", category_values)
+        self.assertNotIn("Ability", category_values)
+        # But other categories should still be available
+        self.assertIn("New Background", category_values)
+
+
+class TestXPCostCalculations(TestCase):
+    """Test XP cost calculations for different stat types."""
+
+    def setUp(self):
+        xp_test_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.character = Human.objects.create(
+            name="Test Character",
+            owner=self.user,
+            xp=50,
+        )
+
+    def test_attribute_xp_cost(self):
+        """Test XP cost for attributes (current rating * 4)."""
+        # Attribute XP cost is current rating * 4
+        self.assertEqual(self.character.xp_cost("attribute", 1), 4)
+        self.assertEqual(self.character.xp_cost("attribute", 2), 8)
+        self.assertEqual(self.character.xp_cost("attribute", 3), 12)
+        self.assertEqual(self.character.xp_cost("attribute", 4), 16)
+        self.assertEqual(self.character.xp_cost("attribute", 5), 20)
+
+    def test_ability_xp_cost(self):
+        """Test XP cost for abilities (current rating * 2)."""
+        # Ability XP cost is current rating * 2
+        self.assertEqual(self.character.xp_cost("ability", 1), 2)
+        self.assertEqual(self.character.xp_cost("ability", 2), 4)
+        self.assertEqual(self.character.xp_cost("ability", 3), 6)
+        self.assertEqual(self.character.xp_cost("ability", 4), 8)
+        self.assertEqual(self.character.xp_cost("ability", 5), 10)
+
+    def test_new_ability_xp_cost(self):
+        """Test XP cost for new abilities (3 XP)."""
+        self.assertEqual(self.character.xp_cost("ability", 0), 3)
+
+    def test_background_xp_cost(self):
+        """Test XP cost for backgrounds (current rating * 3)."""
+        self.assertEqual(self.character.xp_cost("background", 1), 3)
+        self.assertEqual(self.character.xp_cost("background", 2), 6)
+        self.assertEqual(self.character.xp_cost("background", 3), 9)
+
+    def test_new_background_xp_cost(self):
+        """Test XP cost for new backgrounds (5 XP * rating)."""
+        # The cost formula is: costs["new background"] * trait_value = 5 * trait_value
+        self.assertEqual(self.character.xp_cost("new background", 1), 5)
+        self.assertEqual(self.character.xp_cost("new background", 2), 10)
+        self.assertEqual(self.character.xp_cost("new background", 3), 15)
+
+    def test_willpower_xp_cost(self):
+        """Test XP cost for willpower (current rating * 1)."""
+        self.assertEqual(self.character.xp_cost("willpower", 1), 1)
+        self.assertEqual(self.character.xp_cost("willpower", 5), 5)
+        self.assertEqual(self.character.xp_cost("willpower", 10), 10)
+
+    def test_meritflaw_xp_cost(self):
+        """Test XP cost for merits/flaws (rating change * 3)."""
+        self.assertEqual(self.character.xp_cost("meritflaw", 1), 3)
+        self.assertEqual(self.character.xp_cost("meritflaw", 2), 6)

--- a/characters/tests/forms/mage/test_xp.py
+++ b/characters/tests/forms/mage/test_xp.py
@@ -1,5 +1,538 @@
-"""Tests for xp module."""
+"""
+Tests for Mage XP spending form validation and processing.
 
+Tests cover:
+- MageXPForm initialization and mage-specific fields
+- Category validation for mage-specific categories (Sphere, Arete, Practice, etc.)
+- Category filtering based on character state
+- Example field population for mage categories
+- XP cost calculations for mage-specific stats
+"""
+
+from characters.forms.mage.xp import CATEGORY_CHOICES, MageXPForm
+from characters.models.mage.faction import MageFaction
+from characters.models.mage.focus import Practice, Tenet
+from characters.models.mage.mage import Mage, PracticeRating
+from characters.models.mage.resonance import Resonance
+from characters.models.mage.sphere import Sphere
+from characters.tests.utils import mage_setup
+from core.models import Number
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMageXPFormBasics(TestCase):
+    """Test basic MageXPForm initialization and structure."""
+
+    def setUp(self):
+        mage_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.faction = MageFaction.objects.first()
+        self.character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_form_has_mage_specific_fields(self):
+        """Test that form has mage-specific fields."""
+        form = MageXPForm(character=self.character)
+
+        # Should have inherited fields
+        self.assertIn("category", form.fields)
+        self.assertIn("example", form.fields)
+        self.assertIn("value", form.fields)
+
+        # Should have mage-specific field
+        self.assertIn("resonance", form.fields)
+
+    def test_form_category_has_mage_choices(self):
+        """Test that category field has mage-specific choices."""
+        form = MageXPForm(character=self.character)
+
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        # Check for mage-specific categories
+        self.assertIn("Sphere", category_values)
+        self.assertIn("Arete", category_values)
+        self.assertIn("Rote Points", category_values)
+        self.assertIn("Resonance", category_values)
+        self.assertIn("Tenet", category_values)
+        self.assertIn("Practice", category_values)
+
+    def test_resonance_field_has_suggestions(self):
+        """Test that resonance field has autocomplete suggestions."""
+        form = MageXPForm(character=self.character)
+
+        suggestions = form.fields["resonance"].widget.suggestions
+        self.assertIsNotNone(suggestions)
+        self.assertGreater(len(suggestions), 0)
+
+
+class TestMageXPFormCategoryFiltering(TestCase):
+    """Test that mage-specific categories are filtered based on character state."""
+
+    def setUp(self):
+        mage_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.faction = MageFaction.objects.first()
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_sphere_category_hidden_when_insufficient_xp(self):
+        """Test Sphere category is hidden when character can't afford any sphere."""
+        character = Mage.objects.create(
+            name="Poor Mage",
+            owner=self.user,
+            xp=0,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form = MageXPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertNotIn("Sphere", category_values)
+
+    def test_sphere_category_shown_when_affordable(self):
+        """Test Sphere category is shown when character can afford sphere upgrades."""
+        character = Mage.objects.create(
+            name="Rich Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form = MageXPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertIn("Sphere", category_values)
+
+    def test_rote_points_category_requires_xp(self):
+        """Test Rote Points category requires at least 1 XP."""
+        character_with_xp = Mage.objects.create(
+            name="Mage With XP",
+            owner=self.user,
+            xp=5,
+            arete=3,
+            faction=self.faction,
+        )
+        character_no_xp = Mage.objects.create(
+            name="Mage No XP",
+            owner=self.user,
+            xp=0,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form_with = MageXPForm(character=character_with_xp)
+        form_without = MageXPForm(character=character_no_xp)
+
+        categories_with = [choice[0] for choice in form_with.fields["category"].choices]
+        categories_without = [choice[0] for choice in form_without.fields["category"].choices]
+
+        self.assertIn("Rote Points", categories_with)
+        self.assertNotIn("Rote Points", categories_without)
+
+    def test_resonance_category_requires_3_xp(self):
+        """Test Resonance category requires at least 3 XP."""
+        character_with_xp = Mage.objects.create(
+            name="Mage With XP",
+            owner=self.user,
+            xp=3,
+            arete=3,
+            faction=self.faction,
+        )
+        character_no_xp = Mage.objects.create(
+            name="Mage No XP",
+            owner=self.user,
+            xp=2,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form_with = MageXPForm(character=character_with_xp)
+        form_without = MageXPForm(character=character_no_xp)
+
+        categories_with = [choice[0] for choice in form_with.fields["category"].choices]
+        categories_without = [choice[0] for choice in form_without.fields["category"].choices]
+
+        self.assertIn("Resonance", categories_with)
+        self.assertNotIn("Resonance", categories_without)
+
+    def test_tenet_category_always_available(self):
+        """Test Tenet category is always available (free to add)."""
+        character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=0,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form = MageXPForm(character=character)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        self.assertIn("Tenet", category_values)
+
+    def test_arete_category_requires_sufficient_xp(self):
+        """Test Arete category requires sufficient XP based on current arete."""
+        # Arete 3 -> 4 costs 8 * 3 = 24 XP
+        character_with_xp = Mage.objects.create(
+            name="Rich Mage",
+            owner=self.user,
+            xp=30,
+            arete=3,
+            faction=self.faction,
+        )
+        character_no_xp = Mage.objects.create(
+            name="Poor Mage",
+            owner=self.user,
+            xp=10,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form_with = MageXPForm(character=character_with_xp)
+        form_without = MageXPForm(character=character_no_xp)
+
+        categories_with = [choice[0] for choice in form_with.fields["category"].choices]
+        categories_without = [choice[0] for choice in form_without.fields["category"].choices]
+
+        self.assertIn("Arete", categories_with)
+        self.assertNotIn("Arete", categories_without)
+
+    def test_rote_category_requires_rote_points(self):
+        """Test Rote category requires character to have rote points."""
+        character_with_points = Mage.objects.create(
+            name="Mage With Points",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+            rote_points=5,
+        )
+        character_no_points = Mage.objects.create(
+            name="Mage No Points",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+            rote_points=0,
+        )
+
+        form_with = MageXPForm(character=character_with_points)
+        form_without = MageXPForm(character=character_no_points)
+
+        categories_with = [choice[0] for choice in form_with.fields["category"].choices]
+        categories_without = [choice[0] for choice in form_without.fields["category"].choices]
+
+        self.assertIn("Rote", categories_with)
+        self.assertNotIn("Rote", categories_without)
+
+
+class TestMageXPFormExamplePopulation(TestCase):
+    """Test example field population for mage-specific categories."""
+
+    def setUp(self):
+        mage_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.faction = MageFaction.objects.first()
+        self.character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_sphere_category_populates_example_with_spheres(self):
+        """Test that selecting Sphere populates example with sphere choices."""
+        form = MageXPForm(
+            data={"category": "Sphere"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        choice_names = [choice[1] for choice in example_choices]
+
+        # Check for some standard spheres
+        self.assertIn("Correspondence", choice_names)
+        self.assertIn("Forces", choice_names)
+        self.assertIn("Mind", choice_names)
+
+    def test_tenet_category_populates_example_with_tenets(self):
+        """Test that selecting Tenet populates example with tenet choices."""
+        form = MageXPForm(
+            data={"category": "Tenet"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        self.assertGreater(len(example_choices), 0)
+
+    def test_practice_category_populates_example_with_practices(self):
+        """Test that selecting Practice populates example with practice choices."""
+        form = MageXPForm(
+            data={"category": "Practice"},
+            character=self.character,
+        )
+
+        example_choices = form.fields["example"].choices
+        self.assertGreater(len(example_choices), 0)
+
+
+class TestMageXPFormValidityChecks(TestCase):
+    """Test the mage-specific *_valid() methods."""
+
+    def setUp(self):
+        mage_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.faction = MageFaction.objects.first()
+
+    def test_spheres_valid_with_available_xp(self):
+        """Test spheres_valid returns True when XP is available."""
+        character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+        form = MageXPForm(character=character)
+
+        self.assertTrue(form.spheres_valid())
+
+    def test_spheres_valid_false_when_no_xp(self):
+        """Test spheres_valid returns False when XP is insufficient."""
+        character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=0,
+            arete=3,
+            faction=self.faction,
+        )
+        form = MageXPForm(character=character)
+
+        self.assertFalse(form.spheres_valid())
+
+    def test_rote_points_valid_requires_xp(self):
+        """Test rote_points_valid requires at least 1 XP."""
+        character_with = Mage.objects.create(
+            name="With",
+            owner=self.user,
+            xp=1,
+            arete=3,
+            faction=self.faction,
+        )
+        character_without = Mage.objects.create(
+            name="Without",
+            owner=self.user,
+            xp=0,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form_with = MageXPForm(character=character_with)
+        form_without = MageXPForm(character=character_without)
+
+        self.assertTrue(form_with.rote_points_valid())
+        self.assertFalse(form_without.rote_points_valid())
+
+    def test_resonance_valid_requires_3_xp(self):
+        """Test resonance_valid requires at least 3 XP."""
+        character_with = Mage.objects.create(
+            name="With",
+            owner=self.user,
+            xp=3,
+            arete=3,
+            faction=self.faction,
+        )
+        character_without = Mage.objects.create(
+            name="Without",
+            owner=self.user,
+            xp=2,
+            arete=3,
+            faction=self.faction,
+        )
+
+        form_with = MageXPForm(character=character_with)
+        form_without = MageXPForm(character=character_without)
+
+        self.assertTrue(form_with.resonance_valid())
+        self.assertFalse(form_without.resonance_valid())
+
+    def test_add_tenet_valid_always_true(self):
+        """Test add_tenet_valid always returns True."""
+        character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=0,
+            arete=1,
+            faction=self.faction,
+        )
+        form = MageXPForm(character=character)
+
+        self.assertTrue(form.add_tenet_valid())
+
+    def test_arete_valid_checks_xp_and_tenet_limit(self):
+        """Test arete_valid checks XP cost and tenet requirements."""
+        character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+        form = MageXPForm(character=character)
+
+        # Should be valid with plenty of XP and arete <= tenets + 3
+        self.assertTrue(form.arete_valid())
+
+    def test_rote_valid_requires_rote_points(self):
+        """Test rote_valid requires rote points > 0."""
+        character_with = Mage.objects.create(
+            name="With",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+            rote_points=5,
+        )
+        character_without = Mage.objects.create(
+            name="Without",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+            rote_points=0,
+        )
+
+        form_with = MageXPForm(character=character_with)
+        form_without = MageXPForm(character=character_without)
+
+        self.assertTrue(form_with.rote_valid())
+        self.assertFalse(form_without.rote_valid())
+
+
+class TestMageXPFormCleanExample(TestCase):
+    """Test example field cleaning for mage-specific categories."""
+
+    def setUp(self):
+        mage_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.faction = MageFaction.objects.first()
+        self.character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+        for i in range(1, 6):
+            Number.objects.get_or_create(value=i)
+
+    def test_clean_example_returns_sphere_object(self):
+        """Test that clean_example returns Sphere object for Sphere category."""
+        forces = Sphere.objects.get(property_name="forces")
+
+        form = MageXPForm(
+            data={"category": "Sphere", "example": forces.id},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "example" in form.cleaned_data:
+            self.assertEqual(form.cleaned_data["example"], forces)
+
+    def test_clean_example_returns_tenet_object(self):
+        """Test that clean_example returns Tenet object for Tenet category."""
+        tenet = Tenet.objects.first()
+
+        form = MageXPForm(
+            data={"category": "Tenet", "example": tenet.id},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "example" in form.cleaned_data:
+            self.assertEqual(form.cleaned_data["example"], tenet)
+
+    def test_clean_example_returns_practice_object(self):
+        """Test that clean_example returns Practice object for Practice category."""
+        practice = Practice.objects.first()
+
+        form = MageXPForm(
+            data={"category": "Practice", "example": practice.id},
+            character=self.character,
+        )
+        form.is_valid()
+
+        if "example" in form.cleaned_data:
+            self.assertEqual(form.cleaned_data["example"], practice)
+
+
+class TestMageXPCostCalculations(TestCase):
+    """Test XP cost calculations for mage-specific stat types."""
+
+    def setUp(self):
+        mage_setup()
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.faction = MageFaction.objects.first()
+        self.character = Mage.objects.create(
+            name="Test Mage",
+            owner=self.user,
+            xp=50,
+            arete=3,
+            faction=self.faction,
+        )
+
+    def test_sphere_xp_cost(self):
+        """Test XP cost for spheres (current rating * 8)."""
+        self.assertEqual(self.character.xp_cost("sphere", 1), 8)
+        self.assertEqual(self.character.xp_cost("sphere", 2), 16)
+        self.assertEqual(self.character.xp_cost("sphere", 3), 24)
+
+    def test_new_sphere_xp_cost(self):
+        """Test XP cost for new spheres (10 XP)."""
+        self.assertEqual(self.character.xp_cost("sphere", 0), 10)
+
+    def test_arete_xp_cost(self):
+        """Test XP cost for arete (current rating * 8)."""
+        self.assertEqual(self.character.xp_cost("arete", 1), 8)
+        self.assertEqual(self.character.xp_cost("arete", 3), 24)
+        self.assertEqual(self.character.xp_cost("arete", 5), 40)
+
+    def test_tenet_xp_cost(self):
+        """Test XP cost for adding tenet (0 - free)."""
+        self.assertEqual(self.character.xp_cost("tenet", 1), 0)
+
+    def test_remove_tenet_xp_cost(self):
+        """Test XP cost for removing tenet (1 per excess tenet)."""
+        self.assertEqual(self.character.xp_cost("remove tenet", 1), 1)
+        self.assertEqual(self.character.xp_cost("remove tenet", 3), 3)
+
+    def test_practice_xp_cost(self):
+        """Test XP cost for practices (current rating * 1)."""
+        self.assertEqual(self.character.xp_cost("practice", 1), 1)
+        self.assertEqual(self.character.xp_cost("practice", 3), 3)
+
+    def test_new_practice_xp_cost(self):
+        """Test XP cost for new practices (3 XP)."""
+        self.assertEqual(self.character.xp_cost("practice", 0), 3)
+
+    def test_resonance_xp_cost(self):
+        """Test XP cost for resonance (current rating * 3)."""
+        self.assertEqual(self.character.xp_cost("resonance", 1), 3)
+        self.assertEqual(self.character.xp_cost("resonance", 3), 9)
+
+    def test_new_resonance_xp_cost(self):
+        """Test XP cost for new resonance (5 XP)."""
+        self.assertEqual(self.character.xp_cost("resonance", 0), 5)


### PR DESCRIPTION
## Summary
- Add 78 comprehensive tests for XP spending forms (core and mage)
- Achieve 95% overall coverage (97% core, 94% mage)
- Tests cover form initialization, validation, category filtering, and XP cost calculations

## Test plan
- [x] Core XP form tests pass (46 tests)
- [x] Mage XP form tests pass (32 tests)
- [x] Coverage exceeds 80% target (95% achieved)
- [x] All tests run successfully with `python manage.py test characters.tests.forms.core.test_xp characters.tests.forms.mage.test_xp`

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)