### PR TITLE
Add comprehensive tests for Vampire gameline models and forms

### DIFF
--- a/characters/tests/forms/vampire/test_freebies.py
+++ b/characters/tests/forms/vampire/test_freebies.py
@@ -1,5 +1,290 @@
-"""Tests for freebies module."""
+"""
+Tests for VampireFreebiesForm and GhoulFreebiesForm.
 
+Tests cover:
+- Form initialization with vampire/ghoul instance
+- Category choices including vampire-specific options
+- Validator method for checking freebie costs
+- Discipline queryset population
+- Form validation for different categories
+"""
+
+from characters.forms.vampire.freebies import (
+    VAMPIRE_CATEGORY_CHOICES,
+    GhoulFreebiesForm,
+    VampireFreebiesForm,
+)
+from characters.models.vampire.clan import VampireClan
+from characters.models.vampire.discipline import Discipline
+from characters.models.vampire.ghoul import Ghoul
+from characters.models.vampire.vampire import Vampire
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class VampireFreebiesFormTestCase(TestCase):
+    """Base test case with common setup for VampireFreebiesForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.celerity = Discipline.objects.create(name="Celerity", property_name="celerity")
+        cls.presence = Discipline.objects.create(name="Presence", property_name="presence")
+        cls.dominate = Discipline.objects.create(name="Dominate", property_name="dominate")
+
+        # Create clan
+        cls.brujah = VampireClan.objects.create(
+            name="Brujah",
+            nickname="Rabble",
+        )
+        cls.brujah.disciplines.add(cls.potence, cls.celerity, cls.presence)
+
+    def setUp(self):
+        """Set up test user and character."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.vampire = Vampire.objects.create(
+            name="Test Vampire",
+            owner=self.user,
+            clan=self.brujah,
+            freebies=15,
+        )
+
+
+class TestVampireCategoryChoices(VampireFreebiesFormTestCase):
+    """Test vampire-specific category choices."""
+
+    def test_vampire_category_choices_includes_discipline(self):
+        """VAMPIRE_CATEGORY_CHOICES includes Discipline option."""
+        category_values = [choice[0] for choice in VAMPIRE_CATEGORY_CHOICES]
+        self.assertIn("Discipline", category_values)
+
+    def test_vampire_category_choices_includes_virtue(self):
+        """VAMPIRE_CATEGORY_CHOICES includes Virtue option."""
+        category_values = [choice[0] for choice in VAMPIRE_CATEGORY_CHOICES]
+        self.assertIn("Virtue", category_values)
+
+    def test_vampire_category_choices_includes_humanity(self):
+        """VAMPIRE_CATEGORY_CHOICES includes Humanity option."""
+        category_values = [choice[0] for choice in VAMPIRE_CATEGORY_CHOICES]
+        self.assertIn("Humanity", category_values)
+
+    def test_vampire_category_choices_includes_path_rating(self):
+        """VAMPIRE_CATEGORY_CHOICES includes Path Rating option."""
+        category_values = [choice[0] for choice in VAMPIRE_CATEGORY_CHOICES]
+        self.assertIn("Path Rating", category_values)
+
+
+class TestVampireFreebiesFormInitialization(VampireFreebiesFormTestCase):
+    """Test form initialization."""
+
+    def test_form_initializes_with_instance(self):
+        """Form initializes correctly with vampire instance."""
+        form = VampireFreebiesForm(instance=self.vampire)
+        self.assertEqual(form.instance, self.vampire)
+
+    def test_form_filters_unaffordable_categories(self):
+        """Form filters out categories the vampire cannot afford."""
+        self.vampire.freebies = 5
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        # Should include Attribute (cost 5)
+        self.assertIn("Attribute", category_values)
+
+    def test_form_includes_base_categories_with_sufficient_freebies(self):
+        """Form includes base categories when vampire has enough freebies."""
+        self.vampire.freebies = 15
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        # Base categories from HumanFreebiesForm should be present
+        self.assertIn("Attribute", category_values)
+        self.assertIn("Ability", category_values)
+        self.assertIn("Willpower", category_values)
+
+
+class TestVampireFreebiesFormValidator(VampireFreebiesFormTestCase):
+    """Test validator method for category affordability."""
+
+    def test_validator_returns_true_for_affordable_discipline(self):
+        """Validator returns True when vampire can afford disciplines."""
+        self.vampire.freebies = 10
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        # Discipline costs 7, should be affordable with 10 freebies
+        self.assertTrue(form.validator("Discipline"))
+
+    def test_validator_returns_false_for_unaffordable_discipline(self):
+        """Validator returns False when vampire cannot afford disciplines."""
+        self.vampire.freebies = 5
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        # Discipline costs 7, should not be affordable with 5 freebies
+        self.assertFalse(form.validator("Discipline"))
+
+    def test_validator_returns_true_for_affordable_virtue(self):
+        """Validator returns True when vampire can afford virtues."""
+        self.vampire.freebies = 3
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        # Virtue costs 2, should be affordable with 3 freebies
+        self.assertTrue(form.validator("Virtue"))
+
+    def test_validator_returns_true_for_affordable_humanity(self):
+        """Validator returns True when vampire can afford humanity."""
+        self.vampire.freebies = 2
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        # Humanity costs 1, should be affordable with 2 freebies
+        self.assertTrue(form.validator("Humanity"))
+
+    def test_validator_returns_true_for_affordable_path_rating(self):
+        """Validator returns True when vampire can afford path rating."""
+        self.vampire.freebies = 1
+        self.vampire.save()
+
+        form = VampireFreebiesForm(instance=self.vampire)
+        # Path Rating costs 1, should be affordable with 1 freebie
+        self.assertTrue(form.validator("Path Rating"))
+
+
+class TestVampireFreebiesFormBoundData(VampireFreebiesFormTestCase):
+    """Test form behavior when bound with data."""
+
+    def test_discipline_queryset_populated_when_bound(self):
+        """Discipline queryset includes all disciplines when form is bound."""
+        form = VampireFreebiesForm(
+            data={"category": "Discipline", "example": "", "value": ""},
+            instance=self.vampire,
+        )
+        example_qs = form.fields["example"].queryset
+        self.assertIn(self.potence, example_qs)
+        self.assertIn(self.dominate, example_qs)
+
+
+class TestVampireFreebiesFormSave(VampireFreebiesFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_returns_instance(self):
+        """Saving form returns the character instance."""
+        form = VampireFreebiesForm(
+            data={"category": "Discipline", "example": "", "value": ""},
+            instance=self.vampire,
+        )
+        result = form.save()
+        self.assertEqual(result, self.vampire)
+
+
+class GhoulFreebiesFormTestCase(TestCase):
+    """Base test case with common setup for GhoulFreebiesForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.celerity = Discipline.objects.create(name="Celerity", property_name="celerity")
+        cls.fortitude = Discipline.objects.create(name="Fortitude", property_name="fortitude")
+
+    def setUp(self):
+        """Set up test user and character."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.ghoul = Ghoul.objects.create(
+            name="Test Ghoul",
+            owner=self.user,
+            freebies=15,
+        )
+
+
+class TestGhoulFreebiesFormInitialization(GhoulFreebiesFormTestCase):
+    """Test form initialization."""
+
+    def test_form_initializes_with_instance(self):
+        """Form initializes correctly with ghoul instance."""
+        form = GhoulFreebiesForm(instance=self.ghoul)
+        self.assertEqual(form.instance, self.ghoul)
+
+    def test_form_includes_base_categories(self):
+        """Form includes base categories for ghouls."""
+        form = GhoulFreebiesForm(instance=self.ghoul)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+        # Base categories from HumanFreebiesForm should be present
+        self.assertIn("Attribute", category_values)
+        self.assertIn("Ability", category_values)
+
+    def test_form_excludes_vampire_specific_categories(self):
+        """Form excludes vampire-specific categories like Virtue, Humanity."""
+        form = GhoulFreebiesForm(instance=self.ghoul)
+        category_values = [choice[0] for choice in form.fields["category"].choices]
+
+        # Ghouls shouldn't have Virtue, Humanity, Path Rating categories
+        self.assertNotIn("Virtue", category_values)
+        self.assertNotIn("Humanity", category_values)
+        self.assertNotIn("Path Rating", category_values)
+
+
+class TestGhoulFreebiesFormValidator(GhoulFreebiesFormTestCase):
+    """Test validator method for category affordability."""
+
+    def test_validator_returns_true_for_affordable_discipline(self):
+        """Validator returns True when ghoul can afford disciplines."""
+        self.ghoul.freebies = 10
+        self.ghoul.save()
+
+        form = GhoulFreebiesForm(instance=self.ghoul)
+        # Discipline costs 7 for ghouls, should be affordable with 10 freebies
+        self.assertTrue(form.validator("Discipline"))
+
+    def test_validator_returns_false_for_unaffordable_discipline(self):
+        """Validator returns False when ghoul cannot afford disciplines."""
+        self.ghoul.freebies = 5
+        self.ghoul.save()
+
+        form = GhoulFreebiesForm(instance=self.ghoul)
+        # Discipline costs 7, should not be affordable with 5 freebies
+        self.assertFalse(form.validator("Discipline"))
+
+
+class TestGhoulFreebiesFormBoundData(GhoulFreebiesFormTestCase):
+    """Test form behavior when bound with data."""
+
+    def test_discipline_queryset_populated_when_bound(self):
+        """Discipline queryset includes all disciplines when form is bound."""
+        form = GhoulFreebiesForm(
+            data={"category": "Discipline", "example": "", "value": ""},
+            instance=self.ghoul,
+        )
+        example_qs = form.fields["example"].queryset
+        self.assertIn(self.potence, example_qs)
+        self.assertIn(self.celerity, example_qs)
+
+
+class TestGhoulFreebiesFormSave(GhoulFreebiesFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_returns_instance(self):
+        """Saving form returns the character instance."""
+        form = GhoulFreebiesForm(
+            data={"category": "Discipline", "example": "", "value": ""},
+            instance=self.ghoul,
+        )
+        result = form.save()
+        self.assertEqual(result, self.ghoul)

--- a/characters/tests/forms/vampire/test_ghoul.py
+++ b/characters/tests/forms/vampire/test_ghoul.py
@@ -1,5 +1,267 @@
-"""Tests for ghoul module."""
+"""
+Tests for GhoulCreationForm.
 
+Tests cover:
+- Form initialization with user
+- Queryset setup for domitor field
+- Field configuration (required fields, placeholders)
+- Form validation with valid and invalid data
+- Owner assignment on save
+"""
+
+from characters.forms.vampire.ghoul import GhoulCreationForm
+from characters.models.core.archetype import Archetype
+from characters.models.vampire.clan import VampireClan
+from characters.models.vampire.ghoul import Ghoul
+from characters.models.vampire.vampire import Vampire
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class GhoulCreationFormTestCase(TestCase):
+    """Base test case with common setup for GhoulCreationForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create a clan
+        cls.ventrue = VampireClan.objects.create(
+            name="Ventrue",
+            nickname="Blue Bloods",
+        )
+
+        # Create archetypes
+        cls.survivor = Archetype.objects.create(name="Survivor")
+        cls.soldier = Archetype.objects.create(name="Soldier")
+
+    def setUp(self):
+        """Set up test user."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+        # Create potential domitor
+        self.domitor = Vampire.objects.create(
+            name="Lord Ventrue",
+            owner=self.user,
+            clan=self.ventrue,
+        )
+
+
+class TestGhoulCreationFormInitialization(GhoulCreationFormTestCase):
+    """Test form initialization."""
+
+    def test_form_initializes_with_user(self):
+        """Form initializes correctly with user parameter."""
+        form = GhoulCreationForm(user=self.user)
+        self.assertEqual(form.user, self.user)
+
+    def test_form_has_expected_fields(self):
+        """Form has all expected fields."""
+        form = GhoulCreationForm(user=self.user)
+        expected_fields = [
+            "name",
+            "nature",
+            "demeanor",
+            "concept",
+            "domitor",
+            "is_independent",
+            "chronicle",
+            "image",
+            "npc",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_domitor_queryset_empty_initially(self):
+        """Domitor queryset is empty when form is not bound."""
+        form = GhoulCreationForm(user=self.user)
+        domitor_qs = form.fields["domitor"].queryset
+        self.assertEqual(domitor_qs.count(), 0)
+
+
+class TestGhoulCreationFormFieldConfiguration(GhoulCreationFormTestCase):
+    """Test form field configuration."""
+
+    def test_name_has_placeholder(self):
+        """Name field has placeholder."""
+        form = GhoulCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("placeholder"),
+            "Enter name here",
+        )
+
+    def test_concept_has_placeholder(self):
+        """Concept field has placeholder."""
+        form = GhoulCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["concept"].widget.attrs.get("placeholder"),
+            "Enter concept here",
+        )
+
+    def test_image_not_required(self):
+        """Image field is not required."""
+        form = GhoulCreationForm(user=self.user)
+        self.assertFalse(form.fields["image"].required)
+
+    def test_domitor_not_required(self):
+        """Domitor field is not required."""
+        form = GhoulCreationForm(user=self.user)
+        self.assertFalse(form.fields["domitor"].required)
+
+
+class TestGhoulCreationFormBoundData(GhoulCreationFormTestCase):
+    """Test form behavior when bound with data."""
+
+    def test_domitor_queryset_populated_when_bound(self):
+        """Domitor queryset includes all vampires when form is bound."""
+        form = GhoulCreationForm(
+            data={
+                "name": "New Ghoul",
+                "concept": "Bodyguard",
+            },
+            user=self.user,
+        )
+        domitor_qs = form.fields["domitor"].queryset
+        self.assertIn(self.domitor, domitor_qs)
+
+
+class TestGhoulCreationFormValidation(GhoulCreationFormTestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal required data."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Test Ghoul",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Bodyguard",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_with_domitor(self):
+        """Valid submission with domitor specified."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Test Ghoul",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Bodyguard",
+                "domitor": str(self.domitor.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_independent_ghoul(self):
+        """Valid submission for independent ghoul."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Independent Ghoul",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Survivor",
+                "is_independent": True,
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_invalid_without_name(self):
+        """Form is invalid without name."""
+        form = GhoulCreationForm(
+            data={
+                "concept": "Bodyguard",
+            },
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+
+class TestGhoulCreationFormSave(GhoulCreationFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_assigns_owner(self):
+        """Saving form assigns owner to ghoul."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Test Ghoul",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Bodyguard",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        ghoul = form.save()
+        self.assertEqual(ghoul.owner, self.user)
+
+    def test_save_commit_false(self):
+        """Saving with commit=False returns unsaved instance."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Test Ghoul",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Bodyguard",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        ghoul = form.save(commit=False)
+        self.assertIsNone(ghoul.pk)
+        self.assertEqual(ghoul.owner, self.user)
+
+    def test_save_creates_ghoul_with_domitor(self):
+        """Saving form creates ghoul with correct domitor."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Marcus the Guard",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Trusted Bodyguard",
+                "domitor": str(self.domitor.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        ghoul = form.save()
+
+        self.assertEqual(ghoul.name, "Marcus the Guard")
+        self.assertEqual(ghoul.concept, "Trusted Bodyguard")
+        self.assertEqual(ghoul.domitor, self.domitor)
+        self.assertEqual(ghoul.owner, self.user)
+
+    def test_save_creates_independent_ghoul(self):
+        """Saving form creates independent ghoul correctly."""
+        form = GhoulCreationForm(
+            data={
+                "name": "Ancient Ghoul",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.soldier.pk),
+                "concept": "Survivor",
+                "is_independent": True,
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        ghoul = form.save()
+
+        self.assertEqual(ghoul.name, "Ancient Ghoul")
+        self.assertTrue(ghoul.is_independent)
+        self.assertIsNone(ghoul.domitor)

--- a/characters/tests/forms/vampire/test_revenant.py
+++ b/characters/tests/forms/vampire/test_revenant.py
@@ -1,5 +1,238 @@
-"""Tests for revenant module."""
+"""
+Tests for RevenantCreationForm.
 
+Tests cover:
+- Form initialization with user
+- Queryset setup for family field
+- Field configuration (required fields, placeholders)
+- Form validation with valid and invalid data
+- Owner assignment on save
+"""
+
+from characters.forms.vampire.revenant import RevenantCreationForm
+from characters.models.core.archetype import Archetype
+from characters.models.vampire.discipline import Discipline
+from characters.models.vampire.revenant import Revenant, RevenantFamily
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class RevenantCreationFormTestCase(TestCase):
+    """Base test case with common setup for RevenantCreationForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.fortitude = Discipline.objects.create(name="Fortitude", property_name="fortitude")
+        cls.vicissitude = Discipline.objects.create(name="Vicissitude", property_name="vicissitude")
+
+        # Create revenant families
+        cls.bratovich = RevenantFamily.objects.create(
+            name="Bratovich",
+            description="Brutal overseers and enforcers",
+            weakness="Sadistic tendencies",
+        )
+        cls.bratovich.disciplines.add(cls.potence, cls.fortitude, cls.vicissitude)
+
+        cls.grimaldi = RevenantFamily.objects.create(
+            name="Grimaldi",
+            description="Diplomats and spies",
+        )
+
+        # Create archetypes
+        cls.survivor = Archetype.objects.create(name="Survivor")
+        cls.brute = Archetype.objects.create(name="Brute")
+
+    def setUp(self):
+        """Set up test user."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+
+class TestRevenantCreationFormInitialization(RevenantCreationFormTestCase):
+    """Test form initialization."""
+
+    def test_form_initializes_with_user(self):
+        """Form initializes correctly with user parameter."""
+        form = RevenantCreationForm(user=self.user)
+        self.assertEqual(form.user, self.user)
+
+    def test_form_has_expected_fields(self):
+        """Form has all expected fields."""
+        form = RevenantCreationForm(user=self.user)
+        expected_fields = [
+            "name",
+            "nature",
+            "demeanor",
+            "concept",
+            "family",
+            "chronicle",
+            "image",
+            "npc",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_family_queryset_includes_all_families(self):
+        """Family queryset includes all revenant families."""
+        form = RevenantCreationForm(user=self.user)
+        family_qs = form.fields["family"].queryset
+        self.assertIn(self.bratovich, family_qs)
+        self.assertIn(self.grimaldi, family_qs)
+
+
+class TestRevenantCreationFormFieldConfiguration(RevenantCreationFormTestCase):
+    """Test form field configuration."""
+
+    def test_name_has_placeholder(self):
+        """Name field has placeholder."""
+        form = RevenantCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("placeholder"),
+            "Enter name here",
+        )
+
+    def test_concept_has_placeholder(self):
+        """Concept field has placeholder."""
+        form = RevenantCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["concept"].widget.attrs.get("placeholder"),
+            "Enter concept here",
+        )
+
+    def test_image_not_required(self):
+        """Image field is not required."""
+        form = RevenantCreationForm(user=self.user)
+        self.assertFalse(form.fields["image"].required)
+
+    def test_family_not_required(self):
+        """Family field is not required."""
+        form = RevenantCreationForm(user=self.user)
+        self.assertFalse(form.fields["family"].required)
+
+
+class TestRevenantCreationFormValidation(RevenantCreationFormTestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal required data."""
+        form = RevenantCreationForm(
+            data={
+                "name": "Test Revenant",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.brute.pk),
+                "concept": "Family Enforcer",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_with_family(self):
+        """Valid submission with family specified."""
+        form = RevenantCreationForm(
+            data={
+                "name": "Test Revenant",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.brute.pk),
+                "concept": "Family Enforcer",
+                "family": str(self.bratovich.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_invalid_without_name(self):
+        """Form is invalid without name."""
+        form = RevenantCreationForm(
+            data={
+                "concept": "Enforcer",
+            },
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+
+class TestRevenantCreationFormSave(RevenantCreationFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_assigns_owner(self):
+        """Saving form assigns owner to revenant."""
+        form = RevenantCreationForm(
+            data={
+                "name": "Test Revenant",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.brute.pk),
+                "concept": "Enforcer",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        revenant = form.save()
+        self.assertEqual(revenant.owner, self.user)
+
+    def test_save_commit_false(self):
+        """Saving with commit=False returns unsaved instance."""
+        form = RevenantCreationForm(
+            data={
+                "name": "Test Revenant",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.brute.pk),
+                "concept": "Enforcer",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        revenant = form.save(commit=False)
+        self.assertIsNone(revenant.pk)
+        self.assertEqual(revenant.owner, self.user)
+
+    def test_save_creates_revenant_with_family(self):
+        """Saving form creates revenant with correct family."""
+        form = RevenantCreationForm(
+            data={
+                "name": "Ivan Bratovich",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.brute.pk),
+                "concept": "Family Enforcer",
+                "family": str(self.bratovich.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        revenant = form.save()
+
+        self.assertEqual(revenant.name, "Ivan Bratovich")
+        self.assertEqual(revenant.concept, "Family Enforcer")
+        self.assertEqual(revenant.family, self.bratovich)
+        self.assertEqual(revenant.owner, self.user)
+
+    def test_save_creates_revenant_without_family(self):
+        """Saving form creates revenant without family (orphan)."""
+        form = RevenantCreationForm(
+            data={
+                "name": "Orphan Revenant",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.brute.pk),
+                "concept": "Lost One",
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        revenant = form.save()
+
+        self.assertEqual(revenant.name, "Orphan Revenant")
+        self.assertIsNone(revenant.family)

--- a/characters/tests/forms/vampire/test_vampire.py
+++ b/characters/tests/forms/vampire/test_vampire.py
@@ -1,5 +1,314 @@
-"""Tests for vampire module."""
+"""
+Tests for VampireCreationForm.
 
+Tests cover:
+- Form initialization with user
+- Queryset setup for clan, sect, path, sire fields
+- Field configuration (required fields, placeholders)
+- Form validation with valid and invalid data
+- Owner assignment on save
+"""
+
+from characters.forms.vampire.vampire import VampireCreationForm
+from characters.models.core.archetype import Archetype
+from characters.models.vampire.clan import VampireClan
+from characters.models.vampire.discipline import Discipline
+from characters.models.vampire.path import Path
+from characters.models.vampire.sect import VampireSect
+from characters.models.vampire.vampire import Vampire
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class VampireCreationFormTestCase(TestCase):
+    """Base test case with common setup for VampireCreationForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.celerity = Discipline.objects.create(name="Celerity", property_name="celerity")
+        cls.presence = Discipline.objects.create(name="Presence", property_name="presence")
+        cls.dominate = Discipline.objects.create(name="Dominate", property_name="dominate")
+
+        # Create clans
+        cls.brujah = VampireClan.objects.create(
+            name="Brujah",
+            nickname="Rabble",
+            is_bloodline=False,
+        )
+        cls.brujah.disciplines.add(cls.potence, cls.celerity, cls.presence)
+
+        cls.ventrue = VampireClan.objects.create(
+            name="Ventrue",
+            nickname="Blue Bloods",
+            is_bloodline=False,
+        )
+        cls.ventrue.disciplines.add(cls.dominate, cls.potence, cls.presence)
+
+        # Create a bloodline (should be excluded from default queryset)
+        cls.true_brujah = VampireClan.objects.create(
+            name="True Brujah",
+            is_bloodline=True,
+            parent_clan=cls.brujah,
+        )
+
+        # Create sects
+        cls.camarilla = VampireSect.objects.create(name="Camarilla")
+        cls.sabbat = VampireSect.objects.create(name="Sabbat")
+
+        # Create paths
+        cls.path_of_caine = Path.objects.create(
+            name="Path of Caine",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+
+        # Create archetypes
+        cls.survivor = Archetype.objects.create(name="Survivor")
+        cls.bravo = Archetype.objects.create(name="Bravo")
+
+    def setUp(self):
+        """Set up test user."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+
+class TestVampireCreationFormInitialization(VampireCreationFormTestCase):
+    """Test form initialization."""
+
+    def test_form_initializes_with_user(self):
+        """Form initializes correctly with user parameter."""
+        form = VampireCreationForm(user=self.user)
+        self.assertEqual(form.user, self.user)
+
+    def test_form_has_expected_fields(self):
+        """Form has all expected fields."""
+        form = VampireCreationForm(user=self.user)
+        expected_fields = [
+            "name",
+            "nature",
+            "demeanor",
+            "concept",
+            "clan",
+            "sect",
+            "sire",
+            "path",
+            "chronicle",
+            "image",
+            "npc",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_clan_queryset_excludes_bloodlines(self):
+        """Clan queryset only includes main clans, not bloodlines."""
+        form = VampireCreationForm(user=self.user)
+        clan_qs = form.fields["clan"].queryset
+        self.assertIn(self.brujah, clan_qs)
+        self.assertIn(self.ventrue, clan_qs)
+        self.assertNotIn(self.true_brujah, clan_qs)
+
+    def test_sect_queryset_includes_all_sects(self):
+        """Sect queryset includes all sects."""
+        form = VampireCreationForm(user=self.user)
+        sect_qs = form.fields["sect"].queryset
+        self.assertIn(self.camarilla, sect_qs)
+        self.assertIn(self.sabbat, sect_qs)
+
+    def test_path_queryset_includes_all_paths(self):
+        """Path queryset includes all paths."""
+        form = VampireCreationForm(user=self.user)
+        path_qs = form.fields["path"].queryset
+        self.assertIn(self.path_of_caine, path_qs)
+
+    def test_sire_queryset_empty_initially(self):
+        """Sire queryset is empty when form is not bound."""
+        form = VampireCreationForm(user=self.user)
+        sire_qs = form.fields["sire"].queryset
+        self.assertEqual(sire_qs.count(), 0)
+
+
+class TestVampireCreationFormFieldConfiguration(VampireCreationFormTestCase):
+    """Test form field configuration."""
+
+    def test_name_has_placeholder(self):
+        """Name field has placeholder."""
+        form = VampireCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("placeholder"),
+            "Enter name here",
+        )
+
+    def test_concept_has_placeholder(self):
+        """Concept field has placeholder."""
+        form = VampireCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["concept"].widget.attrs.get("placeholder"),
+            "Enter concept here",
+        )
+
+    def test_image_not_required(self):
+        """Image field is not required."""
+        form = VampireCreationForm(user=self.user)
+        self.assertFalse(form.fields["image"].required)
+
+    def test_sire_not_required(self):
+        """Sire field is not required."""
+        form = VampireCreationForm(user=self.user)
+        self.assertFalse(form.fields["sire"].required)
+
+    def test_path_not_required(self):
+        """Path field is not required."""
+        form = VampireCreationForm(user=self.user)
+        self.assertFalse(form.fields["path"].required)
+
+
+class TestVampireCreationFormBoundData(VampireCreationFormTestCase):
+    """Test form behavior when bound with data."""
+
+    def test_sire_queryset_populated_when_bound(self):
+        """Sire queryset includes all vampires when form is bound."""
+        # Create a potential sire
+        sire = Vampire.objects.create(
+            name="Elder Brujah",
+            owner=self.user,
+            clan=self.brujah,
+        )
+
+        form = VampireCreationForm(
+            data={
+                "name": "New Vampire",
+                "concept": "Warrior",
+            },
+            user=self.user,
+        )
+        sire_qs = form.fields["sire"].queryset
+        self.assertIn(sire, sire_qs)
+
+
+class TestVampireCreationFormValidation(VampireCreationFormTestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal required data."""
+        form = VampireCreationForm(
+            data={
+                "name": "Test Vampire",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.bravo.pk),
+                "concept": "Warrior",
+                "clan": str(self.brujah.pk),
+                "sect": str(self.camarilla.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_full_submission(self):
+        """Valid submission with all fields filled."""
+        sire = Vampire.objects.create(
+            name="Elder",
+            owner=self.user,
+            clan=self.brujah,
+        )
+
+        form = VampireCreationForm(
+            data={
+                "name": "Test Vampire",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.bravo.pk),
+                "concept": "Warrior",
+                "clan": str(self.brujah.pk),
+                "sect": str(self.camarilla.pk),
+                "sire": str(sire.pk),
+                "path": str(self.path_of_caine.pk),
+                "chronicle": str(self.chronicle.pk),
+                "npc": False,
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_invalid_without_name(self):
+        """Form is invalid without name."""
+        form = VampireCreationForm(
+            data={
+                "concept": "Warrior",
+                "clan": str(self.brujah.pk),
+            },
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+
+class TestVampireCreationFormSave(VampireCreationFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_assigns_owner(self):
+        """Saving form assigns owner to vampire."""
+        form = VampireCreationForm(
+            data={
+                "name": "Test Vampire",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.bravo.pk),
+                "concept": "Warrior",
+                "clan": str(self.brujah.pk),
+                "sect": str(self.camarilla.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        vampire = form.save()
+        self.assertEqual(vampire.owner, self.user)
+
+    def test_save_commit_false(self):
+        """Saving with commit=False returns unsaved instance."""
+        form = VampireCreationForm(
+            data={
+                "name": "Test Vampire",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.bravo.pk),
+                "concept": "Warrior",
+                "clan": str(self.brujah.pk),
+                "sect": str(self.camarilla.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        vampire = form.save(commit=False)
+        self.assertIsNone(vampire.pk)
+        self.assertEqual(vampire.owner, self.user)
+
+    def test_save_creates_vampire_with_correct_data(self):
+        """Saving form creates vampire with correct data."""
+        form = VampireCreationForm(
+            data={
+                "name": "Marcus Brujah",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.bravo.pk),
+                "concept": "Philosopher Warrior",
+                "clan": str(self.brujah.pk),
+                "sect": str(self.camarilla.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        vampire = form.save()
+
+        self.assertEqual(vampire.name, "Marcus Brujah")
+        self.assertEqual(vampire.concept, "Philosopher Warrior")
+        self.assertEqual(vampire.clan, self.brujah)
+        self.assertEqual(vampire.sect, self.camarilla)
+        self.assertEqual(vampire.owner, self.user)

--- a/characters/tests/models/vampire/test_ghoul.py
+++ b/characters/tests/models/vampire/test_ghoul.py
@@ -1,5 +1,283 @@
-"""Tests for ghoul module."""
+"""
+Tests for Ghoul model.
 
+Tests cover:
+- Ghoul creation and basic attributes
+- Blood pool limitations
+- Domitor relationship
+- Discipline tracking and costs
+- Independent ghoul mechanics
+"""
+
+from characters.models.vampire.clan import VampireClan
+from characters.models.vampire.discipline import Discipline
+from characters.models.vampire.ghoul import Ghoul
+from characters.models.vampire.vampire import Vampire
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class GhoulModelTestCase(TestCase):
+    """Base test case with common setup for Ghoul model tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.celerity = Discipline.objects.create(name="Celerity", property_name="celerity")
+        cls.fortitude = Discipline.objects.create(name="Fortitude", property_name="fortitude")
+        cls.dominate = Discipline.objects.create(name="Dominate", property_name="dominate")
+        cls.presence = Discipline.objects.create(name="Presence", property_name="presence")
+
+        # Create a clan
+        cls.ventrue = VampireClan.objects.create(
+            name="Ventrue",
+            nickname="Blue Bloods",
+        )
+        cls.ventrue.disciplines.add(cls.dominate, cls.fortitude, cls.presence)
+
+    def setUp(self):
+        """Set up test user and character."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+        # Create a domitor vampire
+        self.domitor = Vampire.objects.create(
+            name="Lord Ventrue",
+            owner=self.user,
+            clan=self.ventrue,
+            generation_rating=9,
+        )
+
+
+class TestGhoulCreation(GhoulModelTestCase):
+    """Test Ghoul model creation and basic attributes."""
+
+    def test_ghoul_creation_basic(self):
+        """Test basic ghoul creation."""
+        ghoul = Ghoul.objects.create(
+            name="Test Ghoul",
+            owner=self.user,
+            chronicle=self.chronicle,
+            concept="Bodyguard",
+        )
+        self.assertEqual(ghoul.name, "Test Ghoul")
+        self.assertEqual(ghoul.owner, self.user)
+        self.assertEqual(ghoul.concept, "Bodyguard")
+        self.assertEqual(ghoul.type, "ghoul")
+
+    def test_ghoul_default_blood_pool(self):
+        """Test that ghouls default to limited blood pool."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.blood_pool, 0)
+        self.assertEqual(ghoul.max_blood_pool, 2)
+
+    def test_ghoul_default_potence(self):
+        """Test that ghouls start with 1 dot of Potence."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.potence, 1)
+
+    def test_ghoul_default_other_disciplines(self):
+        """Test that ghouls default to 0 in other disciplines."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.celerity, 0)
+        self.assertEqual(ghoul.fortitude, 0)
+        self.assertEqual(ghoul.auspex, 0)
+        self.assertEqual(ghoul.dominate, 0)
+        self.assertEqual(ghoul.obfuscate, 0)
+        self.assertEqual(ghoul.presence, 0)
+
+    def test_ghoul_get_absolute_url(self):
+        """Test that get_absolute_url returns correct path."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        expected_url = f"/characters/vampire/ghoul/{ghoul.id}/"
+        self.assertEqual(ghoul.get_absolute_url(), expected_url)
+
+    def test_ghoul_get_update_url(self):
+        """Test that get_update_url returns correct path."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        expected_url = f"/characters/vampire/update/ghoul/{ghoul.pk}/"
+        self.assertEqual(ghoul.get_update_url(), expected_url)
+
+    def test_ghoul_get_creation_url(self):
+        """Test that get_creation_url returns correct path."""
+        expected_url = "/characters/vampire/create/ghoul/"
+        self.assertEqual(Ghoul.get_creation_url(), expected_url)
+
+    def test_ghoul_get_heading(self):
+        """Test that get_heading returns vtm_heading."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.get_heading(), "vtm_heading")
+
+
+class TestGhoulDomitor(GhoulModelTestCase):
+    """Test domitor relationship mechanics."""
+
+    def test_ghoul_can_have_domitor(self):
+        """Test that a ghoul can have a domitor."""
+        ghoul = Ghoul.objects.create(
+            name="Test Ghoul",
+            owner=self.user,
+            domitor=self.domitor,
+        )
+        self.assertEqual(ghoul.domitor, self.domitor)
+
+    def test_domitor_can_have_ghouls(self):
+        """Test that ghouls relationship is accessible from domitor."""
+        ghoul1 = Ghoul.objects.create(
+            name="Ghoul 1",
+            owner=self.user,
+            domitor=self.domitor,
+        )
+        ghoul2 = Ghoul.objects.create(
+            name="Ghoul 2",
+            owner=self.user,
+            domitor=self.domitor,
+        )
+        ghouls = list(self.domitor.ghouls.all())
+        self.assertEqual(len(ghouls), 2)
+        self.assertIn(ghoul1, ghouls)
+        self.assertIn(ghoul2, ghouls)
+
+    def test_ghoul_can_be_independent(self):
+        """Test that a ghoul can be independent."""
+        ghoul = Ghoul.objects.create(
+            name="Independent Ghoul",
+            owner=self.user,
+            is_independent=True,
+        )
+        self.assertTrue(ghoul.is_independent)
+        self.assertIsNone(ghoul.domitor)
+
+    def test_ghoul_independent_default_false(self):
+        """Test that is_independent defaults to False."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertFalse(ghoul.is_independent)
+
+
+class TestGhoulDisciplines(GhoulModelTestCase):
+    """Test discipline tracking and methods."""
+
+    def test_get_disciplines_includes_potence(self):
+        """Test get_disciplines includes default Potence."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        disciplines = ghoul.get_disciplines()
+        self.assertEqual(disciplines, {"Potence": 1})
+
+    def test_get_disciplines_with_multiple_ratings(self):
+        """Test get_disciplines returns only disciplines with ratings > 0."""
+        ghoul = Ghoul.objects.create(
+            name="Test",
+            owner=self.user,
+            potence=2,
+            celerity=1,
+            fortitude=0,  # Should not appear
+        )
+        disciplines = ghoul.get_disciplines()
+        self.assertEqual(disciplines, {"Potence": 2, "Celerity": 1})
+        self.assertNotIn("Fortitude", disciplines)
+
+    def test_get_available_disciplines_with_domitor(self):
+        """Test get_available_disciplines returns domitor's clan disciplines."""
+        ghoul = Ghoul.objects.create(
+            name="Test",
+            owner=self.user,
+            domitor=self.domitor,
+        )
+        available = ghoul.get_available_disciplines()
+        discipline_names = [d.name for d in available]
+        self.assertIn("Dominate", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+        self.assertIn("Presence", discipline_names)
+
+    def test_get_available_disciplines_independent(self):
+        """Test get_available_disciplines returns physical for independent ghouls."""
+        ghoul = Ghoul.objects.create(
+            name="Test",
+            owner=self.user,
+            is_independent=True,
+        )
+        available = ghoul.get_available_disciplines()
+        discipline_names = [d.name for d in available]
+        self.assertIn("Potence", discipline_names)
+        self.assertIn("Celerity", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+
+    def test_get_available_disciplines_no_domitor(self):
+        """Test get_available_disciplines returns physical without domitor."""
+        ghoul = Ghoul.objects.create(
+            name="Test",
+            owner=self.user,
+        )
+        available = ghoul.get_available_disciplines()
+        discipline_names = [d.name for d in available]
+        self.assertIn("Potence", discipline_names)
+        self.assertIn("Celerity", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+
+
+class TestGhoulFreebies(GhoulModelTestCase):
+    """Test freebie point costs."""
+
+    def test_freebie_cost_discipline(self):
+        """Test freebie cost for disciplines."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.freebie_cost("discipline"), 7)
+
+    def test_freebie_step(self):
+        """Test that ghouls have freebie_step of 6."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.freebie_step, 6)
+
+
+class TestGhoulAllowedBackgrounds(GhoulModelTestCase):
+    """Test allowed backgrounds for ghouls."""
+
+    def test_allowed_backgrounds_includes_contacts(self):
+        """Test that allowed_backgrounds includes contacts."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertIn("contacts", ghoul.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_mentor(self):
+        """Test that allowed_backgrounds includes mentor."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertIn("mentor", ghoul.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_resources(self):
+        """Test that allowed_backgrounds includes resources."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertIn("resources", ghoul.allowed_backgrounds)
+
+    def test_allowed_backgrounds_excludes_generation(self):
+        """Test that allowed_backgrounds excludes generation (vampire only)."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertNotIn("generation", ghoul.allowed_backgrounds)
+
+    def test_allowed_backgrounds_excludes_domain(self):
+        """Test that allowed_backgrounds excludes domain (vampire only)."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertNotIn("domain", ghoul.allowed_backgrounds)
+
+
+class TestGhoulYearsAsGhoul(GhoulModelTestCase):
+    """Test years as ghoul tracking."""
+
+    def test_years_as_ghoul_default(self):
+        """Test that years_as_ghoul defaults to 0."""
+        ghoul = Ghoul.objects.create(name="Test", owner=self.user)
+        self.assertEqual(ghoul.years_as_ghoul, 0)
+
+    def test_years_as_ghoul_can_be_set(self):
+        """Test that years_as_ghoul can be set."""
+        ghoul = Ghoul.objects.create(
+            name="Ancient Ghoul",
+            owner=self.user,
+            years_as_ghoul=150,
+        )
+        self.assertEqual(ghoul.years_as_ghoul, 150)

--- a/characters/tests/models/vampire/test_path.py
+++ b/characters/tests/models/vampire/test_path.py
@@ -1,5 +1,407 @@
-"""Tests for path module."""
+"""
+Tests for Path of Enlightenment model.
 
+Tests cover:
+- Path creation and basic attributes
+- Virtue requirements (Conviction/Conscience, Instinct/Self-Control)
+- Character virtue checking
+- Character virtue updating
+- Virtue display methods
+"""
+
+from characters.models.vampire.path import Path
+from characters.models.vampire.vampire import Vampire
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class PathModelTestCase(TestCase):
+    """Base test case with common setup for Path model tests."""
+
+    def setUp(self):
+        """Set up test user."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+
+
+class TestPathCreation(PathModelTestCase):
+    """Test Path model creation and basic attributes."""
+
+    def test_path_creation_basic(self):
+        """Test basic path creation."""
+        path = Path.objects.create(
+            name="Path of Caine",
+            ethics="Follow the ways of the First Vampire",
+        )
+        self.assertEqual(path.name, "Path of Caine")
+        self.assertEqual(path.ethics, "Follow the ways of the First Vampire")
+        self.assertEqual(path.type, "path")
+        self.assertEqual(path.gameline, "vtm")
+
+    def test_path_requires_conviction_default(self):
+        """Test that requires_conviction defaults to True."""
+        path = Path.objects.create(name="Test Path")
+        self.assertTrue(path.requires_conviction)
+
+    def test_path_requires_instinct_default(self):
+        """Test that requires_instinct defaults to True."""
+        path = Path.objects.create(name="Test Path")
+        self.assertTrue(path.requires_instinct)
+
+    def test_path_str(self):
+        """Test path string representation."""
+        path = Path.objects.create(name="Path of Honorable Accord")
+        self.assertEqual(str(path), "Path of Honorable Accord")
+
+    def test_path_get_absolute_url(self):
+        """Test that get_absolute_url returns correct path."""
+        path = Path.objects.create(name="Test Path")
+        expected_url = f"/characters/vampire/path/{path.id}/"
+        self.assertEqual(path.get_absolute_url(), expected_url)
+
+    def test_path_get_update_url(self):
+        """Test that get_update_url returns correct path."""
+        path = Path.objects.create(name="Test Path")
+        expected_url = f"/characters/vampire/update/path/{path.pk}/"
+        self.assertEqual(path.get_update_url(), expected_url)
+
+    def test_path_get_creation_url(self):
+        """Test that get_creation_url returns correct path."""
+        expected_url = "/characters/vampire/create/path/"
+        self.assertEqual(Path.get_creation_url(), expected_url)
+
+    def test_path_get_heading(self):
+        """Test that get_heading returns vtm_heading."""
+        path = Path.objects.create(name="Test Path")
+        self.assertEqual(path.get_heading(), "vtm_heading")
+
+
+class TestPathVirtueConfigurations(PathModelTestCase):
+    """Test different virtue requirement configurations."""
+
+    def test_path_conviction_instinct(self):
+        """Test path requiring Conviction and Instinct."""
+        path = Path.objects.create(
+            name="Path of Caine",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        self.assertTrue(path.requires_conviction)
+        self.assertTrue(path.requires_instinct)
+
+    def test_path_conviction_self_control(self):
+        """Test path requiring Conviction and Self-Control."""
+        path = Path.objects.create(
+            name="Path of the Feral Heart",
+            requires_conviction=True,
+            requires_instinct=False,
+        )
+        self.assertTrue(path.requires_conviction)
+        self.assertFalse(path.requires_instinct)
+
+    def test_path_conscience_instinct(self):
+        """Test path requiring Conscience and Instinct."""
+        path = Path.objects.create(
+            name="Path of Cathari",
+            requires_conviction=False,
+            requires_instinct=True,
+        )
+        self.assertFalse(path.requires_conviction)
+        self.assertTrue(path.requires_instinct)
+
+    def test_path_conscience_self_control(self):
+        """Test path requiring Conscience and Self-Control (like Humanity)."""
+        path = Path.objects.create(
+            name="Path of Humanity",
+            requires_conviction=False,
+            requires_instinct=False,
+        )
+        self.assertFalse(path.requires_conviction)
+        self.assertFalse(path.requires_instinct)
+
+
+class TestPathCheckCharacterVirtues(PathModelTestCase):
+    """Test check_character_virtues method."""
+
+    def test_check_virtues_matching_conviction_instinct(self):
+        """Test check_character_virtues returns True when virtues match."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=True,
+            has_instinct=True,
+        )
+        self.assertTrue(path.check_character_virtues(vampire))
+
+    def test_check_virtues_matching_conscience_self_control(self):
+        """Test check_character_virtues for Humanity-like path."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=False,
+            requires_instinct=False,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            has_instinct=False,
+        )
+        self.assertTrue(path.check_character_virtues(vampire))
+
+    def test_check_virtues_mismatched_first_virtue(self):
+        """Test check_character_virtues returns False when first virtue mismatched."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,  # Mismatch
+            has_instinct=True,
+        )
+        self.assertFalse(path.check_character_virtues(vampire))
+
+    def test_check_virtues_mismatched_second_virtue(self):
+        """Test check_character_virtues returns False when second virtue mismatched."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=True,
+            has_instinct=False,  # Mismatch
+        )
+        self.assertFalse(path.check_character_virtues(vampire))
+
+    def test_check_virtues_both_mismatched(self):
+        """Test check_character_virtues returns False when both virtues mismatched."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            has_instinct=False,
+        )
+        self.assertFalse(path.check_character_virtues(vampire))
+
+
+class TestPathUpdateCharacterVirtues(PathModelTestCase):
+    """Test update_character_virtues method."""
+
+    def test_update_virtues_to_conviction(self):
+        """Test updating character from Conscience to Conviction."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=False,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            conscience=3,
+        )
+
+        changed = path.update_character_virtues(vampire)
+
+        self.assertTrue(changed)
+        self.assertTrue(vampire.has_conviction)
+        self.assertEqual(vampire.conscience, 0)  # Reset
+
+    def test_update_virtues_to_conscience(self):
+        """Test updating character from Conviction to Conscience."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=False,
+            requires_instinct=False,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=True,
+            conviction=4,
+        )
+
+        changed = path.update_character_virtues(vampire)
+
+        self.assertTrue(changed)
+        self.assertFalse(vampire.has_conviction)
+        self.assertEqual(vampire.conviction, 0)  # Reset
+
+    def test_update_virtues_to_instinct(self):
+        """Test updating character from Self-Control to Instinct."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=False,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_instinct=False,
+            self_control=3,
+        )
+
+        changed = path.update_character_virtues(vampire)
+
+        self.assertTrue(changed)
+        self.assertTrue(vampire.has_instinct)
+        self.assertEqual(vampire.self_control, 0)  # Reset
+
+    def test_update_virtues_to_self_control(self):
+        """Test updating character from Instinct to Self-Control."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=False,
+            requires_instinct=False,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_instinct=True,
+            instinct=4,
+        )
+
+        changed = path.update_character_virtues(vampire)
+
+        self.assertTrue(changed)
+        self.assertFalse(vampire.has_instinct)
+        self.assertEqual(vampire.instinct, 0)  # Reset
+
+    def test_update_virtues_no_change_needed(self):
+        """Test update_character_virtues returns False when no change needed."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=True,
+            has_instinct=True,
+        )
+
+        changed = path.update_character_virtues(vampire)
+
+        self.assertFalse(changed)
+
+    def test_update_virtues_both_changed(self):
+        """Test updating both virtue pairs."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            has_instinct=False,
+            conscience=3,
+            self_control=4,
+        )
+
+        changed = path.update_character_virtues(vampire)
+
+        self.assertTrue(changed)
+        self.assertTrue(vampire.has_conviction)
+        self.assertTrue(vampire.has_instinct)
+        self.assertEqual(vampire.conscience, 0)
+        self.assertEqual(vampire.self_control, 0)
+
+
+class TestPathGetVirtuesDisplay(PathModelTestCase):
+    """Test get_virtues_display method."""
+
+    def test_get_virtues_display_conviction_instinct(self):
+        """Test virtue display for Conviction and Instinct."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=True,
+        )
+        self.assertEqual(path.get_virtues_display(), "Conviction and Instinct")
+
+    def test_get_virtues_display_conviction_self_control(self):
+        """Test virtue display for Conviction and Self-Control."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=True,
+            requires_instinct=False,
+        )
+        self.assertEqual(path.get_virtues_display(), "Conviction and Self-Control")
+
+    def test_get_virtues_display_conscience_instinct(self):
+        """Test virtue display for Conscience and Instinct."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=False,
+            requires_instinct=True,
+        )
+        self.assertEqual(path.get_virtues_display(), "Conscience and Instinct")
+
+    def test_get_virtues_display_conscience_self_control(self):
+        """Test virtue display for Conscience and Self-Control."""
+        path = Path.objects.create(
+            name="Test",
+            requires_conviction=False,
+            requires_instinct=False,
+        )
+        self.assertEqual(path.get_virtues_display(), "Conscience and Self-Control")
+
+
+class TestPathOrdering(PathModelTestCase):
+    """Test Path model ordering."""
+
+    def test_paths_ordered_by_name(self):
+        """Test that paths are ordered by name."""
+        path_c = Path.objects.create(name="Path of Cathari")
+        path_a = Path.objects.create(name="Path of Asakku")
+        path_b = Path.objects.create(name="Path of Blood")
+
+        paths = list(Path.objects.all())
+        self.assertEqual(paths[0], path_a)
+        self.assertEqual(paths[1], path_b)
+        self.assertEqual(paths[2], path_c)
+
+
+class TestPathFollowers(PathModelTestCase):
+    """Test followers relationship."""
+
+    def test_path_can_have_followers(self):
+        """Test that followers relationship is accessible."""
+        path = Path.objects.create(name="Path of Caine")
+
+        vampire1 = Vampire.objects.create(
+            name="Follower 1",
+            owner=self.user,
+            path=path,
+        )
+        vampire2 = Vampire.objects.create(
+            name="Follower 2",
+            owner=self.user,
+            path=path,
+        )
+
+        followers = list(path.followers.all())
+        self.assertEqual(len(followers), 2)
+        self.assertIn(vampire1, followers)
+        self.assertIn(vampire2, followers)

--- a/characters/tests/models/vampire/test_revenant.py
+++ b/characters/tests/models/vampire/test_revenant.py
@@ -1,5 +1,322 @@
-"""Tests for revenant module."""
+"""
+Tests for Revenant and RevenantFamily models.
 
+Tests cover:
+- RevenantFamily creation and attributes
+- Revenant creation and basic attributes
+- Blood pool mechanics (natural vitae production)
+- Pseudo-generation
+- Family discipline access
+- Family flaw tracking
+"""
+
+from characters.models.vampire.discipline import Discipline
+from characters.models.vampire.revenant import Revenant, RevenantFamily
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class RevenantModelTestCase(TestCase):
+    """Base test case with common setup for Revenant model tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.celerity = Discipline.objects.create(name="Celerity", property_name="celerity")
+        cls.fortitude = Discipline.objects.create(name="Fortitude", property_name="fortitude")
+        cls.dominate = Discipline.objects.create(name="Dominate", property_name="dominate")
+        cls.animalism = Discipline.objects.create(name="Animalism", property_name="animalism")
+        cls.vicissitude = Discipline.objects.create(name="Vicissitude", property_name="vicissitude")
+
+        # Create revenant families
+        cls.bratovich = RevenantFamily.objects.create(
+            name="Bratovich",
+            description="Brutal overseers and enforcers",
+            weakness="Sadistic tendencies",
+        )
+        cls.bratovich.disciplines.add(cls.potence, cls.fortitude, cls.vicissitude)
+
+        cls.grimaldi = RevenantFamily.objects.create(
+            name="Grimaldi",
+            description="Diplomats and spies",
+            weakness="Scheming nature",
+        )
+        cls.grimaldi.disciplines.add(cls.dominate, cls.fortitude, cls.celerity)
+
+    def setUp(self):
+        """Set up test user and character."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+
+class TestRevenantFamilyCreation(RevenantModelTestCase):
+    """Test RevenantFamily model creation and attributes."""
+
+    def test_family_creation_basic(self):
+        """Test basic revenant family creation."""
+        family = RevenantFamily.objects.create(
+            name="Test Family",
+            description="A test family of revenants",
+            weakness="Test weakness",
+        )
+        self.assertEqual(family.name, "Test Family")
+        self.assertEqual(family.description, "A test family of revenants")
+        self.assertEqual(family.weakness, "Test weakness")
+
+    def test_family_str(self):
+        """Test family string representation."""
+        self.assertEqual(str(self.bratovich), "Bratovich")
+
+    def test_family_has_disciplines(self):
+        """Test that families can have disciplines."""
+        disciplines = list(self.bratovich.disciplines.all())
+        discipline_names = [d.name for d in disciplines]
+        self.assertIn("Potence", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+        self.assertIn("Vicissitude", discipline_names)
+
+    def test_family_get_absolute_url(self):
+        """Test that get_absolute_url returns correct path."""
+        expected_url = f"/characters/vampire/revenant_family/{self.bratovich.id}/"
+        self.assertEqual(self.bratovich.get_absolute_url(), expected_url)
+
+    def test_family_get_update_url(self):
+        """Test that get_update_url returns correct path."""
+        expected_url = f"/characters/vampire/update/revenant_family/{self.bratovich.pk}/"
+        self.assertEqual(self.bratovich.get_update_url(), expected_url)
+
+    def test_family_get_creation_url(self):
+        """Test that get_creation_url returns correct path."""
+        expected_url = "/characters/vampire/create/revenant_family/"
+        self.assertEqual(RevenantFamily.get_creation_url(), expected_url)
+
+
+class TestRevenantCreation(RevenantModelTestCase):
+    """Test Revenant model creation and basic attributes."""
+
+    def test_revenant_creation_basic(self):
+        """Test basic revenant creation."""
+        revenant = Revenant.objects.create(
+            name="Test Revenant",
+            owner=self.user,
+            chronicle=self.chronicle,
+            concept="Family enforcer",
+        )
+        self.assertEqual(revenant.name, "Test Revenant")
+        self.assertEqual(revenant.owner, self.user)
+        self.assertEqual(revenant.concept, "Family enforcer")
+        self.assertEqual(revenant.type, "revenant")
+
+    def test_revenant_default_blood_pool(self):
+        """Test that revenants default to 10 blood pool (natural vitae)."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.blood_pool, 10)
+        self.assertEqual(revenant.max_blood_pool, 10)
+
+    def test_revenant_default_pseudo_generation(self):
+        """Test that pseudo_generation defaults to 10."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.pseudo_generation, 10)
+
+    def test_revenant_can_have_family(self):
+        """Test that a revenant can have a family."""
+        revenant = Revenant.objects.create(
+            name="Test",
+            owner=self.user,
+            family=self.bratovich,
+        )
+        self.assertEqual(revenant.family, self.bratovich)
+
+    def test_revenant_get_absolute_url(self):
+        """Test that get_absolute_url returns correct path."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        expected_url = f"/characters/vampire/revenant/{revenant.id}/"
+        self.assertEqual(revenant.get_absolute_url(), expected_url)
+
+    def test_revenant_get_update_url(self):
+        """Test that get_update_url returns correct path."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        expected_url = f"/characters/vampire/update/revenant/{revenant.pk}/"
+        self.assertEqual(revenant.get_update_url(), expected_url)
+
+    def test_revenant_get_creation_url(self):
+        """Test that get_creation_url returns correct path."""
+        expected_url = "/characters/vampire/create/revenant/"
+        self.assertEqual(Revenant.get_creation_url(), expected_url)
+
+    def test_revenant_get_heading(self):
+        """Test that get_heading returns vtm_heading."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.get_heading(), "vtm_heading")
+
+
+class TestRevenantDisciplines(RevenantModelTestCase):
+    """Test discipline tracking and methods."""
+
+    def test_get_disciplines_empty(self):
+        """Test get_disciplines with no disciplines."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        disciplines = revenant.get_disciplines()
+        self.assertEqual(disciplines, {})
+
+    def test_get_disciplines_with_ratings(self):
+        """Test get_disciplines returns only disciplines with ratings > 0."""
+        revenant = Revenant.objects.create(
+            name="Test",
+            owner=self.user,
+            potence=2,
+            fortitude=1,
+            celerity=0,  # Should not appear
+        )
+        disciplines = revenant.get_disciplines()
+        self.assertEqual(disciplines, {"Potence": 2, "Fortitude": 1})
+        self.assertNotIn("Celerity", disciplines)
+
+    def test_get_family_disciplines_with_family(self):
+        """Test get_family_disciplines returns family disciplines."""
+        revenant = Revenant.objects.create(
+            name="Test",
+            owner=self.user,
+            family=self.bratovich,
+        )
+        family_disciplines = revenant.get_family_disciplines()
+        discipline_names = [d.name for d in family_disciplines]
+        self.assertIn("Potence", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+        self.assertIn("Vicissitude", discipline_names)
+
+    def test_get_family_disciplines_without_family(self):
+        """Test get_family_disciplines returns empty list without family."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        family_disciplines = revenant.get_family_disciplines()
+        self.assertEqual(family_disciplines, [])
+
+    def test_get_available_disciplines_with_family(self):
+        """Test get_available_disciplines returns family disciplines."""
+        revenant = Revenant.objects.create(
+            name="Test",
+            owner=self.user,
+            family=self.grimaldi,
+        )
+        available = revenant.get_available_disciplines()
+        discipline_names = [d.name for d in available]
+        self.assertIn("Dominate", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+        self.assertIn("Celerity", discipline_names)
+
+    def test_get_available_disciplines_without_family(self):
+        """Test get_available_disciplines returns physical without family."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        available = revenant.get_available_disciplines()
+        discipline_names = [d.name for d in available]
+        self.assertIn("Potence", discipline_names)
+        self.assertIn("Celerity", discipline_names)
+        self.assertIn("Fortitude", discipline_names)
+
+
+class TestRevenantFreebies(RevenantModelTestCase):
+    """Test freebie point costs."""
+
+    def test_freebie_cost_discipline(self):
+        """Test freebie cost for in-family disciplines."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.freebie_cost("discipline"), 7)
+
+    def test_freebie_cost_out_of_family_discipline(self):
+        """Test freebie cost for out-of-family disciplines."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.freebie_cost("out_of_family_discipline"), 10)
+
+    def test_freebie_step(self):
+        """Test that revenants have freebie_step of 6."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.freebie_step, 6)
+
+
+class TestRevenantAllowedBackgrounds(RevenantModelTestCase):
+    """Test allowed backgrounds for revenants."""
+
+    def test_allowed_backgrounds_includes_contacts(self):
+        """Test that allowed_backgrounds includes contacts."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertIn("contacts", revenant.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_resources(self):
+        """Test that allowed_backgrounds includes resources."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertIn("resources", revenant.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_generation(self):
+        """Test that allowed_backgrounds includes generation (pseudo-generation)."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertIn("generation", revenant.allowed_backgrounds)
+
+    def test_allowed_backgrounds_excludes_domain(self):
+        """Test that allowed_backgrounds excludes domain."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertNotIn("domain", revenant.allowed_backgrounds)
+
+
+class TestRevenantFamilyFlaw(RevenantModelTestCase):
+    """Test family flaw tracking."""
+
+    def test_family_flaw_can_be_set(self):
+        """Test that family_flaw can be set."""
+        revenant = Revenant.objects.create(
+            name="Test",
+            owner=self.user,
+            family=self.bratovich,
+            family_flaw="Enjoys causing pain",
+        )
+        self.assertEqual(revenant.family_flaw, "Enjoys causing pain")
+
+    def test_family_flaw_defaults_empty(self):
+        """Test that family_flaw defaults to empty string."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.family_flaw, "")
+
+
+class TestRevenantAge(RevenantModelTestCase):
+    """Test age tracking for revenants."""
+
+    def test_actual_age_default(self):
+        """Test that actual_age defaults to 0."""
+        revenant = Revenant.objects.create(name="Test", owner=self.user)
+        self.assertEqual(revenant.actual_age, 0)
+
+    def test_actual_age_can_be_set(self):
+        """Test that actual_age can be set."""
+        revenant = Revenant.objects.create(
+            name="Ancient Revenant",
+            owner=self.user,
+            actual_age=200,
+        )
+        self.assertEqual(revenant.actual_age, 200)
+
+
+class TestRevenantFamilyRevenants(RevenantModelTestCase):
+    """Test family-revenants relationship."""
+
+    def test_family_can_have_revenants(self):
+        """Test that revenants relationship is accessible from family."""
+        rev1 = Revenant.objects.create(
+            name="Rev 1",
+            owner=self.user,
+            family=self.bratovich,
+        )
+        rev2 = Revenant.objects.create(
+            name="Rev 2",
+            owner=self.user,
+            family=self.bratovich,
+        )
+        revenants = list(self.bratovich.revenants.all())
+        self.assertEqual(len(revenants), 2)
+        self.assertIn(rev1, revenants)
+        self.assertIn(rev2, revenants)

--- a/characters/tests/models/vampire/test_vampire.py
+++ b/characters/tests/models/vampire/test_vampire.py
@@ -1,5 +1,677 @@
-"""Tests for vampire module."""
+"""
+Tests for Vampire model.
 
+Tests cover:
+- Vampire creation and basic attributes
+- Generation effects (blood pool, blood per turn)
+- Discipline tracking and costs
+- Virtue system (active virtues, setting virtues)
+- Freebie costs and spending
+- XP costs and spending
+"""
+
+from characters.models.vampire.clan import VampireClan
+from characters.models.vampire.discipline import Discipline
+from characters.models.vampire.path import Path
+from characters.models.vampire.sect import VampireSect
+from characters.models.vampire.vampire import Vampire
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class VampireModelTestCase(TestCase):
+    """Base test case with common setup for Vampire model tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        # Create disciplines
+        cls.potence = Discipline.objects.create(name="Potence", property_name="potence")
+        cls.celerity = Discipline.objects.create(name="Celerity", property_name="celerity")
+        cls.fortitude = Discipline.objects.create(name="Fortitude", property_name="fortitude")
+        cls.dominate = Discipline.objects.create(name="Dominate", property_name="dominate")
+        cls.presence = Discipline.objects.create(name="Presence", property_name="presence")
+        cls.auspex = Discipline.objects.create(name="Auspex", property_name="auspex")
+
+        # Create a clan with disciplines
+        cls.brujah = VampireClan.objects.create(
+            name="Brujah",
+            nickname="Rabble",
+            weakness="Prone to frenzy",
+        )
+        cls.brujah.disciplines.add(cls.potence, cls.celerity, cls.presence)
+
+        cls.ventrue = VampireClan.objects.create(
+            name="Ventrue",
+            nickname="Blue Bloods",
+            weakness="Refined palate",
+        )
+        cls.ventrue.disciplines.add(cls.dominate, cls.fortitude, cls.presence)
+
+        # Create a sect
+        cls.camarilla = VampireSect.objects.create(name="Camarilla")
+
+        # Create a path of enlightenment
+        cls.path_of_caine = Path.objects.create(
+            name="Path of Caine",
+            requires_conviction=True,
+            requires_instinct=True,
+            ethics="Follow the ways of the First Vampire",
+        )
+
+    def setUp(self):
+        """Set up test user and character."""
+        self.user = User.objects.create_user(
+            username="testuser",
+            email="test@test.com",
+            password="testpassword",
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+
+class TestVampireCreation(VampireModelTestCase):
+    """Test Vampire model creation and basic attributes."""
+
+    def test_vampire_creation_basic(self):
+        """Test basic vampire creation."""
+        vampire = Vampire.objects.create(
+            name="Test Vampire",
+            owner=self.user,
+            chronicle=self.chronicle,
+            concept="Warrior",
+        )
+        self.assertEqual(vampire.name, "Test Vampire")
+        self.assertEqual(vampire.owner, self.user)
+        self.assertEqual(vampire.concept, "Warrior")
+        self.assertEqual(vampire.type, "vampire")
+
+    def test_vampire_default_generation(self):
+        """Test that new vampires default to 13th generation."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.generation_rating, 13)
+
+    def test_vampire_default_blood_pool(self):
+        """Test that default blood pool matches 13th generation."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.max_blood_pool, 10)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_vampire_default_virtues(self):
+        """Test default virtue configuration (Humanity with Conscience/Self-Control)."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertFalse(vampire.has_conviction)
+        self.assertFalse(vampire.has_instinct)
+        self.assertEqual(vampire.conscience, 1)
+        self.assertEqual(vampire.self_control, 1)
+        self.assertEqual(vampire.courage, 1)
+        self.assertEqual(vampire.humanity, 7)
+
+    def test_vampire_can_have_clan(self):
+        """Test assigning a clan to a vampire."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            clan=self.brujah,
+        )
+        self.assertEqual(vampire.clan, self.brujah)
+
+    def test_vampire_can_have_sect(self):
+        """Test assigning a sect to a vampire."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            sect=self.camarilla,
+        )
+        self.assertEqual(vampire.sect, self.camarilla)
+
+    def test_vampire_get_absolute_url(self):
+        """Test that get_absolute_url returns correct path."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        expected_url = f"/characters/vampire/vampire/{vampire.id}/"
+        self.assertEqual(vampire.get_absolute_url(), expected_url)
+
+    def test_vampire_get_update_url(self):
+        """Test that get_update_url returns correct path."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        expected_url = f"/characters/vampire/update/vampire/{vampire.pk}/"
+        self.assertEqual(vampire.get_update_url(), expected_url)
+
+    def test_vampire_get_creation_url(self):
+        """Test that get_creation_url returns correct path."""
+        expected_url = "/characters/vampire/create/vampire/"
+        self.assertEqual(Vampire.get_creation_url(), expected_url)
+
+    def test_vampire_get_heading(self):
+        """Test that get_heading returns vtm_heading."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.get_heading(), "vtm_heading")
+
+
+class TestVampireGenerationEffects(VampireModelTestCase):
+    """Test generation-dependent values (blood pool, blood per turn)."""
+
+    def test_generation_3_blood_pool(self):
+        """Test 3rd generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Antediluvian",
+            owner=self.user,
+            generation_rating=3,
+        )
+        self.assertEqual(vampire.max_blood_pool, 50)
+        self.assertEqual(vampire.blood_per_turn, 10)
+
+    def test_generation_4_blood_pool(self):
+        """Test 4th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Methuselah",
+            owner=self.user,
+            generation_rating=4,
+        )
+        self.assertEqual(vampire.max_blood_pool, 50)
+        self.assertEqual(vampire.blood_per_turn, 10)
+
+    def test_generation_5_blood_pool(self):
+        """Test 5th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Elder",
+            owner=self.user,
+            generation_rating=5,
+        )
+        self.assertEqual(vampire.max_blood_pool, 40)
+        self.assertEqual(vampire.blood_per_turn, 8)
+
+    def test_generation_6_blood_pool(self):
+        """Test 6th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Elder",
+            owner=self.user,
+            generation_rating=6,
+        )
+        self.assertEqual(vampire.max_blood_pool, 30)
+        self.assertEqual(vampire.blood_per_turn, 6)
+
+    def test_generation_7_blood_pool(self):
+        """Test 7th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Elder",
+            owner=self.user,
+            generation_rating=7,
+        )
+        self.assertEqual(vampire.max_blood_pool, 20)
+        self.assertEqual(vampire.blood_per_turn, 4)
+
+    def test_generation_8_blood_pool(self):
+        """Test 8th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Ancilla",
+            owner=self.user,
+            generation_rating=8,
+        )
+        self.assertEqual(vampire.max_blood_pool, 15)
+        self.assertEqual(vampire.blood_per_turn, 3)
+
+    def test_generation_9_blood_pool(self):
+        """Test 9th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Ancilla",
+            owner=self.user,
+            generation_rating=9,
+        )
+        self.assertEqual(vampire.max_blood_pool, 14)
+        self.assertEqual(vampire.blood_per_turn, 2)
+
+    def test_generation_10_blood_pool(self):
+        """Test 10th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Neonate",
+            owner=self.user,
+            generation_rating=10,
+        )
+        self.assertEqual(vampire.max_blood_pool, 13)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_generation_11_blood_pool(self):
+        """Test 11th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Neonate",
+            owner=self.user,
+            generation_rating=11,
+        )
+        self.assertEqual(vampire.max_blood_pool, 12)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_generation_12_blood_pool(self):
+        """Test 12th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Neonate",
+            owner=self.user,
+            generation_rating=12,
+        )
+        self.assertEqual(vampire.max_blood_pool, 11)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_generation_13_blood_pool(self):
+        """Test 13th generation blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Fledgling",
+            owner=self.user,
+            generation_rating=13,
+        )
+        self.assertEqual(vampire.max_blood_pool, 10)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_generation_14_blood_pool(self):
+        """Test 14th generation (thin-blood) blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Thin-Blood",
+            owner=self.user,
+            generation_rating=14,
+        )
+        self.assertEqual(vampire.max_blood_pool, 10)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_generation_15_blood_pool(self):
+        """Test 15th generation (thin-blood) blood pool values."""
+        vampire = Vampire.objects.create(
+            name="Thin-Blood",
+            owner=self.user,
+            generation_rating=15,
+        )
+        self.assertEqual(vampire.max_blood_pool, 10)
+        self.assertEqual(vampire.blood_per_turn, 1)
+
+    def test_generation_change_updates_blood_pool(self):
+        """Test that changing generation updates blood pool on save."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            generation_rating=13,
+        )
+        self.assertEqual(vampire.max_blood_pool, 10)
+
+        vampire.generation_rating = 8
+        vampire.save()
+        vampire.refresh_from_db()
+
+        self.assertEqual(vampire.max_blood_pool, 15)
+        self.assertEqual(vampire.blood_per_turn, 3)
+
+
+class TestVampireDisciplines(VampireModelTestCase):
+    """Test discipline tracking and methods."""
+
+    def test_get_disciplines_empty(self):
+        """Test get_disciplines with no disciplines."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        disciplines = vampire.get_disciplines()
+        self.assertEqual(disciplines, {})
+
+    def test_get_disciplines_with_ratings(self):
+        """Test get_disciplines returns only disciplines with ratings > 0."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            potence=3,
+            celerity=2,
+            fortitude=0,  # Should not appear
+        )
+        disciplines = vampire.get_disciplines()
+        self.assertEqual(disciplines, {"Potence": 3, "Celerity": 2})
+        self.assertNotIn("Fortitude", disciplines)
+
+    def test_get_clan_disciplines_with_clan(self):
+        """Test get_clan_disciplines returns clan disciplines."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            clan=self.brujah,
+        )
+        clan_disciplines = vampire.get_clan_disciplines()
+        discipline_names = [d.name for d in clan_disciplines]
+        self.assertIn("Potence", discipline_names)
+        self.assertIn("Celerity", discipline_names)
+        self.assertIn("Presence", discipline_names)
+
+    def test_get_clan_disciplines_without_clan(self):
+        """Test get_clan_disciplines returns empty list without clan."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        clan_disciplines = vampire.get_clan_disciplines()
+        self.assertEqual(clan_disciplines, [])
+
+    def test_is_clan_discipline_true(self):
+        """Test is_clan_discipline returns True for in-clan discipline."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            clan=self.brujah,
+        )
+        self.assertTrue(vampire.is_clan_discipline(self.potence))
+        self.assertTrue(vampire.is_clan_discipline("potence"))
+
+    def test_is_clan_discipline_false(self):
+        """Test is_clan_discipline returns False for out-of-clan discipline."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            clan=self.brujah,
+        )
+        self.assertFalse(vampire.is_clan_discipline(self.dominate))
+        self.assertFalse(vampire.is_clan_discipline("dominate"))
+
+    def test_is_clan_discipline_no_clan(self):
+        """Test is_clan_discipline returns False without clan."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertFalse(vampire.is_clan_discipline(self.potence))
+
+
+class TestVampireVirtues(VampireModelTestCase):
+    """Test virtue system and properties."""
+
+    def test_active_virtue_1_conscience(self):
+        """Test active_virtue_1 returns Conscience when has_conviction is False."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            conscience=3,
+            conviction=2,
+        )
+        self.assertEqual(vampire.active_virtue_1, 3)
+        self.assertEqual(vampire.active_virtue_1_name, "Conscience")
+
+    def test_active_virtue_1_conviction(self):
+        """Test active_virtue_1 returns Conviction when has_conviction is True."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=True,
+            conscience=3,
+            conviction=4,
+        )
+        self.assertEqual(vampire.active_virtue_1, 4)
+        self.assertEqual(vampire.active_virtue_1_name, "Conviction")
+
+    def test_active_virtue_2_self_control(self):
+        """Test active_virtue_2 returns Self-Control when has_instinct is False."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_instinct=False,
+            self_control=3,
+            instinct=2,
+        )
+        self.assertEqual(vampire.active_virtue_2, 3)
+        self.assertEqual(vampire.active_virtue_2_name, "Self-Control")
+
+    def test_active_virtue_2_instinct(self):
+        """Test active_virtue_2 returns Instinct when has_instinct is True."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_instinct=True,
+            self_control=3,
+            instinct=4,
+        )
+        self.assertEqual(vampire.active_virtue_2, 4)
+        self.assertEqual(vampire.active_virtue_2_name, "Instinct")
+
+    def test_get_active_virtues_humanity(self):
+        """Test get_active_virtues for Humanity character."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            has_instinct=False,
+            conscience=3,
+            self_control=2,
+            courage=4,
+        )
+        virtues = vampire.get_active_virtues()
+        self.assertEqual(virtues, {
+            "Conscience": 3,
+            "Self-Control": 2,
+            "Courage": 4,
+        })
+
+    def test_get_active_virtues_path(self):
+        """Test get_active_virtues for Path follower."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=True,
+            has_instinct=True,
+            conviction=4,
+            instinct=3,
+            courage=2,
+        )
+        virtues = vampire.get_active_virtues()
+        self.assertEqual(virtues, {
+            "Conviction": 4,
+            "Instinct": 3,
+            "Courage": 2,
+        })
+
+    def test_set_virtue_by_name_valid(self):
+        """Test set_virtue_by_name with valid virtue names."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+
+        vampire.set_virtue_by_name("conscience", 4)
+        self.assertEqual(vampire.conscience, 4)
+
+        vampire.set_virtue_by_name("Conviction", 3)
+        self.assertEqual(vampire.conviction, 3)
+
+        vampire.set_virtue_by_name("SELF_CONTROL", 5)
+        self.assertEqual(vampire.self_control, 5)
+
+        vampire.set_virtue_by_name("instinct", 2)
+        self.assertEqual(vampire.instinct, 2)
+
+        vampire.set_virtue_by_name("Courage", 4)
+        self.assertEqual(vampire.courage, 4)
+
+    def test_set_virtue_by_name_invalid(self):
+        """Test set_virtue_by_name raises error for invalid virtue."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+
+        with self.assertRaises(ValueError) as context:
+            vampire.set_virtue_by_name("invalid_virtue", 3)
+        self.assertIn("Unknown virtue", str(context.exception))
+
+
+class TestVampirePathIntegration(VampireModelTestCase):
+    """Test Path of Enlightenment integration."""
+
+    def test_path_updates_virtues_on_save(self):
+        """Test that setting a path updates virtue booleans on save."""
+        vampire = Vampire.objects.create(
+            name="Test",
+            owner=self.user,
+            has_conviction=False,
+            has_instinct=False,
+            conscience=3,
+            self_control=3,
+        )
+        self.assertFalse(vampire.has_conviction)
+        self.assertFalse(vampire.has_instinct)
+
+        vampire.path = self.path_of_caine
+        vampire.save()
+        vampire.refresh_from_db()
+
+        self.assertTrue(vampire.has_conviction)
+        self.assertTrue(vampire.has_instinct)
+        # Original virtues should be reset
+        self.assertEqual(vampire.conscience, 0)
+        self.assertEqual(vampire.self_control, 0)
+
+
+class TestVampireFreebies(VampireModelTestCase):
+    """Test freebie point costs and methods."""
+
+    def test_freebie_cost_discipline(self):
+        """Test freebie cost for in-clan disciplines."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.freebie_cost("discipline"), 7)
+
+    def test_freebie_cost_out_of_clan_discipline(self):
+        """Test freebie cost for out-of-clan disciplines."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.freebie_cost("out_of_clan_discipline"), 10)
+
+    def test_freebie_cost_virtue(self):
+        """Test freebie cost for virtues."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.freebie_cost("virtue"), 2)
+
+    def test_freebie_cost_humanity(self):
+        """Test freebie cost for humanity."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.freebie_cost("humanity"), 1)
+
+    def test_freebie_cost_path_rating(self):
+        """Test freebie cost for path rating."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.freebie_cost("path_rating"), 1)
+
+    def test_freebie_costs_dict(self):
+        """Test freebie_costs returns complete cost dictionary."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        costs = vampire.freebie_costs()
+        self.assertEqual(costs["discipline"], 7)
+        self.assertEqual(costs["out_of_clan_discipline"], 10)
+        self.assertEqual(costs["virtue"], 2)
+        self.assertEqual(costs["humanity"], 1)
+        self.assertEqual(costs["path_rating"], 1)
+
+    def test_freebie_frequencies(self):
+        """Test freebie_frequencies returns expected distribution."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        freqs = vampire.freebie_frequencies()
+        self.assertIn("discipline", freqs)
+        self.assertIn("virtue", freqs)
+        self.assertIn("humanity", freqs)
+        self.assertIn("path_rating", freqs)
+
+
+class TestVampireXPCosts(VampireModelTestCase):
+    """Test XP costs for vampire traits."""
+
+    def test_xp_cost_new_discipline(self):
+        """Test XP cost for new discipline."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.xp_cost("new_discipline"), 10)
+
+    def test_xp_cost_clan_discipline(self):
+        """Test XP cost for raising clan discipline."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        # Cost is 5 * new rating
+        self.assertEqual(vampire.xp_cost("clan_discipline", 3), 15)
+
+    def test_xp_cost_out_of_clan_discipline(self):
+        """Test XP cost for raising out-of-clan discipline."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        # Cost is 7 * new rating
+        self.assertEqual(vampire.xp_cost("out_of_clan_discipline", 3), 21)
+
+    def test_xp_cost_virtue(self):
+        """Test XP cost for virtue."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        # Cost is 2 * new rating
+        self.assertEqual(vampire.xp_cost("virtue", 4), 8)
+
+    def test_xp_cost_humanity(self):
+        """Test XP cost for humanity."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        # Cost is 1 * new rating
+        self.assertEqual(vampire.xp_cost("humanity", 8), 8)
+
+    def test_xp_cost_path_rating(self):
+        """Test XP cost for path rating."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        # Cost is 1 * new rating
+        self.assertEqual(vampire.xp_cost("path_rating", 5), 5)
+
+    def test_xp_frequencies(self):
+        """Test xp_frequencies returns expected distribution."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        freqs = vampire.xp_frequencies()
+        self.assertIn("discipline", freqs)
+        self.assertIn("virtue", freqs)
+        self.assertIn("humanity", freqs)
+        self.assertIn("path_rating", freqs)
+
+
+class TestVampireSireRelationship(VampireModelTestCase):
+    """Test sire/childe relationship."""
+
+    def test_vampire_can_have_sire(self):
+        """Test that a vampire can have a sire."""
+        sire = Vampire.objects.create(
+            name="Elder Ventrue",
+            owner=self.user,
+            generation_rating=8,
+        )
+        childe = Vampire.objects.create(
+            name="Neonate",
+            owner=self.user,
+            sire=sire,
+            generation_rating=9,
+        )
+        self.assertEqual(childe.sire, sire)
+
+    def test_sire_can_have_childer(self):
+        """Test that childer relationship is accessible from sire."""
+        sire = Vampire.objects.create(
+            name="Elder",
+            owner=self.user,
+            generation_rating=8,
+        )
+        childe1 = Vampire.objects.create(
+            name="Childe 1",
+            owner=self.user,
+            sire=sire,
+        )
+        childe2 = Vampire.objects.create(
+            name="Childe 2",
+            owner=self.user,
+            sire=sire,
+        )
+        childer = list(sire.childer.all())
+        self.assertEqual(len(childer), 2)
+        self.assertIn(childe1, childer)
+        self.assertIn(childe2, childer)
+
+
+class TestVampireAllowedBackgrounds(VampireModelTestCase):
+    """Test allowed backgrounds for vampires."""
+
+    def test_allowed_backgrounds_includes_generation(self):
+        """Test that allowed_backgrounds includes generation."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertIn("generation", vampire.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_domain(self):
+        """Test that allowed_backgrounds includes domain."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertIn("domain", vampire.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_herd(self):
+        """Test that allowed_backgrounds includes herd."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertIn("herd", vampire.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_status(self):
+        """Test that allowed_backgrounds includes status_background."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertIn("status_background", vampire.allowed_backgrounds)
+
+
+class TestVampireFreebieStep(VampireModelTestCase):
+    """Test freebie_step configuration."""
+
+    def test_vampire_freebie_step(self):
+        """Test that vampires have freebie_step of 7."""
+        vampire = Vampire.objects.create(name="Test", owner=self.user)
+        self.assertEqual(vampire.freebie_step, 7)


### PR DESCRIPTION
## Summary
- Adds 217 comprehensive tests for Vampire gameline models and forms
- Covers Vampire, Ghoul, Revenant, and Path model functionality
- Tests creation forms for Vampire, Ghoul, and Revenant characters
- Tests VampireFreebiesForm and GhoulFreebiesForm category handling

## Test Coverage

**Models (148 tests):**
- `test_vampire.py`: Generation effects (blood pool, blood per turn), disciplines, virtues, freebies, XP costs, sire relationships
- `test_ghoul.py`: Domitor relationships, discipline access, independent ghouls, years as ghoul tracking
- `test_path.py`: Virtue requirements, character virtue updating, virtue display methods
- `test_revenant.py`: Family relationships, pseudo-generation, family discipline access

**Forms (69 tests):**
- `test_vampire.py`: VampireCreationForm initialization, validation, save behavior
- `test_ghoul.py`: GhoulCreationForm initialization, validation, save behavior
- `test_revenant.py`: RevenantCreationForm initialization, validation, save behavior
- `test_freebies.py`: VampireFreebiesForm and GhoulFreebiesForm category choices, validators

## Test plan
- [x] All 217 new tests pass
- [ ] Verify tests run successfully in CI

Closes #1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)