### PR TITLE
Add comprehensive tests for Wraith models and forms (Issue #1180)

### DIFF
--- a/characters/tests/forms/wraith/test_fetter.py
+++ b/characters/tests/forms/wraith/test_fetter.py
@@ -1,5 +1,128 @@
-"""Tests for fetter module."""
+"""Tests for Fetter model."""
 
+from characters.models.wraith.fetter import Fetter
+from characters.models.wraith.wraith import Wraith
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class FetterTestCase(TestCase):
+    """Base test case with common setup for Fetter tests."""
+
+    def setUp(self):
+        """Create test user and wraith."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.wraith = Wraith.objects.create(name="Test Wraith", owner=self.user)
+
+
+class TestFetterModel(FetterTestCase):
+    """Tests for Fetter model creation and attributes."""
+
+    def test_fetter_creation(self):
+        """Fetter can be created with required attributes."""
+        fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="object",
+            description="My wedding ring",
+            rating=3,
+        )
+        self.assertEqual(fetter.wraith, self.wraith)
+        self.assertEqual(fetter.fetter_type, "object")
+        self.assertEqual(fetter.description, "My wedding ring")
+        self.assertEqual(fetter.rating, 3)
+
+    def test_fetter_default_values(self):
+        """Fetter has correct default values."""
+        fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            description="Test fetter",
+        )
+        self.assertEqual(fetter.fetter_type, "object")
+        self.assertEqual(fetter.rating, 1)
+
+    def test_fetter_type_choices(self):
+        """Fetter can have object, location, or person type."""
+        object_fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="object",
+            description="Ring",
+        )
+        location_fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="location",
+            description="Old house",
+        )
+        person_fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="person",
+            description="My daughter",
+        )
+        self.assertEqual(object_fetter.fetter_type, "object")
+        self.assertEqual(location_fetter.fetter_type, "location")
+        self.assertEqual(person_fetter.fetter_type, "person")
+
+
+class TestFetterStrRepresentation(FetterTestCase):
+    """Tests for Fetter string representation."""
+
+    def test_fetter_str(self):
+        """Fetter string includes description and rating."""
+        fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            description="My childhood home",
+            rating=4,
+        )
+        self.assertEqual(str(fetter), "My childhood home (4)")
+
+
+class TestFetterRelationship(FetterTestCase):
+    """Tests for Fetter-Wraith relationship."""
+
+    def test_wraith_related_name(self):
+        """Fetter is accessible via wraith.fetters."""
+        fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            description="Test fetter",
+        )
+        self.assertIn(fetter, self.wraith.fetters.all())
+
+    def test_deleting_wraith_deletes_fetters(self):
+        """Deleting a wraith cascades to delete its fetters."""
+        fetter = Fetter.objects.create(
+            wraith=self.wraith,
+            description="Test fetter",
+        )
+        fetter_id = fetter.id
+        self.wraith.delete()
+        self.assertFalse(Fetter.objects.filter(id=fetter_id).exists())
+
+    def test_multiple_fetters_per_wraith(self):
+        """A wraith can have multiple fetters."""
+        fetter1 = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="object",
+            description="Ring",
+        )
+        fetter2 = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="location",
+            description="House",
+        )
+        fetter3 = Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="person",
+            description="Child",
+        )
+        self.assertEqual(self.wraith.fetters.count(), 3)
+
+
+class TestFetterMetaOptions(FetterTestCase):
+    """Tests for Fetter Meta options."""
+
+    def test_verbose_name(self):
+        """Fetter has correct verbose_name."""
+        self.assertEqual(Fetter._meta.verbose_name, "Fetter")
+
+    def test_verbose_name_plural(self):
+        """Fetter has correct verbose_name_plural."""
+        self.assertEqual(Fetter._meta.verbose_name_plural, "Fetters")

--- a/characters/tests/forms/wraith/test_freebies.py
+++ b/characters/tests/forms/wraith/test_freebies.py
@@ -1,5 +1,165 @@
-"""Tests for freebies module."""
+"""Tests for WraithFreebiesForm."""
 
+from characters.forms.wraith.freebies import WraithFreebiesForm
+from characters.models.wraith.wraith import Wraith
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class WraithFreebiesFormTestCase(TestCase):
+    """Base test case with common setup for WraithFreebiesForm tests."""
+
+    def setUp(self):
+        """Set up test user and wraith."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.wraith = Wraith.objects.create(
+            name="Test Wraith",
+            owner=self.user,
+            freebies=21,  # Wraith gets 21 freebies (15 + 7 from freebie_step)
+        )
+
+
+class TestWraithFreebiesFormInitialization(WraithFreebiesFormTestCase):
+    """Tests for WraithFreebiesForm initialization."""
+
+    def test_form_initializes_with_wraith_instance(self):
+        """Form initializes correctly with wraith instance."""
+        form = WraithFreebiesForm(instance=self.wraith)
+        self.assertIn("category", form.fields)
+        self.assertIn("example", form.fields)
+
+    def test_form_inherits_from_human_freebies_form(self):
+        """Form inherits from HumanFreebiesForm."""
+        from characters.forms.core.freebies import HumanFreebiesForm
+
+        self.assertTrue(issubclass(WraithFreebiesForm, HumanFreebiesForm))
+
+
+class TestWraithFreebiesFormValidator(WraithFreebiesFormTestCase):
+    """Tests for the validator method."""
+
+    def test_validator_returns_true_for_affordable_trait(self):
+        """Validator returns True when wraith can afford trait."""
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Arcanos costs 7, should be affordable with 21 freebies
+        self.assertTrue(form.validator("arcanos"))
+
+    def test_validator_returns_false_for_unaffordable_trait(self):
+        """Validator returns False when wraith cannot afford trait."""
+        self.wraith.freebies = 3
+        self.wraith.save()
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Arcanos costs 7, should not be affordable with 3 freebies
+        self.assertFalse(form.validator("arcanos"))
+
+    def test_validator_returns_false_for_unknown_trait(self):
+        """Validator returns False for unknown traits (cost 10000)."""
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Unknown traits have cost 10000 which is treated as blocked
+        self.assertFalse(form.validator("unknown_trait_type"))
+
+    def test_validator_handles_different_costs(self):
+        """Validator handles different freebie costs correctly."""
+        self.wraith.freebies = 5
+        self.wraith.save()
+        form = WraithFreebiesForm(instance=self.wraith)
+
+        # Pathos costs 1, should be affordable
+        self.assertTrue(form.validator("pathos"))
+
+        # Corpus costs 1, should be affordable
+        self.assertTrue(form.validator("corpus"))
+
+        # Arcanos costs 7, should not be affordable
+        self.assertFalse(form.validator("arcanos"))
+
+    def test_validator_returns_false_for_blocked_category(self):
+        """Validator returns False for blocked categories (cost 10000)."""
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Default blocked category
+        self.assertFalse(form.validator("-----"))
+
+
+class TestWraithFreebiesFormSave(WraithFreebiesFormTestCase):
+    """Tests for form save behavior."""
+
+    def test_save_returns_instance(self):
+        """Save returns the wraith instance."""
+        form = WraithFreebiesForm(
+            data={"category": "Willpower", "example": "", "value": ""},
+            instance=self.wraith,
+        )
+        if form.is_valid():
+            result = form.save()
+            self.assertEqual(result, self.wraith)
+
+
+class TestWraithFreebiesFormCostCalculations(WraithFreebiesFormTestCase):
+    """Tests for wraith-specific freebie cost calculations."""
+
+    def test_arcanos_cost_is_seven(self):
+        """Arcanos costs 7 freebies."""
+        cost = self.wraith.freebie_cost("arcanos")
+        self.assertEqual(cost, 7)
+
+    def test_pathos_cost_is_one(self):
+        """Pathos costs 1 freebie."""
+        cost = self.wraith.freebie_cost("pathos")
+        self.assertEqual(cost, 1)
+
+    def test_passion_cost_is_two(self):
+        """Passion costs 2 freebies."""
+        cost = self.wraith.freebie_cost("passion")
+        self.assertEqual(cost, 2)
+
+    def test_fetter_cost_is_one(self):
+        """Fetter costs 1 freebie."""
+        cost = self.wraith.freebie_cost("fetter")
+        self.assertEqual(cost, 1)
+
+    def test_corpus_cost_is_one(self):
+        """Corpus costs 1 freebie."""
+        cost = self.wraith.freebie_cost("corpus")
+        self.assertEqual(cost, 1)
+
+
+class TestWraithFreebiesFormEdgeCases(WraithFreebiesFormTestCase):
+    """Tests for edge cases and boundary conditions."""
+
+    def test_zero_freebies(self):
+        """Form handles zero freebies correctly."""
+        self.wraith.freebies = 0
+        self.wraith.save()
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Should not be able to afford anything
+        self.assertFalse(form.validator("arcanos"))
+        self.assertFalse(form.validator("pathos"))
+
+    def test_exact_freebie_amount(self):
+        """Validator handles exact freebie amount correctly."""
+        self.wraith.freebies = 7
+        self.wraith.save()
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Exactly enough for arcanos
+        self.assertTrue(form.validator("arcanos"))
+
+    def test_one_below_required(self):
+        """Validator handles one below required amount correctly."""
+        self.wraith.freebies = 6
+        self.wraith.save()
+        form = WraithFreebiesForm(instance=self.wraith)
+        # Not quite enough for arcanos
+        self.assertFalse(form.validator("arcanos"))
+
+    def test_validator_with_lowercase_trait(self):
+        """Validator handles lowercase trait names."""
+        form = WraithFreebiesForm(instance=self.wraith)
+        self.assertTrue(form.validator("arcanos"))
+
+    def test_validator_with_spaces_in_trait(self):
+        """Validator handles trait names with spaces."""
+        form = WraithFreebiesForm(instance=self.wraith)
+        # "new background" should convert to "new_background" internally
+        result = form.validator("new background")
+        # This tests the normalization in the validator
+        self.assertIsInstance(result, bool)

--- a/characters/tests/forms/wraith/test_passion.py
+++ b/characters/tests/forms/wraith/test_passion.py
@@ -1,5 +1,190 @@
-"""Tests for passion module."""
+"""Tests for Passion model."""
 
+from characters.models.wraith.passion import Passion
+from characters.models.wraith.wraith import Wraith
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class PassionTestCase(TestCase):
+    """Base test case with common setup for Passion tests."""
+
+    def setUp(self):
+        """Create test user and wraith."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.wraith = Wraith.objects.create(name="Test Wraith", owner=self.user)
+
+
+class TestPassionModel(PassionTestCase):
+    """Tests for Passion model creation and attributes."""
+
+    def test_passion_creation(self):
+        """Passion can be created with required attributes."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Love",
+            description="Protect my sister at all costs",
+            rating=4,
+        )
+        self.assertEqual(passion.wraith, self.wraith)
+        self.assertEqual(passion.emotion, "Love")
+        self.assertEqual(passion.description, "Protect my sister at all costs")
+        self.assertEqual(passion.rating, 4)
+
+    def test_passion_default_values(self):
+        """Passion has correct default values."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Rage",
+            description="Test passion",
+        )
+        self.assertEqual(passion.rating, 1)
+        self.assertFalse(passion.is_dark_passion)
+
+    def test_passion_can_be_dark(self):
+        """Passion can be marked as a dark passion."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Hatred",
+            description="Destroy the living",
+            is_dark_passion=True,
+        )
+        self.assertTrue(passion.is_dark_passion)
+
+
+class TestPassionStrRepresentation(PassionTestCase):
+    """Tests for Passion string representation."""
+
+    def test_passion_str(self):
+        """Passion string includes emotion, description, and rating."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Grief",
+            description="Mourn my lost family",
+            rating=3,
+        )
+        self.assertEqual(str(passion), "Grief: Mourn my lost family (3)")
+
+
+class TestPassionRelationship(PassionTestCase):
+    """Tests for Passion-Wraith relationship."""
+
+    def test_wraith_related_name(self):
+        """Passion is accessible via wraith.passions."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Fear",
+            description="Test passion",
+        )
+        self.assertIn(passion, self.wraith.passions.all())
+
+    def test_deleting_wraith_deletes_passions(self):
+        """Deleting a wraith cascades to delete its passions."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Fear",
+            description="Test passion",
+        )
+        passion_id = passion.id
+        self.wraith.delete()
+        self.assertFalse(Passion.objects.filter(id=passion_id).exists())
+
+    def test_multiple_passions_per_wraith(self):
+        """A wraith can have multiple passions."""
+        passion1 = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Love",
+            description="Family",
+        )
+        passion2 = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Rage",
+            description="Murder",
+        )
+        passion3 = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Fear",
+            description="Being forgotten",
+        )
+        self.assertEqual(self.wraith.passions.count(), 3)
+
+
+class TestPassionDarkConversion(PassionTestCase):
+    """Tests for converting passions to dark passions."""
+
+    def test_convert_passion_to_dark(self):
+        """Regular passion can be converted to dark passion."""
+        passion = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Love",
+            description="Family",
+        )
+        self.assertFalse(passion.is_dark_passion)
+
+        passion.is_dark_passion = True
+        passion.save()
+        passion.refresh_from_db()
+        self.assertTrue(passion.is_dark_passion)
+
+    def test_mix_of_regular_and_dark_passions(self):
+        """Wraith can have both regular and dark passions."""
+        regular = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Love",
+            description="Family",
+            is_dark_passion=False,
+        )
+        dark = Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Hatred",
+            description="Enemies",
+            is_dark_passion=True,
+        )
+        regular_passions = Passion.objects.filter(wraith=self.wraith, is_dark_passion=False)
+        dark_passions = Passion.objects.filter(wraith=self.wraith, is_dark_passion=True)
+        self.assertEqual(regular_passions.count(), 1)
+        self.assertEqual(dark_passions.count(), 1)
+
+
+class TestPassionMetaOptions(PassionTestCase):
+    """Tests for Passion Meta options."""
+
+    def test_verbose_name(self):
+        """Passion has correct verbose_name."""
+        self.assertEqual(Passion._meta.verbose_name, "Passion")
+
+    def test_verbose_name_plural(self):
+        """Passion has correct verbose_name_plural."""
+        self.assertEqual(Passion._meta.verbose_name_plural, "Passions")
+
+
+class TestPassionRatings(PassionTestCase):
+    """Tests for Passion rating functionality."""
+
+    def test_passion_rating_values(self):
+        """Passion ratings can range from 1 to higher values."""
+        for rating in [1, 2, 3, 4, 5]:
+            passion = Passion.objects.create(
+                wraith=self.wraith,
+                emotion=f"Test{rating}",
+                description=f"Rating {rating} passion",
+                rating=rating,
+            )
+            self.assertEqual(passion.rating, rating)
+
+    def test_wraith_total_passion_rating_calculation(self):
+        """Wraith can calculate total passion ratings."""
+        Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Love",
+            description="Family",
+            rating=3,
+        )
+        Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Rage",
+            description="Murder",
+            rating=4,
+        )
+        total = sum(p.rating for p in Passion.objects.filter(wraith=self.wraith))
+        self.assertEqual(total, 7)

--- a/characters/tests/forms/wraith/test_wraith.py
+++ b/characters/tests/forms/wraith/test_wraith.py
@@ -1,5 +1,204 @@
-"""Tests for wraith module."""
+"""Tests for Wraith forms."""
 
+from characters.forms.wraith.wraith import WraithCreationForm
+from characters.models.wraith.guild import Guild
+from characters.models.wraith.wraith import Wraith
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class WraithCreationFormTestCase(TestCase):
+    """Base test case with common setup for WraithCreationForm tests."""
+
+    def setUp(self):
+        """Set up test user and guild."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.guild = Guild.objects.create(
+            name="Masquers",
+            guild_type="greater",
+            willpower=6,
+        )
+
+
+class TestWraithCreationFormInitialization(WraithCreationFormTestCase):
+    """Tests for WraithCreationForm initialization."""
+
+    def test_form_requires_user(self):
+        """Form requires user parameter."""
+        form = WraithCreationForm(user=self.user)
+        self.assertEqual(form.user, self.user)
+
+    def test_form_has_expected_fields(self):
+        """Form has all expected fields."""
+        form = WraithCreationForm(user=self.user)
+        expected_fields = [
+            "name",
+            "nature",
+            "demeanor",
+            "concept",
+            "chronicle",
+            "image",
+            "guild",
+            "npc",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_guild_field_required(self):
+        """Guild field is required."""
+        form = WraithCreationForm(user=self.user)
+        self.assertTrue(form.fields["guild"].required)
+
+    def test_image_field_not_required(self):
+        """Image field is not required."""
+        form = WraithCreationForm(user=self.user)
+        self.assertFalse(form.fields["image"].required)
+
+    def test_guild_queryset(self):
+        """Guild field queryset includes all guilds."""
+        form = WraithCreationForm(user=self.user)
+        self.assertIn(self.guild, form.fields["guild"].queryset)
+
+    def test_name_placeholder(self):
+        """Name field has placeholder."""
+        form = WraithCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("placeholder"),
+            "Enter name here",
+        )
+
+    def test_concept_placeholder(self):
+        """Concept field has placeholder."""
+        form = WraithCreationForm(user=self.user)
+        self.assertEqual(
+            form.fields["concept"].widget.attrs.get("placeholder"),
+            "Enter concept here",
+        )
+
+
+class TestWraithCreationFormValidation(WraithCreationFormTestCase):
+    """Tests for WraithCreationForm validation."""
+
+    def test_valid_data(self):
+        """Form is valid with required fields."""
+        data = {
+            "name": "Test Wraith",
+            "guild": self.guild.pk,
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_missing_name_invalid(self):
+        """Form is invalid without name."""
+        data = {
+            "guild": self.guild.pk,
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+    def test_missing_guild_invalid(self):
+        """Form is invalid without guild."""
+        data = {
+            "name": "Test Wraith",
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("guild", form.errors)
+
+
+class TestWraithCreationFormSave(WraithCreationFormTestCase):
+    """Tests for WraithCreationForm save behavior."""
+
+    def test_save_sets_owner(self):
+        """Save assigns user as owner."""
+        data = {
+            "name": "Test Wraith",
+            "guild": self.guild.pk,
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertTrue(form.is_valid())
+        wraith = form.save()
+        self.assertEqual(wraith.owner, self.user)
+
+    def test_save_creates_wraith(self):
+        """Save creates Wraith object."""
+        data = {
+            "name": "Test Wraith",
+            "guild": self.guild.pk,
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertTrue(form.is_valid())
+        wraith = form.save()
+        self.assertIsInstance(wraith, Wraith)
+        self.assertEqual(wraith.name, "Test Wraith")
+        self.assertEqual(wraith.guild, self.guild)
+
+    def test_save_with_optional_fields(self):
+        """Save works with optional fields."""
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        data = {
+            "name": "Test Wraith",
+            "guild": self.guild.pk,
+            "concept": "A restless spirit",
+            "chronicle": chronicle.pk,
+            "npc": True,
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        wraith = form.save()
+        self.assertEqual(wraith.concept, "A restless spirit")
+        self.assertEqual(wraith.chronicle, chronicle)
+        self.assertTrue(wraith.npc)
+
+    def test_save_commit_false(self):
+        """Save with commit=False doesn't save to database."""
+        initial_count = Wraith.objects.count()
+        data = {
+            "name": "Test Wraith",
+            "guild": self.guild.pk,
+        }
+        form = WraithCreationForm(data=data, user=self.user)
+        self.assertTrue(form.is_valid())
+        wraith = form.save(commit=False)
+        self.assertEqual(Wraith.objects.count(), initial_count)
+        self.assertEqual(wraith.owner, self.user)
+
+
+class TestWraithCreationFormMultipleGuilds(WraithCreationFormTestCase):
+    """Tests for WraithCreationForm with multiple guilds."""
+
+    def setUp(self):
+        super().setUp()
+        self.guild2 = Guild.objects.create(
+            name="Haunters",
+            guild_type="greater",
+            willpower=5,
+        )
+        self.guild3 = Guild.objects.create(
+            name="Solicitors",
+            guild_type="greater",
+            willpower=6,
+        )
+
+    def test_guild_queryset_contains_all_guilds(self):
+        """Guild queryset includes all created guilds."""
+        form = WraithCreationForm(user=self.user)
+        queryset = form.fields["guild"].queryset
+        self.assertIn(self.guild, queryset)
+        self.assertIn(self.guild2, queryset)
+        self.assertIn(self.guild3, queryset)
+
+    def test_can_select_different_guilds(self):
+        """Form accepts different guild selections."""
+        for guild in [self.guild, self.guild2, self.guild3]:
+            data = {
+                "name": f"Wraith of {guild.name}",
+                "guild": guild.pk,
+            }
+            form = WraithCreationForm(data=data, user=self.user)
+            self.assertTrue(form.is_valid(), f"Form errors for {guild.name}: {form.errors}")
+            wraith = form.save()
+            self.assertEqual(wraith.guild, guild)
+            wraith.delete()  # Clean up for next iteration

--- a/characters/tests/models/wraith/test_arcanos.py
+++ b/characters/tests/models/wraith/test_arcanos.py
@@ -1,5 +1,169 @@
-"""Tests for arcanos module."""
+"""Tests for Arcanos model."""
 
+from characters.models.wraith.arcanos import Arcanos
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class TestArcanosModel(TestCase):
+    """Tests for Arcanos model creation and attributes."""
+
+    def test_arcanos_creation(self):
+        """Arcanos can be created with basic attributes."""
+        arcanos = Arcanos.objects.create(
+            name="Argos",
+            level=1,
+            description="The art of navigation in the Underworld.",
+        )
+        self.assertEqual(arcanos.name, "Argos")
+        self.assertEqual(arcanos.level, 1)
+
+    def test_arcanos_default_values(self):
+        """Arcanos has correct default values."""
+        arcanos = Arcanos.objects.create(
+            name="Test Arcanos",
+            description="Test description",
+        )
+        self.assertEqual(arcanos.arcanos_type, "standard")
+        self.assertEqual(arcanos.level, 1)
+        self.assertEqual(arcanos.pathos_cost, 0)
+        self.assertEqual(arcanos.angst_cost, 0)
+        self.assertEqual(arcanos.difficulty, 6)
+
+    def test_arcanos_type_choices(self):
+        """Arcanos can have standard or dark type."""
+        standard = Arcanos.objects.create(
+            name="Standard",
+            arcanos_type="standard",
+            description="Standard arcanos",
+        )
+        dark = Arcanos.objects.create(
+            name="Dark",
+            arcanos_type="dark",
+            description="Dark arcanos",
+        )
+        self.assertEqual(standard.arcanos_type, "standard")
+        self.assertEqual(dark.arcanos_type, "dark")
+
+    def test_arcanos_gameline(self):
+        """Arcanos has correct gameline."""
+        arcanos = Arcanos.objects.create(name="Test", description="Test description")
+        self.assertEqual(arcanos.gameline, "wto")
+
+    def test_arcanos_type_attribute(self):
+        """Arcanos has correct type attribute."""
+        arcanos = Arcanos.objects.create(name="Test", description="Test description")
+        self.assertEqual(arcanos.type, "arcanos")
+
+    def test_arcanos_parent_relationship(self):
+        """Arcanos can have a parent arcanos for leveled abilities."""
+        parent = Arcanos.objects.create(
+            name="Argos",
+            level=0,
+            description="Parent arcanos",
+        )
+        child = Arcanos.objects.create(
+            name="Enshroud",
+            level=1,
+            parent_arcanos=parent,
+            description="Child arcanos",
+        )
+        self.assertEqual(child.parent_arcanos, parent)
+        self.assertIn(child, parent.levels.all())
+
+    def test_arcanos_pathos_and_angst_costs(self):
+        """Arcanos can have pathos and angst costs."""
+        arcanos = Arcanos.objects.create(
+            name="Blighted Insight",
+            arcanos_type="dark",
+            pathos_cost=2,
+            angst_cost=1,
+            description="Dark arcanos ability",
+        )
+        self.assertEqual(arcanos.pathos_cost, 2)
+        self.assertEqual(arcanos.angst_cost, 1)
+
+
+class TestArcanosUrls(TestCase):
+    """Tests for Arcanos URL methods."""
+
+    def setUp(self):
+        self.arcanos = Arcanos.objects.create(
+            name="Test Arcanos",
+            description="Test description",
+        )
+
+    def test_get_absolute_url_method_exists(self):
+        """Arcanos has get_absolute_url method."""
+        self.assertTrue(hasattr(self.arcanos, "get_absolute_url"))
+        self.assertTrue(callable(getattr(self.arcanos, "get_absolute_url")))
+
+    def test_get_heading(self):
+        """Arcanos returns correct heading class."""
+        self.assertEqual(self.arcanos.get_heading(), "wto_heading")
+
+
+class TestArcanosHierarchy(TestCase):
+    """Tests for Arcanos hierarchy with parent relationships."""
+
+    def test_multiple_levels_under_parent(self):
+        """Parent arcanos can have multiple levels."""
+        parent = Arcanos.objects.create(
+            name="Castigate",
+            level=0,
+            description="Parent",
+        )
+        level1 = Arcanos.objects.create(
+            name="Soulsight",
+            level=1,
+            parent_arcanos=parent,
+            description="Level 1",
+        )
+        level2 = Arcanos.objects.create(
+            name="Tainted Touch",
+            level=2,
+            parent_arcanos=parent,
+            description="Level 2",
+        )
+        level3 = Arcanos.objects.create(
+            name="Condemn",
+            level=3,
+            parent_arcanos=parent,
+            description="Level 3",
+        )
+
+        self.assertEqual(parent.levels.count(), 3)
+        self.assertIn(level1, parent.levels.all())
+        self.assertIn(level2, parent.levels.all())
+        self.assertIn(level3, parent.levels.all())
+
+    def test_deleting_parent_nullifies_children(self):
+        """Deleting parent arcanos sets children's parent to null."""
+        parent = Arcanos.objects.create(name="Parent", level=0, description="Parent")
+        child = Arcanos.objects.create(
+            name="Child",
+            level=1,
+            parent_arcanos=parent,
+            description="Child",
+        )
+        child_id = child.id
+
+        parent.delete()
+        child.refresh_from_db()
+        self.assertIsNone(child.parent_arcanos)
+
+    def test_arcanos_str_representation(self):
+        """Arcanos uses name for string representation (from Model base)."""
+        arcanos = Arcanos.objects.create(name="Phantasm", description="Test")
+        self.assertEqual(str(arcanos), "Phantasm")
+
+
+class TestArcanosMetaOptions(TestCase):
+    """Tests for Arcanos Meta options."""
+
+    def test_verbose_name(self):
+        """Arcanos has correct verbose_name."""
+        self.assertEqual(Arcanos._meta.verbose_name, "Arcanos")
+
+    def test_verbose_name_plural(self):
+        """Arcanos has correct verbose_name_plural (Arcanoi)."""
+        self.assertEqual(Arcanos._meta.verbose_name_plural, "Arcanoi")

--- a/characters/tests/models/wraith/test_faction.py
+++ b/characters/tests/models/wraith/test_faction.py
@@ -1,5 +1,177 @@
-"""Tests for faction module."""
+"""Tests for WraithFaction model."""
 
+from characters.models.wraith.faction import WraithFaction
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class TestWraithFactionModel(TestCase):
+    """Tests for WraithFaction model creation and attributes."""
+
+    def test_faction_creation(self):
+        """WraithFaction can be created with basic attributes."""
+        faction = WraithFaction.objects.create(
+            name="Iron Legion",
+            faction_type="legion",
+            description="Legion of soldiers and warriors.",
+        )
+        self.assertEqual(faction.name, "Iron Legion")
+        self.assertEqual(faction.faction_type, "legion")
+
+    def test_faction_default_values(self):
+        """WraithFaction has correct default values."""
+        faction = WraithFaction.objects.create(
+            name="Test Faction",
+            description="Test description",
+        )
+        self.assertEqual(faction.faction_type, "legion")
+        self.assertIsNone(faction.parent)
+
+    def test_faction_type_choices(self):
+        """WraithFaction can have various faction types."""
+        legion = WraithFaction.objects.create(
+            name="Legion",
+            faction_type="legion",
+            description="Legion faction",
+        )
+        guild = WraithFaction.objects.create(
+            name="Guild",
+            faction_type="guild",
+            description="Guild faction",
+        )
+        heretic = WraithFaction.objects.create(
+            name="Heretic",
+            faction_type="heretic",
+            description="Heretic faction",
+        )
+        spectre = WraithFaction.objects.create(
+            name="Spectre",
+            faction_type="spectre",
+            description="Spectre faction",
+        )
+        other = WraithFaction.objects.create(
+            name="Other",
+            faction_type="other",
+            description="Other faction",
+        )
+        self.assertEqual(legion.faction_type, "legion")
+        self.assertEqual(guild.faction_type, "guild")
+        self.assertEqual(heretic.faction_type, "heretic")
+        self.assertEqual(spectre.faction_type, "spectre")
+        self.assertEqual(other.faction_type, "other")
+
+    def test_faction_gameline(self):
+        """WraithFaction has correct gameline."""
+        faction = WraithFaction.objects.create(name="Test", description="Test")
+        self.assertEqual(faction.gameline, "wto")
+
+    def test_faction_type_attribute(self):
+        """WraithFaction has correct type attribute."""
+        faction = WraithFaction.objects.create(name="Test", description="Test")
+        self.assertEqual(faction.type, "wraith_faction")
+
+
+class TestWraithFactionHierarchy(TestCase):
+    """Tests for WraithFaction parent-child relationships."""
+
+    def test_faction_can_have_parent(self):
+        """WraithFaction can have a parent faction."""
+        parent = WraithFaction.objects.create(
+            name="Parent Faction",
+            description="Parent",
+        )
+        child = WraithFaction.objects.create(
+            name="Child Faction",
+            parent=parent,
+            description="Child",
+        )
+        self.assertEqual(child.parent, parent)
+
+    def test_faction_subfactions_related_name(self):
+        """Parent faction can access subfactions via related name."""
+        parent = WraithFaction.objects.create(
+            name="Parent Faction",
+            description="Parent",
+        )
+        child1 = WraithFaction.objects.create(
+            name="Child 1",
+            parent=parent,
+            description="Child 1",
+        )
+        child2 = WraithFaction.objects.create(
+            name="Child 2",
+            parent=parent,
+            description="Child 2",
+        )
+        self.assertIn(child1, parent.subfactions.all())
+        self.assertIn(child2, parent.subfactions.all())
+        self.assertEqual(parent.subfactions.count(), 2)
+
+    def test_deleting_parent_nullifies_children(self):
+        """Deleting parent faction sets children's parent to null."""
+        parent = WraithFaction.objects.create(
+            name="Parent",
+            description="Parent",
+        )
+        child = WraithFaction.objects.create(
+            name="Child",
+            parent=parent,
+            description="Child",
+        )
+        child_id = child.id
+
+        parent.delete()
+        child.refresh_from_db()
+        self.assertIsNone(child.parent)
+
+
+class TestWraithFactionUrls(TestCase):
+    """Tests for WraithFaction URL methods."""
+
+    def setUp(self):
+        self.faction = WraithFaction.objects.create(
+            name="Test Faction",
+            description="Test description",
+        )
+
+    def test_get_absolute_url_method_exists(self):
+        """WraithFaction has get_absolute_url method."""
+        self.assertTrue(hasattr(self.faction, "get_absolute_url"))
+        self.assertTrue(callable(getattr(self.faction, "get_absolute_url")))
+
+    def test_get_update_url_method_exists(self):
+        """WraithFaction has get_update_url method."""
+        self.assertTrue(hasattr(self.faction, "get_update_url"))
+        self.assertTrue(callable(getattr(self.faction, "get_update_url")))
+
+    def test_get_creation_url_method_exists(self):
+        """WraithFaction has get_creation_url class method."""
+        self.assertTrue(hasattr(WraithFaction, "get_creation_url"))
+        self.assertTrue(callable(getattr(WraithFaction, "get_creation_url")))
+
+    def test_get_heading(self):
+        """WraithFaction returns correct heading class."""
+        self.assertEqual(self.faction.get_heading(), "wto_heading")
+
+
+class TestWraithFactionMetaOptions(TestCase):
+    """Tests for WraithFaction Meta options."""
+
+    def test_verbose_name(self):
+        """WraithFaction has correct verbose_name."""
+        self.assertEqual(WraithFaction._meta.verbose_name, "Wraith Faction")
+
+    def test_verbose_name_plural(self):
+        """WraithFaction has correct verbose_name_plural."""
+        self.assertEqual(WraithFaction._meta.verbose_name_plural, "Wraith Factions")
+
+
+class TestWraithFactionStr(TestCase):
+    """Tests for WraithFaction string representation."""
+
+    def test_faction_str(self):
+        """WraithFaction uses name for string representation."""
+        faction = WraithFaction.objects.create(
+            name="Renegades",
+            description="Free wraiths",
+        )
+        self.assertEqual(str(faction), "Renegades")

--- a/characters/tests/models/wraith/test_guild.py
+++ b/characters/tests/models/wraith/test_guild.py
@@ -1,5 +1,113 @@
-"""Tests for guild module."""
+"""Tests for Guild model."""
 
+from characters.models.wraith.guild import Guild
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class TestGuildModel(TestCase):
+    """Tests for Guild model creation and attributes."""
+
+    def test_guild_creation(self):
+        """Guild can be created with basic attributes."""
+        guild = Guild.objects.create(
+            name="Masquers",
+            guild_type="greater",
+            willpower=6,
+            description="Masters of disguise and illusion.",
+        )
+        self.assertEqual(guild.name, "Masquers")
+        self.assertEqual(guild.guild_type, "greater")
+        self.assertEqual(guild.willpower, 6)
+
+    def test_guild_default_values(self):
+        """Guild has correct default values."""
+        guild = Guild.objects.create(
+            name="Test Guild",
+            description="Test description",
+        )
+        self.assertEqual(guild.guild_type, "greater")
+        self.assertEqual(guild.willpower, 5)
+
+    def test_guild_type_choices(self):
+        """Guild can have greater, lesser, or banned type."""
+        greater = Guild.objects.create(
+            name="Greater Guild",
+            guild_type="greater",
+            description="Greater guild",
+        )
+        lesser = Guild.objects.create(
+            name="Lesser Guild",
+            guild_type="lesser",
+            description="Lesser guild",
+        )
+        banned = Guild.objects.create(
+            name="Banned Guild",
+            guild_type="banned",
+            description="Banned guild",
+        )
+        self.assertEqual(greater.guild_type, "greater")
+        self.assertEqual(lesser.guild_type, "lesser")
+        self.assertEqual(banned.guild_type, "banned")
+
+    def test_guild_gameline(self):
+        """Guild has correct gameline."""
+        guild = Guild.objects.create(name="Test", description="Test")
+        self.assertEqual(guild.gameline, "wto")
+
+    def test_guild_type_attribute(self):
+        """Guild has correct type attribute."""
+        guild = Guild.objects.create(name="Test", description="Test")
+        self.assertEqual(guild.type, "guild")
+
+
+class TestGuildUrls(TestCase):
+    """Tests for Guild URL methods."""
+
+    def setUp(self):
+        self.guild = Guild.objects.create(
+            name="Test Guild",
+            description="Test description",
+        )
+
+    def test_get_absolute_url_method_exists(self):
+        """Guild has get_absolute_url method."""
+        self.assertTrue(hasattr(self.guild, "get_absolute_url"))
+        self.assertTrue(callable(getattr(self.guild, "get_absolute_url")))
+
+    def test_get_update_url_method_exists(self):
+        """Guild has get_update_url method."""
+        self.assertTrue(hasattr(self.guild, "get_update_url"))
+        self.assertTrue(callable(getattr(self.guild, "get_update_url")))
+
+    def test_get_creation_url_method_exists(self):
+        """Guild has get_creation_url class method."""
+        self.assertTrue(hasattr(Guild, "get_creation_url"))
+        self.assertTrue(callable(getattr(Guild, "get_creation_url")))
+
+    def test_get_heading(self):
+        """Guild returns correct heading class."""
+        self.assertEqual(self.guild.get_heading(), "wto_heading")
+
+
+class TestGuildMetaOptions(TestCase):
+    """Tests for Guild Meta options."""
+
+    def test_verbose_name(self):
+        """Guild has correct verbose_name."""
+        self.assertEqual(Guild._meta.verbose_name, "Guild")
+
+    def test_verbose_name_plural(self):
+        """Guild has correct verbose_name_plural."""
+        self.assertEqual(Guild._meta.verbose_name_plural, "Guilds")
+
+
+class TestGuildStr(TestCase):
+    """Tests for Guild string representation."""
+
+    def test_guild_str(self):
+        """Guild uses name for string representation."""
+        guild = Guild.objects.create(
+            name="Haunters",
+            description="Masters of fear",
+        )
+        self.assertEqual(str(guild), "Haunters")

--- a/characters/tests/models/wraith/test_wraith.py
+++ b/characters/tests/models/wraith/test_wraith.py
@@ -1,9 +1,924 @@
 """Tests for Wraith model."""
 
+from characters.models.wraith.faction import WraithFaction
+from characters.models.wraith.fetter import Fetter
+from characters.models.wraith.guild import Guild
+from characters.models.wraith.passion import Passion
+from characters.models.wraith.shadow_archetype import ShadowArchetype
 from characters.models.wraith.thorn import Thorn
 from characters.models.wraith.wraith import ThornRating, Wraith
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.utils import timezone
+
+
+class WraithTestCase(TestCase):
+    """Base test case with common setup for Wraith tests."""
+
+    def setUp(self):
+        """Create test user and wraith."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.wraith = Wraith.objects.create(name="Test Wraith", owner=self.user)
+
+
+class TestWraithCreation(WraithTestCase):
+    """Tests for basic Wraith creation and default values."""
+
+    def test_wraith_creation(self):
+        """Wraith can be created with a name and owner."""
+        self.assertEqual(self.wraith.name, "Test Wraith")
+        self.assertEqual(self.wraith.owner, self.user)
+
+    def test_wraith_default_corpus(self):
+        """Wraith has default corpus of 10."""
+        self.assertEqual(self.wraith.corpus, 10)
+
+    def test_wraith_default_pathos(self):
+        """Wraith has default pathos of 5."""
+        self.assertEqual(self.wraith.pathos, 5)
+        self.assertEqual(self.wraith.pathos_permanent, 5)
+
+    def test_wraith_default_angst(self):
+        """Wraith has default angst of 0."""
+        self.assertEqual(self.wraith.angst, 0)
+        self.assertEqual(self.wraith.angst_permanent, 0)
+
+    def test_wraith_default_character_type(self):
+        """Wraith has default character type of wraith."""
+        self.assertEqual(self.wraith.character_type, "wraith")
+
+    def test_wraith_default_catharsis_state(self):
+        """Wraith has default catharsis state."""
+        self.assertFalse(self.wraith.in_catharsis)
+        self.assertEqual(self.wraith.catharsis_count, 0)
+
+    def test_wraith_default_harrowing_state(self):
+        """Wraith has default harrowing state."""
+        self.assertEqual(self.wraith.harrowing_count, 0)
+        self.assertEqual(self.wraith.last_harrowing_result, "none")
+
+    def test_wraith_type_attribute(self):
+        """Wraith has correct type attribute."""
+        self.assertEqual(self.wraith.type, "wraith")
+
+    def test_wraith_freebie_step(self):
+        """Wraith has correct freebie step."""
+        self.assertEqual(self.wraith.freebie_step, 7)
+
+    def test_wraith_background_points(self):
+        """Wraith has correct background points."""
+        self.assertEqual(self.wraith.background_points, 7)
+
+    def test_wraith_passion_points(self):
+        """Wraith has correct passion points."""
+        self.assertEqual(self.wraith.passion_points, 10)
+
+    def test_wraith_fetter_points(self):
+        """Wraith has correct fetter points."""
+        self.assertEqual(self.wraith.fetter_points, 10)
+
+
+class TestWraithUrls(WraithTestCase):
+    """Tests for Wraith URL methods."""
+
+    def test_get_absolute_url(self):
+        """Wraith returns correct absolute URL."""
+        url = self.wraith.get_absolute_url()
+        self.assertIn(str(self.wraith.pk), url)
+        self.assertIn("wraith", url)
+
+    def test_get_heading(self):
+        """Wraith returns correct heading class."""
+        self.assertEqual(self.wraith.get_heading(), "wto_heading")
+
+
+class TestWraithGuild(WraithTestCase):
+    """Tests for Wraith guild methods."""
+
+    def setUp(self):
+        super().setUp()
+        self.guild = Guild.objects.create(
+            name="Masquers",
+            guild_type="greater",
+            willpower=6,
+        )
+
+    def test_has_guild_returns_false_when_none(self):
+        """has_guild returns False when no guild set."""
+        self.assertFalse(self.wraith.has_guild())
+
+    def test_has_guild_returns_true_when_set(self):
+        """has_guild returns True when guild is set."""
+        self.wraith.guild = self.guild
+        self.wraith.save()
+        self.assertTrue(self.wraith.has_guild())
+
+    def test_set_guild_assigns_guild(self):
+        """set_guild assigns guild to wraith."""
+        result = self.wraith.set_guild(self.guild)
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.guild, self.guild)
+
+    def test_set_guild_sets_willpower(self):
+        """set_guild sets willpower from guild."""
+        self.wraith.set_guild(self.guild)
+        self.assertEqual(self.wraith.willpower, 6)
+
+    def test_set_guild_with_none(self):
+        """set_guild can clear guild by passing None."""
+        self.wraith.set_guild(self.guild)
+        result = self.wraith.set_guild(None)
+        self.assertTrue(result)
+        self.assertIsNone(self.wraith.guild)
+
+
+class TestWraithLegion(WraithTestCase):
+    """Tests for Wraith legion methods."""
+
+    def setUp(self):
+        super().setUp()
+        self.legion = WraithFaction.objects.create(
+            name="Iron Legion",
+            faction_type="legion",
+        )
+
+    def test_has_legion_returns_false_when_none(self):
+        """has_legion returns False when no legion set."""
+        self.assertFalse(self.wraith.has_legion())
+
+    def test_has_legion_returns_true_when_set(self):
+        """has_legion returns True when legion is set."""
+        self.wraith.legion = self.legion
+        self.wraith.save()
+        self.assertTrue(self.wraith.has_legion())
+
+    def test_set_legion_assigns_legion(self):
+        """set_legion assigns legion to wraith."""
+        result = self.wraith.set_legion(self.legion)
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.legion, self.legion)
+
+
+class TestWraithFaction(WraithTestCase):
+    """Tests for Wraith faction methods."""
+
+    def setUp(self):
+        super().setUp()
+        self.faction = WraithFaction.objects.create(
+            name="Renegades",
+            faction_type="other",
+        )
+
+    def test_has_faction_returns_false_when_none(self):
+        """has_faction returns False when no faction set."""
+        self.assertFalse(self.wraith.has_faction())
+
+    def test_has_faction_returns_true_when_set(self):
+        """has_faction returns True when faction is set."""
+        self.wraith.faction = self.faction
+        self.wraith.save()
+        self.assertTrue(self.wraith.has_faction())
+
+    def test_set_faction_assigns_faction(self):
+        """set_faction assigns faction to wraith."""
+        result = self.wraith.set_faction(self.faction)
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.faction, self.faction)
+
+
+class TestWraithArcanoi(WraithTestCase):
+    """Tests for Wraith arcanoi methods."""
+
+    def test_get_arcanoi_returns_dict(self):
+        """get_arcanoi returns dictionary of arcanoi."""
+        arcanoi = self.wraith.get_arcanoi()
+        self.assertIsInstance(arcanoi, dict)
+        self.assertIn("argos", arcanoi)
+        self.assertIn("castigate", arcanoi)
+        self.assertIn("embody", arcanoi)
+        self.assertIn("fatalism", arcanoi)
+        self.assertIn("flux", arcanoi)
+        self.assertIn("inhabit", arcanoi)
+        self.assertIn("keening", arcanoi)
+        self.assertIn("lifeweb", arcanoi)
+        self.assertIn("moliate", arcanoi)
+        self.assertIn("mnemosynis", arcanoi)
+        self.assertIn("outrage", arcanoi)
+        self.assertIn("pandemonium", arcanoi)
+        self.assertIn("phantasm", arcanoi)
+        self.assertIn("usury", arcanoi)
+        self.assertIn("intimation", arcanoi)
+
+    def test_get_arcanoi_values(self):
+        """get_arcanoi returns correct values."""
+        self.wraith.argos = 3
+        self.wraith.castigate = 2
+        self.wraith.save()
+
+        arcanoi = self.wraith.get_arcanoi()
+        self.assertEqual(arcanoi["argos"], 3)
+        self.assertEqual(arcanoi["castigate"], 2)
+        self.assertEqual(arcanoi["embody"], 0)
+
+    def test_get_dark_arcanoi(self):
+        """get_dark_arcanoi returns dark arcanoi dictionary."""
+        dark_arcanoi = self.wraith.get_dark_arcanoi()
+        self.assertIsInstance(dark_arcanoi, dict)
+        self.assertIn("blighted_insight", dark_arcanoi)
+        self.assertIn("collogue", dark_arcanoi)
+        self.assertIn("corruptor", dark_arcanoi)
+        self.assertIn("false_life", dark_arcanoi)
+        self.assertIn("tempestos", dark_arcanoi)
+        self.assertIn("osseum", dark_arcanoi)
+        self.assertIn("connaissance", dark_arcanoi)
+
+    def test_total_arcanoi(self):
+        """total_arcanoi returns sum of all arcanoi."""
+        self.assertEqual(self.wraith.total_arcanoi(), 0)
+        self.wraith.argos = 2
+        self.wraith.castigate = 3
+        self.assertEqual(self.wraith.total_arcanoi(), 5)
+
+    def test_total_dark_arcanoi(self):
+        """total_dark_arcanoi returns sum of dark arcanoi."""
+        self.assertEqual(self.wraith.total_dark_arcanoi(), 0)
+        self.wraith.blighted_insight = 2
+        self.wraith.tempestos = 1
+        self.assertEqual(self.wraith.total_dark_arcanoi(), 3)
+
+    def test_add_arcanos_increases_value(self):
+        """add_arcanos increases arcanos value by 1."""
+        self.assertEqual(self.wraith.argos, 0)
+        result = self.wraith.add_arcanos("argos")
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.argos, 1)
+
+    def test_add_arcanos_up_to_max(self):
+        """add_arcanos works up to maximum of 5."""
+        for i in range(5):
+            result = self.wraith.add_arcanos("argos")
+            self.assertTrue(result)
+        self.assertEqual(self.wraith.argos, 5)
+        # Cannot exceed 5
+        result = self.wraith.add_arcanos("argos")
+        self.assertFalse(result)
+        self.assertEqual(self.wraith.argos, 5)
+
+    def test_filter_arcanoi_all(self):
+        """filter_arcanoi returns all arcanoi when no constraints."""
+        filtered = self.wraith.filter_arcanoi()
+        self.assertEqual(len(filtered), 15)
+
+    def test_filter_arcanoi_by_maximum(self):
+        """filter_arcanoi filters by maximum."""
+        self.wraith.argos = 3
+        self.wraith.castigate = 5
+        self.wraith.save()
+
+        filtered = self.wraith.filter_arcanoi(maximum=3)
+        self.assertEqual(len(filtered), 14)  # All except castigate
+        self.assertNotIn("castigate", filtered)
+
+    def test_filter_arcanoi_by_minimum(self):
+        """filter_arcanoi filters by minimum."""
+        self.wraith.argos = 3
+        self.wraith.castigate = 2
+        self.wraith.save()
+
+        filtered = self.wraith.filter_arcanoi(minimum=2)
+        self.assertEqual(len(filtered), 2)
+        self.assertIn("argos", filtered)
+        self.assertIn("castigate", filtered)
+
+    def test_filter_arcanoi_by_range(self):
+        """filter_arcanoi filters by range."""
+        self.wraith.argos = 3
+        self.wraith.castigate = 2
+        self.wraith.embody = 1
+        self.wraith.save()
+
+        filtered = self.wraith.filter_arcanoi(minimum=2, maximum=3)
+        self.assertEqual(len(filtered), 2)
+        self.assertIn("argos", filtered)
+        self.assertIn("castigate", filtered)
+
+    def test_has_arcanoi_false_when_insufficient(self):
+        """has_arcanoi returns False when total < 5."""
+        self.assertFalse(self.wraith.has_arcanoi())
+        self.wraith.argos = 2
+        self.wraith.castigate = 2
+        self.assertFalse(self.wraith.has_arcanoi())
+
+    def test_has_arcanoi_true_when_sufficient(self):
+        """has_arcanoi returns True when total == 5."""
+        self.wraith.argos = 3
+        self.wraith.castigate = 2
+        self.assertTrue(self.wraith.has_arcanoi())
+
+
+class TestWraithPassions(WraithTestCase):
+    """Tests for Wraith passion methods."""
+
+    def test_add_passion(self):
+        """add_passion creates a passion for the wraith."""
+        result = self.wraith.add_passion("Love", "Protect my sister", rating=3)
+        self.assertTrue(result)
+        self.assertEqual(Passion.objects.filter(wraith=self.wraith).count(), 1)
+
+    def test_add_passion_with_rating(self):
+        """add_passion creates passion with specified rating."""
+        self.wraith.add_passion("Rage", "Avenge my murder", rating=4)
+        passion = Passion.objects.get(wraith=self.wraith)
+        self.assertEqual(passion.rating, 4)
+        self.assertEqual(passion.emotion, "Rage")
+
+    def test_add_dark_passion(self):
+        """add_passion can create dark passions."""
+        self.wraith.add_passion("Hatred", "Destroy all living", rating=2, is_dark=True)
+        passion = Passion.objects.get(wraith=self.wraith)
+        self.assertTrue(passion.is_dark_passion)
+
+    def test_total_passion_rating(self):
+        """total_passion_rating returns sum of all passion ratings."""
+        self.assertEqual(self.wraith.total_passion_rating(), 0)
+        self.wraith.add_passion("Love", "Family", rating=3)
+        self.wraith.add_passion("Rage", "Murder", rating=4)
+        self.assertEqual(self.wraith.total_passion_rating(), 7)
+
+    def test_has_passions_false_when_insufficient(self):
+        """has_passions returns False when total < 10."""
+        self.assertFalse(self.wraith.has_passions())
+        self.wraith.add_passion("Love", "Family", rating=5)
+        self.assertFalse(self.wraith.has_passions())
+
+    def test_has_passions_true_when_sufficient(self):
+        """has_passions returns True when total == 10."""
+        self.wraith.add_passion("Love", "Family", rating=5)
+        self.wraith.add_passion("Rage", "Murder", rating=5)
+        self.assertTrue(self.wraith.has_passions())
+
+
+class TestWraithFetters(WraithTestCase):
+    """Tests for Wraith fetter methods."""
+
+    def test_add_fetter(self):
+        """add_fetter creates a fetter for the wraith."""
+        result = self.wraith.add_fetter("object", "My wedding ring", rating=3)
+        self.assertTrue(result)
+        self.assertEqual(Fetter.objects.filter(wraith=self.wraith).count(), 1)
+
+    def test_add_fetter_with_type(self):
+        """add_fetter creates fetter with specified type."""
+        self.wraith.add_fetter("location", "The house where I died", rating=4)
+        fetter = Fetter.objects.get(wraith=self.wraith)
+        self.assertEqual(fetter.fetter_type, "location")
+        self.assertEqual(fetter.rating, 4)
+
+    def test_total_fetter_rating(self):
+        """total_fetter_rating returns sum of all fetter ratings."""
+        self.assertEqual(self.wraith.total_fetter_rating(), 0)
+        self.wraith.add_fetter("object", "Ring", rating=3)
+        self.wraith.add_fetter("person", "My daughter", rating=4)
+        self.assertEqual(self.wraith.total_fetter_rating(), 7)
+
+    def test_has_fetters_false_when_insufficient(self):
+        """has_fetters returns False when total < 10."""
+        self.assertFalse(self.wraith.has_fetters())
+        self.wraith.add_fetter("object", "Ring", rating=5)
+        self.assertFalse(self.wraith.has_fetters())
+
+    def test_has_fetters_true_when_sufficient(self):
+        """has_fetters returns True when total == 10."""
+        self.wraith.add_fetter("object", "Ring", rating=5)
+        self.wraith.add_fetter("person", "Daughter", rating=5)
+        self.assertTrue(self.wraith.has_fetters())
+
+
+class TestWraithShadow(WraithTestCase):
+    """Tests for Wraith shadow archetype and thorn methods."""
+
+    def setUp(self):
+        super().setUp()
+        self.shadow = ShadowArchetype.objects.create(
+            name="The Director",
+            point_cost=2,
+            core_function="Controls through manipulation",
+            modus_operandi="Uses guilt and obligation",
+            dominance_behavior="Commands attention and obedience",
+            effect_on_psyche="Creates feelings of inadequacy",
+            strengths="Effective in social situations",
+            weaknesses="Struggles with direct confrontation",
+        )
+        self.thorn = Thorn.objects.create(
+            name="Shadow Call",
+            point_cost=2,
+            activation_cost="1 Angst",
+            activation_trigger="When the Wraith experiences strong emotion",
+            mechanical_description="The Shadow can speak through the Wraith",
+            resistance_system="Willpower roll",
+            duration="One scene",
+            frequency_limitation="Once per session",
+            limitations="Cannot be used in Harrowing",
+        )
+
+    def test_has_shadow_false_when_none(self):
+        """has_shadow returns False when no archetype set."""
+        self.assertFalse(self.wraith.has_shadow())
+
+    def test_has_shadow_true_when_set(self):
+        """has_shadow returns True when archetype is set."""
+        self.wraith.shadow_archetype = self.shadow
+        self.assertTrue(self.wraith.has_shadow())
+
+    def test_set_shadow_archetype(self):
+        """set_shadow_archetype assigns archetype to wraith."""
+        result = self.wraith.set_shadow_archetype(self.shadow)
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.shadow_archetype, self.shadow)
+
+    def test_add_thorn_creates_rating(self):
+        """add_thorn creates ThornRating for wraith."""
+        result = self.wraith.add_thorn(self.thorn)
+        self.assertTrue(result)
+        self.assertTrue(ThornRating.objects.filter(wraith=self.wraith, thorn=self.thorn).exists())
+
+    def test_add_thorn_sets_rating_to_one(self):
+        """add_thorn sets rating to 1."""
+        self.wraith.add_thorn(self.thorn)
+        rating = ThornRating.objects.get(wraith=self.wraith, thorn=self.thorn)
+        self.assertEqual(rating.rating, 1)
+
+    def test_add_thorn_returns_false_if_already_added(self):
+        """add_thorn returns False if thorn already at rating 1+."""
+        self.wraith.add_thorn(self.thorn)
+        result = self.wraith.add_thorn(self.thorn)
+        self.assertFalse(result)
+
+
+class TestWraithCorpusPathos(WraithTestCase):
+    """Tests for Wraith corpus and pathos methods."""
+
+    def test_add_corpus(self):
+        """add_corpus increases corpus by 1."""
+        self.assertEqual(self.wraith.corpus, 10)
+        # Corpus is already at 10, so adding won't work
+        result = self.wraith.add_corpus()
+        self.assertFalse(result)
+
+    def test_add_corpus_from_lower_value(self):
+        """add_corpus can increase corpus when below 10."""
+        self.wraith.corpus = 8
+        self.wraith.save()
+        result = self.wraith.add_corpus()
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.corpus, 9)
+
+    def test_add_pathos(self):
+        """add_pathos increases pathos_permanent by 1."""
+        self.assertEqual(self.wraith.pathos_permanent, 5)
+        result = self.wraith.add_pathos()
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.pathos_permanent, 6)
+
+    def test_add_pathos_up_to_max(self):
+        """add_pathos works up to maximum of 10."""
+        self.wraith.pathos_permanent = 9
+        self.wraith.save()
+        result = self.wraith.add_pathos()
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.pathos_permanent, 10)
+        # Cannot exceed 10
+        result = self.wraith.add_pathos()
+        self.assertFalse(result)
+
+    def test_add_angst(self):
+        """add_angst increases angst_permanent by 1."""
+        self.assertEqual(self.wraith.angst_permanent, 0)
+        result = self.wraith.add_angst()
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.angst_permanent, 1)
+
+    def test_add_angst_up_to_max(self):
+        """add_angst works up to maximum of 10."""
+        self.wraith.angst_permanent = 9
+        self.wraith.save()
+        result = self.wraith.add_angst()
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.angst_permanent, 10)
+        # Cannot exceed 10
+        result = self.wraith.add_angst()
+        self.assertFalse(result)
+
+
+class TestWraithHistory(WraithTestCase):
+    """Tests for Wraith history methods."""
+
+    def test_has_wraith_history_false_when_incomplete(self):
+        """has_wraith_history returns False when history incomplete."""
+        self.assertFalse(self.wraith.has_wraith_history())
+        self.wraith.death_description = "Murdered by rival"
+        self.assertFalse(self.wraith.has_wraith_history())
+        self.wraith.death_description = ""
+        self.wraith.age_at_death = 35
+        self.assertFalse(self.wraith.has_wraith_history())
+
+    def test_has_wraith_history_true_when_complete(self):
+        """has_wraith_history returns True when history complete."""
+        self.wraith.death_description = "Murdered by rival"
+        self.wraith.age_at_death = 35
+        self.assertTrue(self.wraith.has_wraith_history())
+
+
+class TestWraithCatharsis(WraithTestCase):
+    """Tests for Wraith catharsis mechanics."""
+
+    def test_check_catharsis_trigger_false_when_angst_low(self):
+        """check_catharsis_trigger returns False when angst <= willpower."""
+        self.wraith.angst = 3
+        self.wraith.willpower = 5
+        self.assertFalse(self.wraith.check_catharsis_trigger())
+
+    def test_check_catharsis_trigger_true_when_angst_high(self):
+        """check_catharsis_trigger returns True when angst > willpower."""
+        self.wraith.angst = 6
+        self.wraith.willpower = 5
+        self.assertTrue(self.wraith.check_catharsis_trigger())
+
+    def test_trigger_catharsis_fails_when_conditions_not_met(self):
+        """trigger_catharsis returns False when conditions not met."""
+        self.wraith.angst = 3
+        self.wraith.willpower = 5
+        result = self.wraith.trigger_catharsis()
+        self.assertFalse(result)
+        self.assertFalse(self.wraith.in_catharsis)
+
+    def test_trigger_catharsis_succeeds_when_conditions_met(self):
+        """trigger_catharsis succeeds when angst > willpower."""
+        self.wraith.angst = 6
+        self.wraith.willpower = 5
+        result = self.wraith.trigger_catharsis()
+        self.assertTrue(result)
+        self.assertTrue(self.wraith.in_catharsis)
+        self.assertTrue(self.wraith.is_shadow_dominant)
+        self.assertEqual(self.wraith.catharsis_count, 1)
+
+    def test_resolve_catharsis_psyche_wins(self):
+        """resolve_catharsis with shadow_won=False restores psyche."""
+        self.wraith.angst = 6
+        self.wraith.willpower = 5
+        self.wraith.trigger_catharsis()
+
+        result = self.wraith.resolve_catharsis(shadow_won=False)
+        self.assertTrue(result)
+        self.assertFalse(self.wraith.in_catharsis)
+        self.assertFalse(self.wraith.is_shadow_dominant)
+
+    def test_resolve_catharsis_shadow_wins(self):
+        """resolve_catharsis with shadow_won=True keeps shadow dominant."""
+        self.wraith.angst = 6
+        self.wraith.willpower = 5
+        self.wraith.trigger_catharsis()
+
+        result = self.wraith.resolve_catharsis(shadow_won=True)
+        self.assertTrue(result)
+        self.assertFalse(self.wraith.in_catharsis)
+        self.assertTrue(self.wraith.is_shadow_dominant)
+
+    def test_get_catharsis_info(self):
+        """get_catharsis_info returns correct state information."""
+        self.wraith.angst = 6
+        self.wraith.willpower = 5
+        self.wraith.trigger_catharsis()
+
+        info = self.wraith.get_catharsis_info()
+        self.assertTrue(info["in_catharsis"])
+        self.assertEqual(info["catharsis_count"], 1)
+        self.assertTrue(info["shadow_dominant"])
+        self.assertEqual(info["angst"], 6)
+        self.assertEqual(info["willpower"], 5)
+
+
+class TestWraithHarrowing(WraithTestCase):
+    """Tests for Wraith harrowing mechanics."""
+
+    def test_check_harrowing_trigger_empty_when_no_triggers(self):
+        """check_harrowing_trigger returns empty list when no triggers."""
+        # Add fetter to avoid "no_fetters" trigger
+        self.wraith.add_fetter("object", "Ring", rating=3)
+        triggers = self.wraith.check_harrowing_trigger()
+        self.assertEqual(triggers, [])
+
+    def test_check_harrowing_trigger_zero_willpower(self):
+        """check_harrowing_trigger detects zero willpower."""
+        self.wraith.willpower = 0
+        triggers = self.wraith.check_harrowing_trigger()
+        self.assertIn("zero_willpower", triggers)
+
+    def test_check_harrowing_trigger_zero_corpus(self):
+        """check_harrowing_trigger detects zero corpus."""
+        self.wraith.corpus = 0
+        triggers = self.wraith.check_harrowing_trigger()
+        self.assertIn("zero_corpus", triggers)
+
+    def test_check_harrowing_trigger_no_fetters(self):
+        """check_harrowing_trigger detects no fetters."""
+        triggers = self.wraith.check_harrowing_trigger()
+        self.assertIn("no_fetters", triggers)
+
+    def test_check_harrowing_trigger_max_angst(self):
+        """check_harrowing_trigger detects max angst."""
+        self.wraith.angst_permanent = 10
+        triggers = self.wraith.check_harrowing_trigger()
+        self.assertIn("max_angst", triggers)
+
+    def test_check_harrowing_trigger_no_fetters_excluded_when_has_fetters(self):
+        """check_harrowing_trigger excludes no_fetters when fetters exist."""
+        self.wraith.add_fetter("object", "Ring", rating=3)
+        triggers = self.wraith.check_harrowing_trigger()
+        self.assertNotIn("no_fetters", triggers)
+
+    def test_trigger_harrowing(self):
+        """trigger_harrowing increments count and returns info."""
+        result = self.wraith.trigger_harrowing(trigger_type="zero_willpower")
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["trigger"], "zero_willpower")
+        self.assertIn("Harrowing #1", result["message"])
+
+    def test_trigger_harrowing_increments_count(self):
+        """trigger_harrowing increments harrowing count."""
+        self.wraith.trigger_harrowing()
+        self.wraith.trigger_harrowing()
+        self.assertEqual(self.wraith.harrowing_count, 2)
+
+    def test_resolve_harrowing_success(self):
+        """resolve_harrowing with success result."""
+        result = self.wraith.resolve_harrowing(result="success")
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.last_harrowing_result, "success")
+
+    def test_resolve_harrowing_catharsis(self):
+        """resolve_harrowing with catharsis reduces angst."""
+        self.wraith.angst_permanent = 5
+        self.wraith.angst = 5
+        result = self.wraith.resolve_harrowing(result="catharsis")
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.last_harrowing_result, "catharsis")
+        self.assertEqual(self.wraith.angst_permanent, 4)
+        self.assertEqual(self.wraith.angst, 2)
+
+    def test_resolve_harrowing_failure_becomes_spectre(self):
+        """resolve_harrowing with failure transforms to spectre."""
+        self.wraith.add_fetter("object", "Ring", rating=3)
+        result = self.wraith.resolve_harrowing(result="failure")
+        # become_spectre returns True when successful
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.character_type, "spectre")
+
+    def test_get_harrowing_info(self):
+        """get_harrowing_info returns correct information."""
+        self.wraith.trigger_harrowing()
+        self.wraith.resolve_harrowing(result="success")
+
+        info = self.wraith.get_harrowing_info()
+        self.assertEqual(info["harrowing_count"], 1)
+        self.assertEqual(info["last_result"], "success")
+
+
+class TestWraithBecomeSpectre(WraithTestCase):
+    """Tests for Wraith becoming a Spectre."""
+
+    def test_become_spectre_changes_type(self):
+        """become_spectre changes character type to spectre."""
+        self.wraith.add_fetter("object", "Ring", rating=5)
+        result = self.wraith.become_spectre()
+        self.assertTrue(result)
+        self.assertEqual(self.wraith.character_type, "spectre")
+
+    def test_become_spectre_sets_shadow_dominant(self):
+        """become_spectre sets is_shadow_dominant to True."""
+        self.wraith.add_fetter("object", "Ring", rating=5)
+        self.wraith.become_spectre()
+        self.assertTrue(self.wraith.is_shadow_dominant)
+
+    def test_become_spectre_sets_spectrehood_date(self):
+        """become_spectre sets spectrehood_date."""
+        self.wraith.add_fetter("object", "Ring", rating=5)
+        self.wraith.become_spectre()
+        self.assertIsNotNone(self.wraith.spectrehood_date)
+
+    def test_become_spectre_converts_passions_to_dark(self):
+        """become_spectre converts passions to dark passions."""
+        self.wraith.add_passion("Love", "Family", rating=3)
+        passion = Passion.objects.get(wraith=self.wraith)
+        self.assertFalse(passion.is_dark_passion)
+
+        self.wraith.become_spectre()
+        passion.refresh_from_db()
+        self.assertTrue(passion.is_dark_passion)
+
+    def test_become_spectre_halves_fetter_ratings(self):
+        """become_spectre halves fetter ratings."""
+        self.wraith.add_fetter("object", "Ring", rating=4)
+        fetter = Fetter.objects.get(wraith=self.wraith)
+        self.assertEqual(fetter.rating, 4)
+
+        self.wraith.become_spectre()
+        fetter.refresh_from_db()
+        self.assertEqual(fetter.rating, 2)
+
+    def test_become_spectre_converts_eidolon_to_angst(self):
+        """become_spectre converts eidolon to angst."""
+        self.wraith.eidolon = 3
+        self.wraith.angst_permanent = 2
+        self.wraith.add_fetter("object", "Ring", rating=4)
+
+        self.wraith.become_spectre()
+        self.assertEqual(self.wraith.eidolon, 0)
+        self.assertEqual(self.wraith.angst_permanent, 5)
+
+    def test_become_spectre_returns_false_if_already_spectre(self):
+        """become_spectre returns False if already a spectre."""
+        self.wraith.character_type = "spectre"
+        result = self.wraith.become_spectre()
+        self.assertFalse(result)
+
+
+class TestWraithRedemption(WraithTestCase):
+    """Tests for Spectre redemption mechanics."""
+
+    def setUp(self):
+        super().setUp()
+        self.wraith.add_fetter("object", "Ring", rating=5)
+        self.wraith.become_spectre()
+
+    def test_attempt_redemption_fails_if_not_spectre(self):
+        """attempt_redemption fails if character is not a spectre."""
+        wraith = Wraith.objects.create(name="Normal Wraith", owner=self.user)
+        result = wraith.attempt_redemption()
+        self.assertFalse(result["success"])
+        self.assertIn("not a Spectre", result["message"])
+
+    def test_attempt_redemption_fails_if_no_fetters(self):
+        """attempt_redemption fails if no fetters remain."""
+        Fetter.objects.filter(wraith=self.wraith).delete()
+        result = self.wraith.attempt_redemption()
+        self.assertFalse(result["success"])
+
+    def test_attempt_redemption_fails_if_angst_too_high(self):
+        """attempt_redemption fails if angst >= 10."""
+        self.wraith.angst_permanent = 10
+        result = self.wraith.attempt_redemption()
+        self.assertFalse(result["success"])
+
+    def test_attempt_redemption_succeeds_if_conditions_met(self):
+        """attempt_redemption succeeds if conditions met."""
+        self.wraith.angst_permanent = 5
+        result = self.wraith.attempt_redemption()
+        self.assertTrue(result["success"])
+        self.assertTrue(result["can_attempt"])
+
+    def test_attempt_redemption_increments_attempts(self):
+        """attempt_redemption increments redemption_attempts."""
+        self.wraith.angst_permanent = 5
+        self.wraith.attempt_redemption()
+        self.assertEqual(self.wraith.redemption_attempts, 1)
+
+    def test_complete_redemption_success(self):
+        """complete_redemption succeeds when psyche wins."""
+        self.wraith.angst_permanent = 5
+        self.wraith.add_passion("Hatred", "Destroy", rating=3, is_dark=True)
+
+        result = self.wraith.complete_redemption(psyche_successes=5, shadow_successes=2)
+        self.assertTrue(result["success"])
+        self.assertEqual(self.wraith.character_type, "wraith")
+        self.assertFalse(self.wraith.is_shadow_dominant)
+
+    def test_complete_redemption_reduces_angst(self):
+        """complete_redemption reduces angst on success."""
+        self.wraith.angst_permanent = 5
+        self.wraith.angst = 8
+
+        result = self.wraith.complete_redemption(psyche_successes=5, shadow_successes=2)
+        self.assertTrue(result["success"])
+        self.assertEqual(self.wraith.angst_permanent, 2)  # Reduced by 3 (5-2)
+        self.assertEqual(self.wraith.angst, 2)  # Reduced by 6 (3*2)
+
+    def test_complete_redemption_failure(self):
+        """complete_redemption fails when shadow wins."""
+        result = self.wraith.complete_redemption(psyche_successes=2, shadow_successes=5)
+        self.assertFalse(result["success"])
+        self.assertEqual(self.wraith.character_type, "spectre")
+
+
+class TestWraithXPCosts(WraithTestCase):
+    """Tests for Wraith XP cost calculations."""
+
+    def test_xp_cost_arcanos(self):
+        """xp_cost returns correct cost for arcanoi."""
+        cost = self.wraith.xp_cost("arcanos", 3)
+        self.assertEqual(cost, 30)  # 10 * 3
+
+    def test_xp_cost_pathos(self):
+        """xp_cost returns correct cost for pathos."""
+        cost = self.wraith.xp_cost("pathos", 2)
+        self.assertEqual(cost, 4)  # 2 * 2
+
+    def test_xp_cost_corpus(self):
+        """xp_cost returns correct cost for corpus."""
+        cost = self.wraith.xp_cost("corpus", 3)
+        self.assertEqual(cost, 3)  # 1 * 3
+
+    def test_xp_cost_angst(self):
+        """xp_cost returns correct cost for angst."""
+        cost = self.wraith.xp_cost("angst", 4)
+        self.assertEqual(cost, 4)  # 1 * 4
+
+    def test_xp_frequencies(self):
+        """xp_frequencies returns correct distribution."""
+        freq = self.wraith.xp_frequencies()
+        self.assertEqual(freq["arcanos"], 37)
+        self.assertEqual(freq["pathos"], 2)
+
+
+class TestWraithFreebieCosts(WraithTestCase):
+    """Tests for Wraith freebie cost calculations."""
+
+    def test_freebie_cost_arcanos(self):
+        """freebie_cost returns correct cost for arcanoi."""
+        cost = self.wraith.freebie_cost("arcanos")
+        self.assertEqual(cost, 7)
+
+    def test_freebie_cost_pathos(self):
+        """freebie_cost returns correct cost for pathos."""
+        cost = self.wraith.freebie_cost("pathos")
+        self.assertEqual(cost, 1)
+
+    def test_freebie_cost_passion(self):
+        """freebie_cost returns correct cost for passion."""
+        cost = self.wraith.freebie_cost("passion")
+        self.assertEqual(cost, 2)
+
+    def test_freebie_cost_fetter(self):
+        """freebie_cost returns correct cost for fetter."""
+        cost = self.wraith.freebie_cost("fetter")
+        self.assertEqual(cost, 1)
+
+    def test_freebie_cost_corpus(self):
+        """freebie_cost returns correct cost for corpus."""
+        cost = self.wraith.freebie_cost("corpus")
+        self.assertEqual(cost, 1)
+
+    def test_freebie_costs(self):
+        """freebie_costs returns correct dictionary."""
+        costs = self.wraith.freebie_costs()
+        self.assertEqual(costs["arcanos"], 7)
+        self.assertEqual(costs["pathos"], 1)
+        self.assertEqual(costs["passion"], 2)
+        self.assertEqual(costs["fetter"], 1)
+        self.assertEqual(costs["corpus"], 1)
+
+    def test_freebie_frequencies(self):
+        """freebie_frequencies returns correct distribution."""
+        freq = self.wraith.freebie_frequencies()
+        self.assertEqual(freq["arcanos"], 25)
+        self.assertEqual(freq["pathos"], 5)
+        self.assertEqual(freq["passion"], 5)
+        self.assertEqual(freq["fetter"], 5)
+        self.assertEqual(freq["corpus"], 5)
+
+
+class TestWraithSpendXP(WraithTestCase):
+    """Tests for Wraith XP spending."""
+
+    def test_spend_xp_on_arcanos_insufficient_xp(self):
+        """spend_xp fails when insufficient XP."""
+        self.wraith.xp = 5
+        self.wraith.argos = 1
+        self.wraith.save()
+
+        result = self.wraith.spend_xp("argos")
+        self.assertFalse(result)
+        self.assertEqual(self.wraith.argos, 1)
+
+
+class TestWraithSpendFreebies(WraithTestCase):
+    """Tests for Wraith freebie spending."""
+
+    def test_spend_freebies_on_arcanos_insufficient(self):
+        """spend_freebies fails when insufficient freebies."""
+        self.wraith.freebies = 5
+        result = self.wraith.spend_freebies("argos")
+        self.assertFalse(result)
+        self.assertEqual(self.wraith.argos, 0)
+
+    def test_spend_freebies_returns_trait_for_special_categories(self):
+        """spend_freebies returns trait name for passion/fetter."""
+        self.wraith.freebies = 10
+        result = self.wraith.spend_freebies("passion")
+        self.assertEqual(result, "passion")
+
+        result = self.wraith.spend_freebies("fetter")
+        self.assertEqual(result, "fetter")
 
 
 class ThornRatingDeleteBehaviorTests(TestCase):
@@ -61,3 +976,8 @@ class ThornRatingDeleteBehaviorTests(TestCase):
     def test_related_name_wraith_ratings_on_thorn(self):
         """Thorn should have wraith_ratings related manager."""
         self.assertIn(self.rating, self.thorn.wraith_ratings.all())
+
+    def test_thorn_rating_str(self):
+        """ThornRating has correct string representation."""
+        expected = f"{self.wraith.name}: {self.thorn.name} (3)"
+        self.assertEqual(str(self.rating), expected)


### PR DESCRIPTION
## Summary
- Add 226 tests covering Wraith character mechanics including:
  - Wraith model: corpus, pathos, angst, arcanoi, and shadow mechanics
  - Catharsis and harrowing mechanics
  - Spectre transformation and redemption
  - Fetter and Passion models with relationships
  - Arcanos model with parent-child hierarchy
  - Guild and WraithFaction models
  - ShadowArchetype and Thorn models
  - WraithCreationForm and WraithFreebiesForm

## Test plan
- [x] All 226 new Wraith tests pass
- [x] Coverage at 83% for characters/models/wraith and characters/forms/wraith
- [x] No regressions in existing tests

Closes #1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)