### PR TITLE
Add tests for Mummy character models and forms

### DIFF
--- a/characters/tests/forms/mummy/test_dynasty.py
+++ b/characters/tests/forms/mummy/test_dynasty.py
@@ -1,5 +1,217 @@
-"""Tests for dynasty module."""
+"""
+Tests for DynastyForm.
 
+Tests cover:
+- Form initialization
+- Widget attribute customization
+- Form validation
+- Form save functionality
+"""
+
+from characters.forms.mummy.dynasty import DynastyForm
+from characters.models.mummy.dynasty import Dynasty
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class TestDynastyFormInitialization(TestCase):
+    """Test form initialization."""
+
+    def test_form_initializes(self):
+        """Form initializes correctly."""
+        form = DynastyForm()
+
+        self.assertIn("name", form.fields)
+        self.assertIn("description", form.fields)
+        self.assertIn("era", form.fields)
+        self.assertIn("favored_hekau", form.fields)
+
+    def test_form_meta_fields(self):
+        """Form has correct fields in Meta."""
+        form = DynastyForm()
+
+        expected_fields = ["name", "description", "era", "favored_hekau"]
+        self.assertEqual(list(form.fields.keys()), expected_fields)
+
+
+class TestDynastyFormWidgetAttrs(TestCase):
+    """Test widget attribute customization."""
+
+    def test_name_placeholder(self):
+        """Name field has correct placeholder."""
+        form = DynastyForm()
+        placeholder = form.fields["name"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter dynasty name")
+
+    def test_description_placeholder(self):
+        """Description field has correct placeholder."""
+        form = DynastyForm()
+        placeholder = form.fields["description"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter description")
+
+    def test_era_placeholder(self):
+        """Era field has correct placeholder."""
+        form = DynastyForm()
+        placeholder = form.fields["era"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "e.g., Old Kingdom, Middle Kingdom")
+
+    def test_favored_hekau_placeholder(self):
+        """Favored hekau field has correct placeholder."""
+        form = DynastyForm()
+        placeholder = form.fields["favored_hekau"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "e.g., Alchemy, Necromancy")
+
+
+class TestDynastyFormValidation(TestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal data."""
+        form = DynastyForm(
+            data={
+                "name": "Test Dynasty",
+            },
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_complete_submission(self):
+        """Valid submission with all fields."""
+        form = DynastyForm(
+            data={
+                "name": "Old Kingdom Dynasty",
+                "description": "A dynasty from the Old Kingdom period.",
+                "era": "Old Kingdom",
+                "favored_hekau": "Necromancy",
+            },
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_empty_submission_invalid(self):
+        """Empty form submission is invalid."""
+        form = DynastyForm(
+            data={},
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+    def test_duplicate_name_invalid(self):
+        """Duplicate dynasty name is invalid."""
+        Dynasty.objects.create(name="Existing Dynasty")
+
+        form = DynastyForm(
+            data={
+                "name": "Existing Dynasty",
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+    def test_optional_fields_blank(self):
+        """Optional fields can be blank."""
+        form = DynastyForm(
+            data={
+                "name": "Minimal Dynasty",
+                "description": "",
+                "era": "",
+                "favored_hekau": "",
+            },
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+
+class TestDynastyFormSave(TestCase):
+    """Test form save functionality."""
+
+    def test_save_creates_dynasty(self):
+        """Form save creates a new Dynasty."""
+        form = DynastyForm(
+            data={
+                "name": "New Dynasty",
+                "era": "New Kingdom",
+                "favored_hekau": "Alchemy",
+            },
+        )
+
+        self.assertTrue(form.is_valid())
+        dynasty = form.save()
+
+        self.assertIsNotNone(dynasty.pk)
+        self.assertEqual(dynasty.name, "New Dynasty")
+        self.assertEqual(dynasty.era, "New Kingdom")
+        self.assertEqual(dynasty.favored_hekau, "Alchemy")
+
+    def test_save_updates_dynasty(self):
+        """Form save updates an existing Dynasty."""
+        dynasty = Dynasty.objects.create(
+            name="Old Name",
+            era="Old Era",
+        )
+
+        form = DynastyForm(
+            data={
+                "name": "Updated Name",
+                "era": "Updated Era",
+            },
+            instance=dynasty,
+        )
+
+        self.assertTrue(form.is_valid())
+        updated = form.save()
+
+        self.assertEqual(updated.pk, dynasty.pk)
+        self.assertEqual(updated.name, "Updated Name")
+        self.assertEqual(updated.era, "Updated Era")
+
+    def test_save_commit_false(self):
+        """Form save with commit=False does not save to database."""
+        form = DynastyForm(
+            data={
+                "name": "Unsaved Dynasty",
+            },
+        )
+
+        self.assertTrue(form.is_valid())
+        dynasty = form.save(commit=False)
+
+        self.assertIsNone(dynasty.pk)
+        self.assertEqual(dynasty.name, "Unsaved Dynasty")
+
+
+class TestDynastyFormWithInstance(TestCase):
+    """Test form with existing Dynasty instance."""
+
+    def setUp(self):
+        """Create a Dynasty for testing."""
+        self.dynasty = Dynasty.objects.create(
+            name="Instance Dynasty",
+            description="An existing dynasty",
+            era="Middle Kingdom",
+            favored_hekau="Celestial",
+        )
+
+    def test_form_populates_from_instance(self):
+        """Form fields are populated from instance."""
+        form = DynastyForm(instance=self.dynasty)
+
+        self.assertEqual(form.initial["name"], "Instance Dynasty")
+        self.assertEqual(form.initial["description"], "An existing dynasty")
+        self.assertEqual(form.initial["era"], "Middle Kingdom")
+        self.assertEqual(form.initial["favored_hekau"], "Celestial")
+
+    def test_instance_update_valid(self):
+        """Updating an instance with valid data."""
+        form = DynastyForm(
+            data={
+                "name": "Instance Dynasty",  # Same name (unique constraint)
+                "description": "Updated description",
+                "era": "New Kingdom",
+                "favored_hekau": "Effigy",
+            },
+            instance=self.dynasty,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")

--- a/characters/tests/forms/mummy/test_mtr_human.py
+++ b/characters/tests/forms/mummy/test_mtr_human.py
@@ -1,5 +1,250 @@
-"""Tests for mtr_human module."""
+"""
+Tests for MtRHumanCreationForm.
 
+Tests cover:
+- Form initialization with user parameter
+- Widget attribute customization
+- Form save with owner assignment
+- Required/optional field handling
+"""
+
+from characters.forms.mummy.mtr_human import MtRHumanCreationForm
+from characters.models.mummy.mtr_human import MtRHuman
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class MtRHumanCreationFormTestCase(TestCase):
+    """Base test case with common setup for MtRHumanCreationForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        cls.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+    def setUp(self):
+        """Set up test users."""
+        self.user = User.objects.create_user(
+            username="test_user",
+            email="test@example.com",
+            password="testpassword",
+        )
+
+
+class TestMtRHumanCreationFormInitialization(MtRHumanCreationFormTestCase):
+    """Test form initialization."""
+
+    def test_form_requires_user(self):
+        """Form initialization requires a user parameter."""
+        with self.assertRaises(KeyError):
+            MtRHumanCreationForm()
+
+    def test_form_initializes_with_user(self):
+        """Form initializes correctly with user."""
+        form = MtRHumanCreationForm(user=self.user)
+
+        self.assertEqual(form.user, self.user)
+        self.assertIn("name", form.fields)
+        self.assertIn("nature", form.fields)
+        self.assertIn("demeanor", form.fields)
+        self.assertIn("concept", form.fields)
+        self.assertIn("chronicle", form.fields)
+        self.assertIn("image", form.fields)
+        self.assertIn("npc", form.fields)
+
+    def test_form_meta_fields(self):
+        """Form has correct fields in Meta."""
+        form = MtRHumanCreationForm(user=self.user)
+
+        expected_fields = [
+            "name",
+            "nature",
+            "demeanor",
+            "concept",
+            "chronicle",
+            "image",
+            "npc",
+        ]
+        self.assertEqual(list(form.fields.keys()), expected_fields)
+
+
+class TestMtRHumanCreationFormFields(MtRHumanCreationFormTestCase):
+    """Test form field configuration."""
+
+    def test_image_not_required(self):
+        """Image field is not required."""
+        form = MtRHumanCreationForm(user=self.user)
+        self.assertFalse(form.fields["image"].required)
+
+
+class TestMtRHumanCreationFormWidgetAttrs(MtRHumanCreationFormTestCase):
+    """Test widget attribute customization."""
+
+    def test_name_placeholder(self):
+        """Name field has correct placeholder."""
+        form = MtRHumanCreationForm(user=self.user)
+        placeholder = form.fields["name"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter name here")
+
+    def test_concept_placeholder(self):
+        """Concept field has correct placeholder."""
+        form = MtRHumanCreationForm(user=self.user)
+        placeholder = form.fields["concept"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter concept here")
+
+
+class TestMtRHumanCreationFormSave(MtRHumanCreationFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_assigns_owner(self):
+        """Form save assigns the user as owner."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "Test Human",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        human = form.save()
+
+        self.assertEqual(human.owner, self.user)
+        self.assertEqual(human.name, "Test Human")
+
+    def test_save_with_concept(self):
+        """Form save with concept."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "Concept Human",
+                "concept": "Egyptian archaeologist",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        human = form.save()
+
+        self.assertEqual(human.concept, "Egyptian archaeologist")
+
+    def test_save_commit_false(self):
+        """Form save with commit=False does not save to database."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "Unsaved Human",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid())
+        human = form.save(commit=False)
+
+        self.assertIsNone(human.pk)
+        self.assertEqual(human.owner, self.user)
+
+    def test_save_with_chronicle(self):
+        """Form save with chronicle assignment."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "Chronicle Human",
+                "chronicle": self.chronicle.pk,
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        human = form.save()
+
+        self.assertEqual(human.chronicle, self.chronicle)
+
+    def test_save_as_npc(self):
+        """Form save with NPC flag."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "NPC Human",
+                "npc": True,
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        human = form.save()
+
+        self.assertTrue(human.npc)
+
+
+class TestMtRHumanCreationFormValidation(MtRHumanCreationFormTestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal data."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "Minimal Human",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_complete_submission(self):
+        """Valid submission with all fields."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "Complete Human",
+                "concept": "Museum curator",
+                "chronicle": self.chronicle.pk,
+                "npc": True,
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_empty_submission_invalid(self):
+        """Empty form submission is invalid."""
+        form = MtRHumanCreationForm(
+            data={},
+            user=self.user,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+
+class TestMtRHumanCreationFormOwnerAssignment(MtRHumanCreationFormTestCase):
+    """Test owner assignment edge cases."""
+
+    def test_save_with_none_user(self):
+        """Form save with None user does not set owner."""
+        form = MtRHumanCreationForm(
+            data={
+                "name": "No Owner Human",
+            },
+            user=None,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        human = form.save()
+
+        self.assertIsNone(human.owner)
+
+    def test_different_user_assignment(self):
+        """Each user gets properly assigned as owner."""
+        user1 = User.objects.create_user(username="user1", password="pass")
+        user2 = User.objects.create_user(username="user2", password="pass")
+
+        form1 = MtRHumanCreationForm(
+            data={"name": "User1 Human"},
+            user=user1,
+        )
+        form2 = MtRHumanCreationForm(
+            data={"name": "User2 Human"},
+            user=user2,
+        )
+
+        human1 = form1.save()
+        human2 = form2.save()
+
+        self.assertEqual(human1.owner, user1)
+        self.assertEqual(human2.owner, user2)

--- a/characters/tests/forms/mummy/test_mummy.py
+++ b/characters/tests/forms/mummy/test_mummy.py
@@ -1,5 +1,258 @@
-"""Tests for mummy module."""
+"""
+Tests for MummyCreationForm.
 
+Tests cover:
+- Form initialization with user parameter
+- Dynasty queryset population
+- Widget attribute customization
+- Form save with owner assignment
+- Required/optional field handling
+"""
+
+from characters.forms.mummy.mummy import MummyCreationForm
+from characters.models.mummy.dynasty import Dynasty
+from characters.models.mummy.mummy import Mummy
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class MummyCreationFormTestCase(TestCase):
+    """Base test case with common setup for MummyCreationForm tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data for all test methods."""
+        cls.dynasty_old = Dynasty.objects.create(
+            name="Old Kingdom Dynasty",
+            era="Old Kingdom",
+            favored_hekau="Necromancy",
+        )
+        cls.dynasty_middle = Dynasty.objects.create(
+            name="Middle Kingdom Dynasty",
+            era="Middle Kingdom",
+            favored_hekau="Alchemy",
+        )
+        cls.chronicle = Chronicle.objects.create(name="Test Chronicle")
+
+    def setUp(self):
+        """Set up test users."""
+        self.user = User.objects.create_user(
+            username="test_user",
+            email="test@example.com",
+            password="testpassword",
+        )
+
+
+class TestMummyCreationFormInitialization(MummyCreationFormTestCase):
+    """Test form initialization."""
+
+    def test_form_requires_user(self):
+        """Form initialization requires a user parameter."""
+        with self.assertRaises(KeyError):
+            MummyCreationForm()
+
+    def test_form_initializes_with_user(self):
+        """Form initializes correctly with user."""
+        form = MummyCreationForm(user=self.user)
+
+        self.assertEqual(form.user, self.user)
+        self.assertIn("name", form.fields)
+        self.assertIn("nature", form.fields)
+        self.assertIn("demeanor", form.fields)
+        self.assertIn("concept", form.fields)
+        self.assertIn("dynasty", form.fields)
+        self.assertIn("web", form.fields)
+        self.assertIn("ancient_name", form.fields)
+        self.assertIn("chronicle", form.fields)
+        self.assertIn("image", form.fields)
+        self.assertIn("npc", form.fields)
+
+    def test_dynasty_queryset_populated(self):
+        """Dynasty field queryset contains all dynasties."""
+        form = MummyCreationForm(user=self.user)
+
+        dynasty_qs = form.fields["dynasty"].queryset
+        self.assertIn(self.dynasty_old, dynasty_qs)
+        self.assertIn(self.dynasty_middle, dynasty_qs)
+        self.assertEqual(dynasty_qs.count(), 2)
+
+
+class TestMummyCreationFormFields(MummyCreationFormTestCase):
+    """Test form field configuration."""
+
+    def test_dynasty_not_required(self):
+        """Dynasty field is not required."""
+        form = MummyCreationForm(user=self.user)
+        self.assertFalse(form.fields["dynasty"].required)
+
+    def test_image_not_required(self):
+        """Image field is not required."""
+        form = MummyCreationForm(user=self.user)
+        self.assertFalse(form.fields["image"].required)
+
+
+class TestMummyCreationFormWidgetAttrs(MummyCreationFormTestCase):
+    """Test widget attribute customization."""
+
+    def test_name_placeholder(self):
+        """Name field has correct placeholder."""
+        form = MummyCreationForm(user=self.user)
+        placeholder = form.fields["name"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter name here")
+
+    def test_concept_placeholder(self):
+        """Concept field has correct placeholder."""
+        form = MummyCreationForm(user=self.user)
+        placeholder = form.fields["concept"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter concept here")
+
+    def test_ancient_name_placeholder(self):
+        """Ancient name field has correct placeholder."""
+        form = MummyCreationForm(user=self.user)
+        placeholder = form.fields["ancient_name"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Name from First Life in ancient Egypt")
+
+
+class TestMummyCreationFormSave(MummyCreationFormTestCase):
+    """Test form save functionality."""
+
+    def test_save_assigns_owner(self):
+        """Form save assigns the user as owner."""
+        form = MummyCreationForm(
+            data={
+                "name": "Test Mummy",
+                "web": "isis",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        mummy = form.save()
+
+        self.assertEqual(mummy.owner, self.user)
+        self.assertEqual(mummy.name, "Test Mummy")
+        self.assertEqual(mummy.web, "isis")
+
+    def test_save_with_dynasty(self):
+        """Form save with dynasty assignment."""
+        form = MummyCreationForm(
+            data={
+                "name": "Dynasty Mummy",
+                "web": "osiris",
+                "dynasty": self.dynasty_old.pk,
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        mummy = form.save()
+
+        self.assertEqual(mummy.dynasty, self.dynasty_old)
+
+    def test_save_with_ancient_name(self):
+        """Form save with ancient name."""
+        form = MummyCreationForm(
+            data={
+                "name": "Modern Name",
+                "ancient_name": "Imhotep",
+                "web": "thoth",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        mummy = form.save()
+
+        self.assertEqual(mummy.ancient_name, "Imhotep")
+
+    def test_save_commit_false(self):
+        """Form save with commit=False does not save to database."""
+        form = MummyCreationForm(
+            data={
+                "name": "Unsaved Mummy",
+                "web": "maat",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid())
+        mummy = form.save(commit=False)
+
+        self.assertIsNone(mummy.pk)
+        self.assertEqual(mummy.owner, self.user)
+
+    def test_save_with_chronicle(self):
+        """Form save with chronicle assignment."""
+        form = MummyCreationForm(
+            data={
+                "name": "Chronicle Mummy",
+                "web": "horus",
+                "chronicle": self.chronicle.pk,
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        mummy = form.save()
+
+        self.assertEqual(mummy.chronicle, self.chronicle)
+
+
+class TestMummyCreationFormValidation(MummyCreationFormTestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal data."""
+        form = MummyCreationForm(
+            data={
+                "name": "Minimal Mummy",
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_complete_submission(self):
+        """Valid submission with all fields."""
+        form = MummyCreationForm(
+            data={
+                "name": "Complete Mummy",
+                "concept": "Ancient guardian",
+                "web": "isis",
+                "dynasty": self.dynasty_old.pk,
+                "ancient_name": "Nefertari",
+                "chronicle": self.chronicle.pk,
+                "npc": True,
+            },
+            user=self.user,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_all_web_choices_valid(self):
+        """All Web choices are valid."""
+        web_choices = ["isis", "osiris", "horus", "maat", "thoth"]
+
+        for web in web_choices:
+            form = MummyCreationForm(
+                data={
+                    "name": f"Mummy of {web.title()}",
+                    "web": web,
+                },
+                user=self.user,
+            )
+            self.assertTrue(
+                form.is_valid(),
+                f"Web '{web}' should be valid. Errors: {form.errors}",
+            )
+
+    def test_empty_submission_invalid(self):
+        """Empty form submission is invalid."""
+        form = MummyCreationForm(
+            data={},
+            user=self.user,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)

--- a/characters/tests/forms/mummy/test_mummy_title.py
+++ b/characters/tests/forms/mummy/test_mummy_title.py
@@ -1,5 +1,212 @@
-"""Tests for mummy_title module."""
+"""
+Tests for MummyTitleForm.
 
+Tests cover:
+- Form initialization
+- Widget attribute customization
+- Form validation
+- Form save functionality
+"""
+
+from characters.forms.mummy.mummy_title import MummyTitleForm
+from characters.models.mummy.mummy_title import MummyTitle
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMummyTitleFormInitialization(TestCase):
+    """Test form initialization."""
+
+    def test_form_initializes(self):
+        """Form initializes correctly."""
+        form = MummyTitleForm()
+
+        self.assertIn("name", form.fields)
+        self.assertIn("rank_level", form.fields)
+        self.assertIn("description", form.fields)
+
+    def test_form_meta_fields(self):
+        """Form has correct fields in Meta."""
+        form = MummyTitleForm()
+
+        expected_fields = ["name", "rank_level", "description"]
+        self.assertEqual(list(form.fields.keys()), expected_fields)
+
+
+class TestMummyTitleFormWidgetAttrs(TestCase):
+    """Test widget attribute customization."""
+
+    def test_name_placeholder(self):
+        """Name field has correct placeholder."""
+        form = MummyTitleForm()
+        placeholder = form.fields["name"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter title name")
+
+    def test_description_placeholder(self):
+        """Description field has correct placeholder."""
+        form = MummyTitleForm()
+        placeholder = form.fields["description"].widget.attrs.get("placeholder")
+        self.assertEqual(placeholder, "Enter description")
+
+
+class TestMummyTitleFormValidation(TestCase):
+    """Test form validation."""
+
+    def test_valid_minimal_submission(self):
+        """Valid submission with minimal data."""
+        form = MummyTitleForm(
+            data={
+                "name": "Test Title",
+                "rank_level": 0,
+            },
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_valid_complete_submission(self):
+        """Valid submission with all fields."""
+        form = MummyTitleForm(
+            data={
+                "name": "High Priest",
+                "rank_level": 5,
+                "description": "The highest rank in the temple hierarchy.",
+            },
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_empty_submission_invalid(self):
+        """Empty form submission is invalid."""
+        form = MummyTitleForm(
+            data={},
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+    def test_duplicate_name_invalid(self):
+        """Duplicate title name is invalid."""
+        MummyTitle.objects.create(name="Existing Title")
+
+        form = MummyTitleForm(
+            data={
+                "name": "Existing Title",
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+    def test_optional_fields_blank(self):
+        """Optional fields can be blank."""
+        form = MummyTitleForm(
+            data={
+                "name": "Minimal Title",
+                "rank_level": 1,
+                "description": "",
+            },
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_rank_level_required(self):
+        """rank_level is a required field."""
+        form = MummyTitleForm(
+            data={
+                "name": "No Rank Title",
+            },
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("rank_level", form.errors)
+
+
+class TestMummyTitleFormSave(TestCase):
+    """Test form save functionality."""
+
+    def test_save_creates_title(self):
+        """Form save creates a new MummyTitle."""
+        form = MummyTitleForm(
+            data={
+                "name": "New Title",
+                "rank_level": 3,
+                "description": "A new title for testing.",
+            },
+        )
+
+        self.assertTrue(form.is_valid())
+        title = form.save()
+
+        self.assertIsNotNone(title.pk)
+        self.assertEqual(title.name, "New Title")
+        self.assertEqual(title.rank_level, 3)
+        self.assertEqual(title.description, "A new title for testing.")
+
+    def test_save_updates_title(self):
+        """Form save updates an existing MummyTitle."""
+        title = MummyTitle.objects.create(
+            name="Old Name",
+            rank_level=1,
+        )
+
+        form = MummyTitleForm(
+            data={
+                "name": "Updated Name",
+                "rank_level": 5,
+            },
+            instance=title,
+        )
+
+        self.assertTrue(form.is_valid())
+        updated = form.save()
+
+        self.assertEqual(updated.pk, title.pk)
+        self.assertEqual(updated.name, "Updated Name")
+        self.assertEqual(updated.rank_level, 5)
+
+    def test_save_commit_false(self):
+        """Form save with commit=False does not save to database."""
+        form = MummyTitleForm(
+            data={
+                "name": "Unsaved Title",
+                "rank_level": 2,
+            },
+        )
+
+        self.assertTrue(form.is_valid())
+        title = form.save(commit=False)
+
+        self.assertIsNone(title.pk)
+        self.assertEqual(title.name, "Unsaved Title")
+
+
+class TestMummyTitleFormWithInstance(TestCase):
+    """Test form with existing MummyTitle instance."""
+
+    def setUp(self):
+        """Create a MummyTitle for testing."""
+        self.title = MummyTitle.objects.create(
+            name="Instance Title",
+            rank_level=4,
+            description="An existing title",
+        )
+
+    def test_form_populates_from_instance(self):
+        """Form fields are populated from instance."""
+        form = MummyTitleForm(instance=self.title)
+
+        self.assertEqual(form.initial["name"], "Instance Title")
+        self.assertEqual(form.initial["rank_level"], 4)
+        self.assertEqual(form.initial["description"], "An existing title")
+
+    def test_instance_update_valid(self):
+        """Updating an instance with valid data."""
+        form = MummyTitleForm(
+            data={
+                "name": "Instance Title",  # Same name (unique constraint)
+                "rank_level": 5,
+                "description": "Updated description",
+            },
+            instance=self.title,
+        )
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")

--- a/characters/tests/models/mummy/test_mummy.py
+++ b/characters/tests/models/mummy/test_mummy.py
@@ -289,3 +289,592 @@ class TestMtRHumanListView(TestCase):
         """List view URL should resolve correctly."""
         url = reverse("characters:mummy:list:mtrhuman")
         self.assertEqual(url, "/characters/mummy/list/mtrhuman/")
+
+
+class TestMummyHekauMethods(TestCase):
+    """Test Mummy Hekau magic system methods."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.mummy = Mummy.objects.create(
+            name="Hekau Test Mummy",
+            owner=self.player,
+            web="isis",
+            sekhem=3,
+        )
+
+    def test_get_hekau_empty(self):
+        """get_hekau returns empty dict when no Hekau is learned."""
+        hekau = self.mummy.get_hekau()
+        self.assertEqual(hekau, {})
+
+    def test_get_hekau_all_paths(self):
+        """get_hekau returns all non-zero paths."""
+        self.mummy.alchemy = 1
+        self.mummy.celestial = 2
+        self.mummy.effigy = 3
+        self.mummy.necromancy = 4
+        self.mummy.nomenclature = 5
+        self.mummy.ushabti = 1
+        self.mummy.judge = 2
+        self.mummy.phoenix = 3
+        self.mummy.vision = 4
+        self.mummy.divination = 5
+        self.mummy.save()
+
+        hekau = self.mummy.get_hekau()
+        self.assertEqual(len(hekau), 10)
+        self.assertEqual(hekau["Alchemy"], 1)
+        self.assertEqual(hekau["Celestial"], 2)
+        self.assertEqual(hekau["Effigy"], 3)
+        self.assertEqual(hekau["Necromancy"], 4)
+        self.assertEqual(hekau["Nomenclature"], 5)
+        self.assertEqual(hekau["Ushabti"], 1)
+        self.assertEqual(hekau["Judge"], 2)
+        self.assertEqual(hekau["Phoenix"], 3)
+        self.assertEqual(hekau["Vision"], 4)
+        self.assertEqual(hekau["Divination"], 5)
+
+    def test_is_web_hekau_all_webs(self):
+        """Test is_web_hekau for all web types."""
+        # Test Isis - favors Ushabti
+        self.mummy.web = "isis"
+        self.assertTrue(self.mummy.is_web_hekau("ushabti"))
+        self.assertFalse(self.mummy.is_web_hekau("judge"))
+
+        # Test Osiris - favors Judge
+        self.mummy.web = "osiris"
+        self.assertTrue(self.mummy.is_web_hekau("judge"))
+        self.assertFalse(self.mummy.is_web_hekau("ushabti"))
+
+        # Test Horus - favors Phoenix
+        self.mummy.web = "horus"
+        self.assertTrue(self.mummy.is_web_hekau("phoenix"))
+        self.assertFalse(self.mummy.is_web_hekau("judge"))
+
+        # Test Ma'at - favors Vision
+        self.mummy.web = "maat"
+        self.assertTrue(self.mummy.is_web_hekau("vision"))
+        self.assertFalse(self.mummy.is_web_hekau("phoenix"))
+
+        # Test Thoth - favors Divination
+        self.mummy.web = "thoth"
+        self.assertTrue(self.mummy.is_web_hekau("divination"))
+        self.assertFalse(self.mummy.is_web_hekau("vision"))
+
+    def test_is_web_hekau_case_insensitive(self):
+        """is_web_hekau should be case-insensitive."""
+        self.mummy.web = "isis"
+        self.assertTrue(self.mummy.is_web_hekau("USHABTI"))
+        self.assertTrue(self.mummy.is_web_hekau("Ushabti"))
+        self.assertTrue(self.mummy.is_web_hekau("ushabti"))
+
+    def test_is_web_hekau_empty_web(self):
+        """is_web_hekau with empty web returns False."""
+        self.mummy.web = ""
+        self.assertFalse(self.mummy.is_web_hekau("ushabti"))
+
+    def test_is_web_hekau_invalid_web(self):
+        """is_web_hekau with invalid web returns False."""
+        self.mummy.web = "invalid_web"
+        self.assertFalse(self.mummy.is_web_hekau("ushabti"))
+
+    def test_total_hekau_empty(self):
+        """total_hekau returns 0 when no Hekau is learned."""
+        self.assertEqual(self.mummy.total_hekau(), 0)
+
+    def test_total_hekau_all_paths(self):
+        """total_hekau sums all paths correctly."""
+        self.mummy.alchemy = 1
+        self.mummy.celestial = 1
+        self.mummy.effigy = 1
+        self.mummy.necromancy = 1
+        self.mummy.nomenclature = 1
+        self.mummy.ushabti = 1
+        self.mummy.judge = 1
+        self.mummy.phoenix = 1
+        self.mummy.vision = 1
+        self.mummy.divination = 1
+
+        self.assertEqual(self.mummy.total_hekau(), 10)
+
+    def test_has_hekau_false(self):
+        """has_hekau returns False when no Hekau is learned."""
+        self.assertFalse(self.mummy.has_hekau())
+
+    def test_has_hekau_true(self):
+        """has_hekau returns True when any Hekau is learned."""
+        self.mummy.alchemy = 1
+        self.assertTrue(self.mummy.has_hekau())
+
+
+class TestMummyXPAndFreebieCosts(TestCase):
+    """Test Mummy XP and freebie cost calculations."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.mummy = Mummy.objects.create(
+            name="Cost Test Mummy",
+            owner=self.player,
+            web="isis",
+            sekhem=3,
+        )
+
+    def test_xp_cost_hekau_web(self):
+        """Web-favored Hekau costs 5 XP per level."""
+        cost = self.mummy.xp_cost("hekau_web", 1)
+        self.assertEqual(cost, 5)
+
+        cost = self.mummy.xp_cost("hekau_web", 3)
+        self.assertEqual(cost, 15)
+
+    def test_xp_cost_hekau_universal(self):
+        """Universal Hekau costs 7 XP per level."""
+        cost = self.mummy.xp_cost("hekau_universal", 1)
+        self.assertEqual(cost, 7)
+
+        cost = self.mummy.xp_cost("hekau_universal", 2)
+        self.assertEqual(cost, 14)
+
+    def test_xp_cost_hekau_other(self):
+        """Other Web's Hekau costs 10 XP per level."""
+        cost = self.mummy.xp_cost("hekau_other", 1)
+        self.assertEqual(cost, 10)
+
+    def test_xp_cost_sekhem(self):
+        """Sekhem costs 10 XP per level."""
+        cost = self.mummy.xp_cost("sekhem", 1)
+        self.assertEqual(cost, 10)
+
+    def test_xp_cost_balance(self):
+        """Balance costs 2 XP per level."""
+        cost = self.mummy.xp_cost("balance", 1)
+        self.assertEqual(cost, 2)
+
+    def test_xp_cost_virtue(self):
+        """Virtue costs 2 XP per level."""
+        cost = self.mummy.xp_cost("virtue", 1)
+        self.assertEqual(cost, 2)
+
+    def test_xp_cost_unknown(self):
+        """Unknown trait type defaults to 1 XP per level."""
+        cost = self.mummy.xp_cost("unknown_trait", 1)
+        self.assertEqual(cost, 1)
+
+    def test_xp_cost_no_value(self):
+        """XP cost with no value uses 1."""
+        cost = self.mummy.xp_cost("sekhem")
+        self.assertEqual(cost, 10)
+
+    def test_freebie_cost_hekau(self):
+        """Hekau costs 5 freebies."""
+        cost = self.mummy.freebie_cost("hekau")
+        self.assertEqual(cost, 5)
+
+    def test_freebie_cost_sekhem(self):
+        """Sekhem costs 7 freebies."""
+        cost = self.mummy.freebie_cost("sekhem")
+        self.assertEqual(cost, 7)
+
+    def test_freebie_cost_balance(self):
+        """Balance costs 2 freebies."""
+        cost = self.mummy.freebie_cost("balance")
+        self.assertEqual(cost, 2)
+
+    def test_freebie_cost_virtue(self):
+        """Virtue costs 2 freebies."""
+        cost = self.mummy.freebie_cost("virtue")
+        self.assertEqual(cost, 2)
+
+    def test_freebie_cost_ba(self):
+        """Ba costs 1 freebie per point."""
+        cost = self.mummy.freebie_cost("ba")
+        self.assertEqual(cost, 1)
+
+    def test_freebie_cost_unknown(self):
+        """Unknown trait defaults to 1 freebie."""
+        cost = self.mummy.freebie_cost("unknown_trait")
+        self.assertEqual(cost, 1)
+
+
+class TestMummyBaMethods(TestCase):
+    """Test Mummy Ba spending and regaining methods."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.mummy = Mummy.objects.create(
+            name="Ba Test Mummy",
+            owner=self.player,
+            web="isis",
+            sekhem=3,
+            ba=20,
+        )
+
+    def test_spend_ba_exact_amount(self):
+        """Can spend exactly the amount of Ba available."""
+        self.mummy.ba = 10
+        self.mummy.save()
+
+        result = self.mummy.spend_ba(10)
+        self.assertTrue(result)
+        self.assertEqual(self.mummy.ba, 0)
+
+    def test_spend_ba_zero(self):
+        """Spending 0 Ba is allowed."""
+        result = self.mummy.spend_ba(0)
+        self.assertTrue(result)
+        self.assertEqual(self.mummy.ba, 20)
+
+    def test_regain_ba_zero(self):
+        """Regaining 0 Ba leaves Ba unchanged."""
+        initial_ba = self.mummy.ba
+        self.mummy.regain_ba(0)
+        self.assertEqual(self.mummy.ba, initial_ba)
+
+    def test_regain_ba_at_max(self):
+        """Regaining Ba when already at max does nothing."""
+        self.mummy.ba = self.mummy.ka_rating
+        self.mummy.save()
+
+        self.mummy.regain_ba(10)
+        self.assertEqual(self.mummy.ba, self.mummy.ka_rating)
+
+
+class TestMummyURLMethods(TestCase):
+    """Test Mummy URL generation methods."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.mummy = Mummy.objects.create(
+            name="URL Test Mummy",
+            owner=self.player,
+        )
+
+    def test_get_update_url(self):
+        """get_update_url returns correct URL."""
+        url = self.mummy.get_update_url()
+        expected = reverse("characters:mummy:update:mummy", kwargs={"pk": self.mummy.pk})
+        self.assertEqual(url, expected)
+
+    def test_get_creation_url(self):
+        """get_creation_url returns correct URL."""
+        url = Mummy.get_creation_url()
+        expected = reverse("characters:mummy:create:mummy")
+        self.assertEqual(url, expected)
+
+    def test_get_heading(self):
+        """get_heading returns mtr_heading."""
+        heading = self.mummy.get_heading()
+        self.assertEqual(heading, "mtr_heading")
+
+
+class TestMummyDefaults(TestCase):
+    """Test Mummy default values."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.mummy = Mummy.objects.create(
+            name="Default Test Mummy",
+            owner=self.player,
+        )
+
+    def test_default_balance(self):
+        """Default balance is 5."""
+        self.assertEqual(self.mummy.balance, 5)
+
+    def test_default_sekhem(self):
+        """Default sekhem is 1."""
+        self.assertEqual(self.mummy.sekhem, 1)
+
+    def test_default_ba(self):
+        """Default ba is 10."""
+        self.assertEqual(self.mummy.ba, 10)
+
+    def test_default_conviction(self):
+        """Default conviction is 1."""
+        self.assertEqual(self.mummy.conviction, 1)
+
+    def test_default_restraint(self):
+        """Default restraint is 1."""
+        self.assertEqual(self.mummy.restraint, 1)
+
+    def test_default_incarnation(self):
+        """Default incarnation is 1."""
+        self.assertEqual(self.mummy.incarnation, 1)
+
+    def test_default_years_since_rebirth(self):
+        """Default years since rebirth is 0."""
+        self.assertEqual(self.mummy.years_since_rebirth, 0)
+
+    def test_default_mummified_appearance(self):
+        """Default mummified appearance is 'preserved'."""
+        self.assertEqual(self.mummy.mummified_appearance, "preserved")
+
+    def test_default_can_pass_as_mortal(self):
+        """Default can_pass_as_mortal is True."""
+        self.assertTrue(self.mummy.can_pass_as_mortal)
+
+    def test_default_hekau_values(self):
+        """All Hekau paths default to 0."""
+        self.assertEqual(self.mummy.alchemy, 0)
+        self.assertEqual(self.mummy.celestial, 0)
+        self.assertEqual(self.mummy.effigy, 0)
+        self.assertEqual(self.mummy.necromancy, 0)
+        self.assertEqual(self.mummy.nomenclature, 0)
+        self.assertEqual(self.mummy.ushabti, 0)
+        self.assertEqual(self.mummy.judge, 0)
+        self.assertEqual(self.mummy.phoenix, 0)
+        self.assertEqual(self.mummy.vision, 0)
+        self.assertEqual(self.mummy.divination, 0)
+
+
+class TestMummyRelationships(TestCase):
+    """Test Mummy relationship fields."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.dynasty = Dynasty.objects.create(
+            name="Test Dynasty",
+            era="Old Kingdom",
+        )
+        self.mentor = Mummy.objects.create(
+            name="Mentor Mummy",
+            owner=self.player,
+        )
+        self.title = MummyTitle.objects.create(
+            name="High Priest",
+            rank_level=5,
+        )
+
+    def test_dynasty_relationship(self):
+        """Mummy can have a dynasty."""
+        mummy = Mummy.objects.create(
+            name="Dynasty Mummy",
+            owner=self.player,
+            dynasty=self.dynasty,
+        )
+        self.assertEqual(mummy.dynasty, self.dynasty)
+
+    def test_mentor_relationship(self):
+        """Mummy can have a mentor mummy."""
+        student = Mummy.objects.create(
+            name="Student Mummy",
+            owner=self.player,
+            mentor_mummy=self.mentor,
+        )
+        self.assertEqual(student.mentor_mummy, self.mentor)
+        self.assertIn(student, self.mentor.students.all())
+
+    def test_titles_relationship(self):
+        """Mummy can have multiple titles."""
+        mummy = Mummy.objects.create(
+            name="Titled Mummy",
+            owner=self.player,
+        )
+        mummy.titles.add(self.title)
+        self.assertIn(self.title, mummy.titles.all())
+
+    def test_dynasty_null_on_delete(self):
+        """Deleting dynasty sets mummy's dynasty to null."""
+        mummy = Mummy.objects.create(
+            name="Dynasty Mummy",
+            owner=self.player,
+            dynasty=self.dynasty,
+        )
+        dynasty_id = self.dynasty.id
+        self.dynasty.delete()
+        mummy.refresh_from_db()
+        self.assertIsNone(mummy.dynasty)
+
+    def test_mentor_null_on_delete(self):
+        """Deleting mentor mummy sets student's mentor to null."""
+        student = Mummy.objects.create(
+            name="Student Mummy",
+            owner=self.player,
+            mentor_mummy=self.mentor,
+        )
+        self.mentor.delete()
+        student.refresh_from_db()
+        self.assertIsNone(student.mentor_mummy)
+
+
+class TestDynastyURLMethods(TestCase):
+    """Test Dynasty URL generation methods."""
+
+    def setUp(self):
+        self.dynasty = Dynasty.objects.create(
+            name="URL Test Dynasty",
+            era="Old Kingdom",
+        )
+
+    def test_get_update_url(self):
+        """get_update_url returns correct URL."""
+        url = self.dynasty.get_update_url()
+        expected = reverse("characters:mummy:update:dynasty", kwargs={"pk": self.dynasty.pk})
+        self.assertEqual(url, expected)
+
+    def test_get_creation_url(self):
+        """get_creation_url returns correct URL."""
+        url = Dynasty.get_creation_url()
+        expected = reverse("characters:mummy:create:dynasty")
+        self.assertEqual(url, expected)
+
+
+class TestMummyTitleURLMethods(TestCase):
+    """Test MummyTitle URL generation methods."""
+
+    def setUp(self):
+        self.title = MummyTitle.objects.create(
+            name="URL Test Title",
+            rank_level=1,
+        )
+
+    def test_get_update_url(self):
+        """get_update_url returns correct URL."""
+        url = self.title.get_update_url()
+        expected = reverse("characters:mummy:update:title", kwargs={"pk": self.title.pk})
+        self.assertEqual(url, expected)
+
+    def test_get_creation_url(self):
+        """get_creation_url returns correct URL."""
+        url = MummyTitle.get_creation_url()
+        expected = reverse("characters:mummy:create:title")
+        self.assertEqual(url, expected)
+
+
+class TestMtRHumanURLMethods(TestCase):
+    """Test MtRHuman URL generation methods."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.human = MtRHuman.objects.create(
+            name="URL Test Human",
+            owner=self.player,
+        )
+
+    def test_get_update_url(self):
+        """get_update_url returns correct URL."""
+        url = self.human.get_update_url()
+        expected = reverse("characters:mummy:update:mtrhuman", kwargs={"pk": self.human.pk})
+        self.assertEqual(url, expected)
+
+    def test_get_creation_url(self):
+        """get_creation_url returns correct URL."""
+        url = MtRHuman.get_creation_url()
+        expected = reverse("characters:mummy:create:mtrhuman")
+        self.assertEqual(url, expected)
+
+    def test_get_heading(self):
+        """get_heading returns mtr_heading."""
+        heading = self.human.get_heading()
+        self.assertEqual(heading, "mtr_heading")
+
+
+class TestMtRHumanAbilityLists(TestCase):
+    """Test MtRHuman ability list configuration."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.human = MtRHuman.objects.create(
+            name="Ability Test Human",
+            owner=self.player,
+        )
+
+    def test_talents_list(self):
+        """Verify talents list is complete."""
+        expected_talents = [
+            "alertness", "athletics", "brawl", "empathy", "expression",
+            "intimidation", "streetwise", "subterfuge", "awareness", "leadership",
+        ]
+        for talent in expected_talents:
+            self.assertIn(talent, self.human.talents)
+        self.assertEqual(len(self.human.talents), 10)
+
+    def test_skills_list(self):
+        """Verify skills list is complete."""
+        expected_skills = [
+            "crafts", "drive", "etiquette", "firearms", "melee", "stealth",
+            "animal_ken", "larceny", "meditation", "performance", "survival",
+        ]
+        for skill in expected_skills:
+            self.assertIn(skill, self.human.skills)
+        self.assertEqual(len(self.human.skills), 11)
+
+    def test_knowledges_list(self):
+        """Verify knowledges list is complete."""
+        expected_knowledges = [
+            "academics", "computer", "investigation", "medicine", "science",
+            "enigmas", "law", "occult", "politics", "technology", "theology",
+        ]
+        for knowledge in expected_knowledges:
+            self.assertIn(knowledge, self.human.knowledges)
+        self.assertEqual(len(self.human.knowledges), 11)
+
+    def test_allowed_backgrounds_list(self):
+        """Verify allowed backgrounds list is complete."""
+        expected_backgrounds = [
+            "contacts", "mentor", "allies", "resources", "retainers",
+            "cult", "tomb", "rank", "remembrance", "vessel", "artifact",
+            "ka", "amenti_companion",
+        ]
+        for background in expected_backgrounds:
+            self.assertIn(background, self.human.allowed_backgrounds)
+        self.assertEqual(len(self.human.allowed_backgrounds), 13)
+
+
+class TestMtRHumanDefaults(TestCase):
+    """Test MtRHuman default values."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player")
+        self.human = MtRHuman.objects.create(
+            name="Default Test Human",
+            owner=self.player,
+        )
+
+    def test_default_additional_talents(self):
+        """Additional talents default to 0."""
+        self.assertEqual(self.human.awareness, 0)
+        self.assertEqual(self.human.leadership, 0)
+
+    def test_default_additional_skills(self):
+        """Additional skills default to 0."""
+        self.assertEqual(self.human.animal_ken, 0)
+        self.assertEqual(self.human.larceny, 0)
+        self.assertEqual(self.human.meditation, 0)
+        self.assertEqual(self.human.performance, 0)
+        self.assertEqual(self.human.survival, 0)
+
+    def test_default_additional_knowledges(self):
+        """Additional knowledges default to 0."""
+        self.assertEqual(self.human.enigmas, 0)
+        self.assertEqual(self.human.law, 0)
+        self.assertEqual(self.human.occult, 0)
+        self.assertEqual(self.human.politics, 0)
+        self.assertEqual(self.human.technology, 0)
+        self.assertEqual(self.human.theology, 0)
+
+    def test_default_mummy_backgrounds(self):
+        """Mummy-specific backgrounds default to 0."""
+        self.assertEqual(self.human.allies, 0)
+        self.assertEqual(self.human.resources, 0)
+        self.assertEqual(self.human.retainers, 0)
+        self.assertEqual(self.human.tomb, 0)
+        self.assertEqual(self.human.rank, 0)
+        self.assertEqual(self.human.remembrance, 0)
+        self.assertEqual(self.human.vessel, 0)
+        self.assertEqual(self.human.artifact, 0)
+        self.assertEqual(self.human.ka, 0)
+        self.assertEqual(self.human.amenti_companion, 0)
+
+    def test_freebie_step(self):
+        """MtRHuman freebie_step is 5."""
+        self.assertEqual(self.human.freebie_step, 5)
+
+    def test_mummy_freebie_step(self):
+        """Mummy freebie_step is 7."""
+        mummy = Mummy.objects.create(
+            name="Freebie Test Mummy",
+            owner=self.player,
+        )
+        self.assertEqual(mummy.freebie_step, 7)


### PR DESCRIPTION
## Summary
- Add comprehensive tests for Mummy model methods (Hekau, Ba, XP/freebie costs)
- Add tests for all Hekau magic system methods with edge cases
- Add tests for Dynasty, MummyTitle, and MtRHuman models
- Add comprehensive form tests for MummyCreationForm, DynastyForm, MtRHumanCreationForm, and MummyTitleForm
- Achieve 100% test coverage on all MtR model and form files (up from 39-91%)

## Test plan
- [x] All 157 MtR tests pass
- [x] 100% code coverage on all MtR files verified via `coverage report`
- [x] Form initialization, validation, save, and widget attribute tests
- [x] Model default values, relationships, and URL methods tested

Closes #1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)