### PR TITLE
Fix #1179: Improve DtF test coverage to 73%

### DIFF
--- a/characters/models/demon/earthbound.py
+++ b/characters/models/demon/earthbound.py
@@ -198,7 +198,7 @@ class Earthbound(LoreBlock, DtFHuman):
 
     # CELESTIAL IDENTITY
     celestial_name = models.CharField(
-        max_length=200, default="", help_text="The demon's Celestial Name"
+        max_length=200, default="", blank=True, help_text="The demon's Celestial Name"
     )
 
     # HISTORY

--- a/characters/models/demon/faction.py
+++ b/characters/models/demon/faction.py
@@ -9,10 +9,10 @@ class DemonFaction(Model):
     type = "demon_faction"
     gameline = "dtf"
 
-    philosophy = models.TextField(default="")
-    goal = models.TextField(default="")
-    leadership = models.TextField(default="")
-    tactics = models.TextField(default="")
+    philosophy = models.TextField(default="", blank=True)
+    goal = models.TextField(default="", blank=True)
+    leadership = models.TextField(default="", blank=True)
+    tactics = models.TextField(default="", blank=True)
 
     class Meta:
         verbose_name = "Demon Faction"

--- a/characters/models/demon/house.py
+++ b/characters/models/demon/house.py
@@ -13,7 +13,7 @@ class DemonHouse(Model):
     starting_torment = models.IntegerField(default=3)
 
     # Domain/specialty description
-    domain = models.TextField(default="")
+    domain = models.TextField(default="", blank=True)
 
     class Meta:
         verbose_name = "House"

--- a/characters/models/demon/lore.py
+++ b/characters/models/demon/lore.py
@@ -16,7 +16,7 @@ class Lore(Model):
     houses = models.ManyToManyField(DemonHouse, blank=True, related_name="lores")
 
     # Description of what this lore does
-    description = models.TextField(default="")
+    description = models.TextField(default="", blank=True)
 
     class Meta:
         verbose_name = "Lore"

--- a/characters/models/demon/pact.py
+++ b/characters/models/demon/pact.py
@@ -8,10 +8,10 @@ class Pact(models.Model):
     demon = models.ForeignKey("Demon", on_delete=models.CASCADE, null=True)
     thrall = models.ForeignKey("Thrall", on_delete=models.CASCADE, null=True)
 
-    terms = models.TextField(default="")
+    terms = models.TextField(default="", blank=True)
     faith_payment = models.IntegerField(default=0)  # How much Faith thrall provides per interval
     enhancements = models.JSONField(
-        default=list
+        default=list, blank=True
     )  # List of enhancements granted (list is callable - safe)
 
     active = models.BooleanField(default=True)

--- a/characters/models/demon/thrall.py
+++ b/characters/models/demon/thrall.py
@@ -28,7 +28,7 @@ class Thrall(DtFHuman):
     )
 
     # Enhancements granted by pact
-    enhancements = models.JSONField(default=list)  # list is callable - safe
+    enhancements = models.JSONField(default=list, blank=True)  # list is callable - safe
 
     # Virtues (same as demons)
     conviction = models.IntegerField(default=1)

--- a/characters/tests/models/demon/test_apocalyptic_form.py
+++ b/characters/tests/models/demon/test_apocalyptic_form.py
@@ -1,5 +1,537 @@
-"""Tests for apocalyptic_form module."""
+"""Tests for ApocalypticForm and ApocalypticFormTrait models."""
 
+from characters.models.demon.apocalyptic_form import (
+    ApocalypticForm,
+    ApocalypticFormTrait,
+)
+from characters.models.demon.house import DemonHouse
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class ApocalypticFormTraitModelTests(TestCase):
+    """Tests for ApocalypticFormTrait model functionality."""
+
+    def setUp(self):
+        """Create a test user for ownership."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.trait = ApocalypticFormTrait.objects.create(
+            name="Wings",
+            description="Manifest wings for flight",
+            cost=2,
+            owner=self.user,
+        )
+
+    def test_default_values(self):
+        """Test default values for ApocalypticFormTrait fields."""
+        trait = ApocalypticFormTrait.objects.create(name="Simple Trait", owner=self.user)
+        self.assertEqual(trait.cost, 1)
+        self.assertEqual(trait.description, "")
+        self.assertFalse(trait.high_torment_only)
+        self.assertIsNone(trait.house)
+
+    def test_type_and_gameline(self):
+        """Test type and gameline values."""
+        self.assertEqual(self.trait.type, "apocalyptic_form_trait")
+        self.assertEqual(self.trait.gameline, "dtf")
+
+    def test_str_representation(self):
+        """Test string representation of trait."""
+        self.assertEqual(str(self.trait), "Wings (2 pts)")
+
+    def test_str_representation_high_torment_only(self):
+        """Test string representation for high torment only trait."""
+        trait = ApocalypticFormTrait.objects.create(
+            name="Terrifying Visage",
+            cost=3,
+            high_torment_only=True,
+            owner=self.user,
+        )
+        self.assertEqual(str(trait), "Terrifying Visage (3 pts) (High Torment Only)")
+
+
+    def test_get_heading(self):
+        """Test get_heading returns DTF heading."""
+        self.assertEqual(self.trait.get_heading(), "dtf_heading")
+
+    def test_house_relationship(self):
+        """Test trait can be associated with a house."""
+        house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", owner=self.user
+        )
+        trait = ApocalypticFormTrait.objects.create(
+            name="Devilish Charm",
+            cost=2,
+            house=house,
+            owner=self.user,
+        )
+        self.assertEqual(trait.house, house)
+        self.assertIn(trait, house.apocalyptic_traits.all())
+
+    def test_ordering_by_cost_then_name(self):
+        """Traits should be ordered by cost, then by name."""
+        trait1 = ApocalypticFormTrait.objects.create(name="Zephyr", cost=1, owner=self.user)
+        trait2 = ApocalypticFormTrait.objects.create(name="Alpha", cost=2, owner=self.user)
+        trait3 = ApocalypticFormTrait.objects.create(name="Beta", cost=1, owner=self.user)
+
+        traits = list(ApocalypticFormTrait.objects.filter(pk__in=[trait1.pk, trait2.pk, trait3.pk]))
+        # Cost 1: Beta, Zephyr (alphabetical), then Cost 2: Alpha
+        self.assertEqual(traits[0], trait3)  # Beta (cost 1)
+        self.assertEqual(traits[1], trait1)  # Zephyr (cost 1)
+        self.assertEqual(traits[2], trait2)  # Alpha (cost 2)
+
+
+class ApocalypticFormModelTests(TestCase):
+    """Tests for ApocalypticForm model functionality."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        # Create some traits for testing
+        self.low_cost_trait = ApocalypticFormTrait.objects.create(
+            name="Minor Power",
+            cost=1,
+            owner=self.user,
+        )
+        self.medium_cost_trait = ApocalypticFormTrait.objects.create(
+            name="Medium Power",
+            cost=2,
+            owner=self.user,
+        )
+        self.high_cost_trait = ApocalypticFormTrait.objects.create(
+            name="Major Power",
+            cost=3,
+            owner=self.user,
+        )
+        self.high_torment_only_trait = ApocalypticFormTrait.objects.create(
+            name="Terrifying Aspect",
+            cost=2,
+            high_torment_only=True,
+            owner=self.user,
+        )
+
+    def test_type_and_gameline(self):
+        """Test type and gameline values."""
+        self.assertEqual(self.form.type, "apocalyptic_form")
+        self.assertEqual(self.form.gameline, "dtf")
+
+    def test_str_representation(self):
+        """Test string representation of form."""
+        self.assertEqual(str(self.form), "Test Form")
+
+
+    def test_get_heading(self):
+        """Test get_heading returns DTF heading."""
+        self.assertEqual(self.form.get_heading(), "dtf_heading")
+
+    def test_ordering_by_name(self):
+        """Forms should be ordered by name."""
+        form_c = ApocalypticForm.objects.create(name="Charlie Form", owner=self.user)
+        form_a = ApocalypticForm.objects.create(name="Alpha Form", owner=self.user)
+        form_b = ApocalypticForm.objects.create(name="Beta Form", owner=self.user)
+
+        forms = list(ApocalypticForm.objects.filter(pk__in=[form_a.pk, form_b.pk, form_c.pk]))
+        self.assertEqual(forms[0], form_a)
+        self.assertEqual(forms[1], form_b)
+        self.assertEqual(forms[2], form_c)
+
+
+class ApocalypticFormTraitCountTests(TestCase):
+    """Tests for trait counting methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        # Create traits
+        self.traits = []
+        for i in range(8):
+            trait = ApocalypticFormTrait.objects.create(
+                name=f"Trait {i}",
+                cost=1,
+                owner=self.user,
+            )
+            self.traits.append(trait)
+
+    def test_low_torment_count_empty(self):
+        """Low torment count should be 0 for empty form."""
+        self.assertEqual(self.form.low_torment_count(), 0)
+
+    def test_high_torment_count_empty(self):
+        """High torment count should be 0 for empty form."""
+        self.assertEqual(self.form.high_torment_count(), 0)
+
+    def test_total_traits_empty(self):
+        """Total traits should be 0 for empty form."""
+        self.assertEqual(self.form.total_traits(), 0)
+
+    def test_low_torment_count_with_traits(self):
+        """Low torment count should reflect added traits."""
+        self.form.low_torment_traits.add(self.traits[0], self.traits[1])
+        self.assertEqual(self.form.low_torment_count(), 2)
+
+    def test_high_torment_count_with_traits(self):
+        """High torment count should reflect added traits."""
+        self.form.high_torment_traits.add(self.traits[0], self.traits[1], self.traits[2])
+        self.assertEqual(self.form.high_torment_count(), 3)
+
+    def test_total_traits_with_both(self):
+        """Total traits should sum low and high torment counts."""
+        self.form.low_torment_traits.add(self.traits[0], self.traits[1])
+        self.form.high_torment_traits.add(self.traits[2], self.traits[3], self.traits[4])
+        self.assertEqual(self.form.total_traits(), 5)
+
+
+class ApocalypticFormPointsTests(TestCase):
+    """Tests for point calculation methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        # Create traits with different costs
+        self.trait_cost_1 = ApocalypticFormTrait.objects.create(
+            name="Cheap Power", cost=1, owner=self.user
+        )
+        self.trait_cost_2 = ApocalypticFormTrait.objects.create(
+            name="Medium Power", cost=2, owner=self.user
+        )
+        self.trait_cost_3 = ApocalypticFormTrait.objects.create(
+            name="Expensive Power", cost=3, owner=self.user
+        )
+        self.trait_cost_2b = ApocalypticFormTrait.objects.create(
+            name="Another Medium", cost=2, owner=self.user
+        )
+
+    def test_low_torment_points_empty(self):
+        """Low torment points should be 0 for empty form."""
+        self.assertEqual(self.form.low_torment_points(), 0)
+
+    def test_high_torment_points_empty(self):
+        """High torment points should be 0 for empty form."""
+        self.assertEqual(self.form.high_torment_points(), 0)
+
+    def test_total_points_empty(self):
+        """Total points should be 0 for empty form."""
+        self.assertEqual(self.form.total_points(), 0)
+
+    def test_points_remaining_empty(self):
+        """Points remaining should be 16 for empty form."""
+        self.assertEqual(self.form.points_remaining(), 16)
+
+    def test_low_torment_points_calculated(self):
+        """Low torment points should sum trait costs."""
+        self.form.low_torment_traits.add(self.trait_cost_1, self.trait_cost_3)
+        self.assertEqual(self.form.low_torment_points(), 4)  # 1 + 3
+
+    def test_high_torment_points_calculated(self):
+        """High torment points should sum trait costs."""
+        self.form.high_torment_traits.add(self.trait_cost_2, self.trait_cost_2b)
+        self.assertEqual(self.form.high_torment_points(), 4)  # 2 + 2
+
+    def test_total_points_both_categories(self):
+        """Total points should sum both low and high torment."""
+        self.form.low_torment_traits.add(self.trait_cost_1, self.trait_cost_2)
+        self.form.high_torment_traits.add(self.trait_cost_3)
+        self.assertEqual(self.form.total_points(), 6)  # 1 + 2 + 3
+
+    def test_points_remaining_with_traits(self):
+        """Points remaining should be 16 minus total points."""
+        self.form.low_torment_traits.add(self.trait_cost_1)
+        self.form.high_torment_traits.add(self.trait_cost_3)
+        self.assertEqual(self.form.points_remaining(), 12)  # 16 - 1 - 3
+
+
+class ApocalypticFormValidationTests(TestCase):
+    """Tests for form validation methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        # Create 8 cost-1 traits for a valid form
+        self.traits = []
+        for i in range(8):
+            trait = ApocalypticFormTrait.objects.create(
+                name=f"Trait {i}", cost=1, owner=self.user
+            )
+            self.traits.append(trait)
+
+    def test_is_valid_empty_form(self):
+        """Empty form should not be valid."""
+        self.assertFalse(self.form.is_valid())
+
+    def test_is_complete_empty_form(self):
+        """Empty form should not be complete."""
+        self.assertFalse(self.form.is_complete())
+
+    def test_is_valid_partial_form(self):
+        """Partial form should not be valid."""
+        self.form.low_torment_traits.add(*self.traits[:2])
+        self.form.high_torment_traits.add(*self.traits[4:6])
+        self.assertFalse(self.form.is_valid())
+
+    def test_is_complete_partial_form(self):
+        """Partial form should not be complete."""
+        self.form.low_torment_traits.add(*self.traits[:3])
+        self.form.high_torment_traits.add(*self.traits[4:7])
+        self.assertFalse(self.form.is_complete())
+
+    def test_is_valid_complete_form(self):
+        """Form with 4+4 traits and points <= 16 should be valid."""
+        self.form.low_torment_traits.add(*self.traits[:4])
+        self.form.high_torment_traits.add(*self.traits[4:8])
+        self.assertTrue(self.form.is_valid())
+
+    def test_is_complete_complete_form(self):
+        """Form with 4+4 traits should be complete."""
+        self.form.low_torment_traits.add(*self.traits[:4])
+        self.form.high_torment_traits.add(*self.traits[4:8])
+        self.assertTrue(self.form.is_complete())
+
+    def test_is_valid_over_point_limit(self):
+        """Form over 16 points should not be valid."""
+        # Create expensive traits
+        expensive_traits = []
+        for i in range(8):
+            trait = ApocalypticFormTrait.objects.create(
+                name=f"Expensive {i}", cost=3, owner=self.user
+            )
+            expensive_traits.append(trait)
+
+        # Add them to form (total = 24 points)
+        self.form.low_torment_traits.set(expensive_traits[:4])
+        self.form.high_torment_traits.set(expensive_traits[4:8])
+        self.assertFalse(self.form.is_valid())
+
+
+class ApocalypticFormCanAddTraitTests(TestCase):
+    """Tests for can_add_*_torment_trait methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        self.normal_trait = ApocalypticFormTrait.objects.create(
+            name="Normal", cost=2, owner=self.user
+        )
+        self.high_torment_only_trait = ApocalypticFormTrait.objects.create(
+            name="High Torment Only", cost=2, high_torment_only=True, owner=self.user
+        )
+
+    def test_can_add_low_torment_trait_empty_form(self):
+        """Should be able to add low torment trait to empty form."""
+        self.assertTrue(self.form.can_add_low_torment_trait(self.normal_trait))
+
+    def test_cannot_add_high_torment_only_to_low_torment(self):
+        """Cannot add high_torment_only trait to low torment list."""
+        self.assertFalse(self.form.can_add_low_torment_trait(self.high_torment_only_trait))
+
+    def test_can_add_high_torment_only_to_high_torment(self):
+        """Can add high_torment_only trait to high torment list."""
+        self.assertTrue(self.form.can_add_high_torment_trait(self.high_torment_only_trait))
+
+    def test_cannot_add_low_torment_when_full(self):
+        """Cannot add to low torment when already has 4 traits."""
+        for i in range(4):
+            trait = ApocalypticFormTrait.objects.create(
+                name=f"Filler {i}", cost=1, owner=self.user
+            )
+            self.form.low_torment_traits.add(trait)
+
+        self.assertFalse(self.form.can_add_low_torment_trait(self.normal_trait))
+
+    def test_cannot_add_high_torment_when_full(self):
+        """Cannot add to high torment when already has 4 traits."""
+        for i in range(4):
+            trait = ApocalypticFormTrait.objects.create(
+                name=f"Filler {i}", cost=1, owner=self.user
+            )
+            self.form.high_torment_traits.add(trait)
+
+        self.assertFalse(self.form.can_add_high_torment_trait(self.normal_trait))
+
+    def test_cannot_add_duplicate_low_torment(self):
+        """Cannot add same trait twice to low torment."""
+        self.form.low_torment_traits.add(self.normal_trait)
+        self.assertFalse(self.form.can_add_low_torment_trait(self.normal_trait))
+
+    def test_cannot_add_duplicate_high_torment(self):
+        """Cannot add same trait twice to high torment."""
+        self.form.high_torment_traits.add(self.normal_trait)
+        self.assertFalse(self.form.can_add_high_torment_trait(self.normal_trait))
+
+    def test_cannot_add_trait_in_other_list_to_low(self):
+        """Cannot add trait already in high torment to low torment."""
+        self.form.high_torment_traits.add(self.normal_trait)
+        self.assertFalse(self.form.can_add_low_torment_trait(self.normal_trait))
+
+    def test_cannot_add_trait_in_other_list_to_high(self):
+        """Cannot add trait already in low torment to high torment."""
+        self.form.low_torment_traits.add(self.normal_trait)
+        self.assertFalse(self.form.can_add_high_torment_trait(self.normal_trait))
+
+    def test_cannot_exceed_point_limit_low_torment(self):
+        """Cannot add trait if it would exceed 16 point limit."""
+        # Add 15 points worth of traits
+        expensive = ApocalypticFormTrait.objects.create(
+            name="Expensive", cost=5, owner=self.user
+        )
+        self.form.low_torment_traits.add(expensive)
+
+        for i in range(3):
+            trait = ApocalypticFormTrait.objects.create(
+                name=f"Cost3 {i}", cost=3, owner=self.user
+            )
+            self.form.high_torment_traits.add(trait)
+        # Total: 5 + 9 = 14 points
+
+        # Try to add a 3-point trait (would be 17)
+        self.assertFalse(self.form.can_add_low_torment_trait(self.high_torment_only_trait))  # Wait, this is high_torment_only
+        three_cost = ApocalypticFormTrait.objects.create(
+            name="Three Cost", cost=3, owner=self.user
+        )
+        self.assertFalse(self.form.can_add_low_torment_trait(three_cost))
+
+
+class ApocalypticFormAddTraitTests(TestCase):
+    """Tests for add_*_torment_trait methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        self.trait = ApocalypticFormTrait.objects.create(
+            name="Power", cost=2, owner=self.user
+        )
+        self.high_only = ApocalypticFormTrait.objects.create(
+            name="Terror", cost=2, high_torment_only=True, owner=self.user
+        )
+
+    def test_add_low_torment_trait_success(self):
+        """Successfully adding low torment trait returns True."""
+        result = self.form.add_low_torment_trait(self.trait)
+        self.assertTrue(result)
+        self.assertIn(self.trait, self.form.low_torment_traits.all())
+
+    def test_add_low_torment_trait_failure(self):
+        """Failing to add low torment trait returns False."""
+        result = self.form.add_low_torment_trait(self.high_only)
+        self.assertFalse(result)
+        self.assertNotIn(self.high_only, self.form.low_torment_traits.all())
+
+    def test_add_high_torment_trait_success(self):
+        """Successfully adding high torment trait returns True."""
+        result = self.form.add_high_torment_trait(self.trait)
+        self.assertTrue(result)
+        self.assertIn(self.trait, self.form.high_torment_traits.all())
+
+    def test_add_high_torment_trait_high_only_success(self):
+        """High torment only trait can be added to high torment."""
+        result = self.form.add_high_torment_trait(self.high_only)
+        self.assertTrue(result)
+        self.assertIn(self.high_only, self.form.high_torment_traits.all())
+
+
+class ApocalypticFormRemoveTraitTests(TestCase):
+    """Tests for remove_*_torment_trait methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.form = ApocalypticForm.objects.create(name="Test Form", owner=self.user)
+
+        self.trait = ApocalypticFormTrait.objects.create(
+            name="Power", cost=2, owner=self.user
+        )
+        self.other_trait = ApocalypticFormTrait.objects.create(
+            name="Other", cost=1, owner=self.user
+        )
+
+    def test_remove_low_torment_trait_success(self):
+        """Successfully removing low torment trait returns True."""
+        self.form.low_torment_traits.add(self.trait)
+        result = self.form.remove_low_torment_trait(self.trait)
+        self.assertTrue(result)
+        self.assertNotIn(self.trait, self.form.low_torment_traits.all())
+
+    def test_remove_low_torment_trait_not_present(self):
+        """Removing non-present trait from low torment returns False."""
+        result = self.form.remove_low_torment_trait(self.trait)
+        self.assertFalse(result)
+
+    def test_remove_high_torment_trait_success(self):
+        """Successfully removing high torment trait returns True."""
+        self.form.high_torment_traits.add(self.trait)
+        result = self.form.remove_high_torment_trait(self.trait)
+        self.assertTrue(result)
+        self.assertNotIn(self.trait, self.form.high_torment_traits.all())
+
+    def test_remove_high_torment_trait_not_present(self):
+        """Removing non-present trait from high torment returns False."""
+        result = self.form.remove_high_torment_trait(self.trait)
+        self.assertFalse(result)
+
+
+class ApocalypticFormCopyTests(TestCase):
+    """Tests for copy_from method."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.source = ApocalypticForm.objects.create(name="Source Form", owner=self.user)
+        self.target = ApocalypticForm.objects.create(name="Target Form", owner=self.user)
+
+        # Create traits
+        self.low_traits = []
+        self.high_traits = []
+        for i in range(4):
+            low = ApocalypticFormTrait.objects.create(
+                name=f"Low {i}", cost=1, owner=self.user
+            )
+            high = ApocalypticFormTrait.objects.create(
+                name=f"High {i}", cost=1, owner=self.user
+            )
+            self.low_traits.append(low)
+            self.high_traits.append(high)
+
+        # Set up source form
+        self.source.low_torment_traits.set(self.low_traits)
+        self.source.high_torment_traits.set(self.high_traits)
+
+    def test_copy_from_copies_low_torment_traits(self):
+        """copy_from should copy low torment traits."""
+        self.target.copy_from(self.source)
+        self.assertEqual(
+            set(self.target.low_torment_traits.all()),
+            set(self.source.low_torment_traits.all()),
+        )
+
+    def test_copy_from_copies_high_torment_traits(self):
+        """copy_from should copy high torment traits."""
+        self.target.copy_from(self.source)
+        self.assertEqual(
+            set(self.target.high_torment_traits.all()),
+            set(self.source.high_torment_traits.all()),
+        )
+
+    def test_copy_from_overwrites_existing(self):
+        """copy_from should overwrite existing traits in target."""
+        # Add some traits to target first
+        other_trait = ApocalypticFormTrait.objects.create(
+            name="Other", cost=1, owner=self.user
+        )
+        self.target.low_torment_traits.add(other_trait)
+
+        self.target.copy_from(self.source)
+
+        # Target should only have source's traits
+        self.assertNotIn(other_trait, self.target.low_torment_traits.all())
+        self.assertEqual(self.target.low_torment_count(), 4)

--- a/characters/tests/models/demon/test_demon.py
+++ b/characters/tests/models/demon/test_demon.py
@@ -1,8 +1,15 @@
 """Tests for Demon model."""
 
 from characters.models.demon import Demon
+from characters.models.demon.apocalyptic_form import ApocalypticForm, ApocalypticFormTrait
 from characters.models.demon.demon import LoreRating
+from characters.models.demon.faction import DemonFaction
+from characters.models.demon.house import DemonHouse
 from characters.models.demon.lore import Lore
+from characters.models.demon.pact import Pact
+from characters.models.demon.ritual import Ritual
+from characters.models.demon.thrall import Thrall
+from characters.models.demon.visage import Visage
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -13,6 +20,7 @@ class DemonModelTests(TestCase):
     def setUp(self):
         """Create a test user for demon ownership."""
         self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
 
     def test_name_field_is_primary_identifier(self):
         """The name field should be the primary identifier (host name)."""
@@ -42,7 +50,7 @@ class DemonModelTests(TestCase):
         demon_b = Demon.objects.create(name="Bob Jones", owner=self.user)
 
         # Query without explicit ordering - should use Meta.ordering
-        demons = list(Demon.objects.all())
+        demons = list(Demon.objects.exclude(pk=self.demon.pk))
 
         # Should be ordered by name alphabetically
         self.assertEqual(demons[0], demon_a)  # Alice
@@ -51,8 +59,650 @@ class DemonModelTests(TestCase):
 
     def test_host_name_field_removed(self):
         """The host_name field should no longer exist."""
-        demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        demon = Demon.objects.create(name="Test Demon 2", owner=self.user)
         self.assertFalse(hasattr(demon, "host_name"))
+
+    def test_default_values(self):
+        """Test default values for Demon fields."""
+        self.assertEqual(self.demon.faith, 3)
+        self.assertEqual(self.demon.temporary_faith, 3)
+        self.assertEqual(self.demon.torment, 3)
+        self.assertEqual(self.demon.temporary_torment, 0)
+        self.assertEqual(self.demon.conviction, 1)
+        self.assertEqual(self.demon.courage, 1)
+        self.assertEqual(self.demon.conscience, 1)
+        self.assertEqual(self.demon.days_until_consumption, 30)
+        self.assertEqual(self.demon.age_of_fall, 0)
+        self.assertEqual(self.demon.background_points, 5)
+        self.assertEqual(self.demon.apocalyptic_form_points, 16)
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url returns correct URL."""
+        url = self.demon.get_absolute_url()
+        self.assertEqual(url, f"/characters/demon/demon/{self.demon.pk}/")
+
+    def test_get_update_url(self):
+        """Test get_update_url returns correct URL."""
+        url = self.demon.get_update_url()
+        self.assertEqual(url, f"/characters/demon/update/demon/{self.demon.pk}/")
+
+    def test_get_creation_url(self):
+        """Test get_creation_url returns correct URL."""
+        url = Demon.get_creation_url()
+        self.assertEqual(url, "/characters/demon/create/demon/")
+
+    def test_get_heading(self):
+        """Test get_heading returns DTF heading."""
+        self.assertEqual(self.demon.get_heading(), "dtf_heading")
+
+
+class DemonHouseTests(TestCase):
+    """Tests for house-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.house = DemonHouse.objects.create(
+            name="Devils",
+            celestial_name="Namaru",
+            starting_torment=4,
+        )
+
+    def test_has_house_returns_false_initially(self):
+        """has_house returns False when no house set."""
+        self.assertFalse(self.demon.has_house())
+
+    def test_has_house_returns_true_after_set(self):
+        """has_house returns True after setting house."""
+        self.demon.house = self.house
+        self.demon.save()
+        self.assertTrue(self.demon.has_house())
+
+    def test_set_house_sets_house_and_torment(self):
+        """set_house sets house and starting torment."""
+        result = self.demon.set_house(self.house)
+        self.assertTrue(result)
+        self.assertEqual(self.demon.house, self.house)
+        self.assertEqual(self.demon.torment, 4)
+
+
+class DemonFactionTests(TestCase):
+    """Tests for faction-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.faction = DemonFaction.objects.create(name="Cryptics")
+
+    def test_has_faction_returns_false_initially(self):
+        """has_faction returns False when no faction set."""
+        self.assertFalse(self.demon.has_faction())
+
+    def test_has_faction_returns_true_after_set(self):
+        """has_faction returns True after setting faction."""
+        self.demon.faction = self.faction
+        self.demon.save()
+        self.assertTrue(self.demon.has_faction())
+
+    def test_set_faction_sets_faction(self):
+        """set_faction sets the faction."""
+        result = self.demon.set_faction(self.faction)
+        self.assertTrue(result)
+        self.assertEqual(self.demon.faction, self.faction)
+
+
+class DemonVisageTests(TestCase):
+    """Tests for visage-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.visage = Visage.objects.create(name="Bel")
+
+    def test_has_visage_returns_false_initially(self):
+        """has_visage returns False when no visage set."""
+        self.assertFalse(self.demon.has_visage())
+
+    def test_has_visage_returns_true_after_set(self):
+        """has_visage returns True after setting visage."""
+        self.demon.visage = self.visage
+        self.demon.save()
+        self.assertTrue(self.demon.has_visage())
+
+    def test_set_visage_sets_visage(self):
+        """set_visage sets the visage."""
+        result = self.demon.set_visage(self.visage)
+        self.assertTrue(result)
+        self.assertEqual(self.demon.visage, self.visage)
+
+
+class DemonFaithTests(TestCase):
+    """Tests for Faith-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+
+    def test_add_faith_increases_faith(self):
+        """add_faith increases faith by 1."""
+        initial_faith = self.demon.faith
+        result = self.demon.add_faith()
+        self.assertTrue(result)
+        self.assertEqual(self.demon.faith, initial_faith + 1)
+
+    def test_add_faith_returns_false_at_max(self):
+        """add_faith returns False when faith is at 10."""
+        self.demon.faith = 10
+        self.demon.save()
+        result = self.demon.add_faith()
+        self.assertFalse(result)
+        self.assertEqual(self.demon.faith, 10)
+
+
+class DemonTormentTests(TestCase):
+    """Tests for Torment-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+
+    def test_add_torment_increases_torment(self):
+        """add_torment increases torment by 1."""
+        initial_torment = self.demon.torment
+        result = self.demon.add_torment()
+        self.assertTrue(result)
+        self.assertEqual(self.demon.torment, initial_torment + 1)
+
+    def test_add_torment_returns_false_at_max(self):
+        """add_torment returns False when torment is at 10."""
+        self.demon.torment = 10
+        self.demon.save()
+        result = self.demon.add_torment()
+        self.assertFalse(result)
+        self.assertEqual(self.demon.torment, 10)
+
+    def test_reduce_torment_decreases_torment(self):
+        """reduce_torment decreases torment by 1."""
+        self.demon.torment = 5
+        self.demon.save()
+        result = self.demon.reduce_torment()
+        self.assertTrue(result)
+        self.assertEqual(self.demon.torment, 4)
+
+    def test_reduce_torment_returns_false_at_min(self):
+        """reduce_torment returns False when torment is at 0."""
+        self.demon.torment = 0
+        self.demon.save()
+        result = self.demon.reduce_torment()
+        self.assertFalse(result)
+        self.assertEqual(self.demon.torment, 0)
+
+
+class DemonVirtuesTests(TestCase):
+    """Tests for virtue-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+
+    def test_has_virtues_false_with_wrong_sum(self):
+        """has_virtues returns False when sum isn't 6."""
+        self.demon.conviction = 1
+        self.demon.courage = 1
+        self.demon.conscience = 1
+        self.assertFalse(self.demon.has_virtues())
+
+    def test_has_virtues_true_with_correct_sum(self):
+        """has_virtues returns True when sum is 6."""
+        self.demon.conviction = 2
+        self.demon.courage = 2
+        self.demon.conscience = 2
+        self.assertTrue(self.demon.has_virtues())
+
+    def test_has_virtues_true_with_uneven_distribution(self):
+        """has_virtues returns True with uneven distribution summing to 6."""
+        self.demon.conviction = 3
+        self.demon.courage = 2
+        self.demon.conscience = 1
+        self.assertTrue(self.demon.has_virtues())
+
+
+class DemonLoreTests(TestCase):
+    """Tests for lore-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+
+    def test_has_lores_false_initially(self):
+        """has_lores returns False with no lores."""
+        self.assertFalse(self.demon.has_lores())
+
+    def test_has_lores_false_under_three(self):
+        """has_lores returns False with less than 3 dots."""
+        self.demon.lore_of_flame = 2
+        self.demon.save()
+        self.assertFalse(self.demon.has_lores())
+
+    def test_has_lores_true_at_three(self):
+        """has_lores returns True with 3 dots."""
+        self.demon.lore_of_flame = 3
+        self.demon.save()
+        self.assertTrue(self.demon.has_lores())
+
+    def test_has_lores_true_over_three(self):
+        """has_lores returns True with more than 3 dots."""
+        self.demon.lore_of_flame = 2
+        self.demon.lore_of_the_fundament = 2
+        self.demon.save()
+        self.assertTrue(self.demon.has_lores())
+
+
+class DemonApocalypticFormTests(TestCase):
+    """Tests for apocalyptic form-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.form = ApocalypticForm.objects.create(name="Test Form")
+        # Create traits
+        self.low_trait1 = ApocalypticFormTrait.objects.create(name="Wings", cost=2)
+        self.low_trait2 = ApocalypticFormTrait.objects.create(name="Claws", cost=2)
+        self.low_trait3 = ApocalypticFormTrait.objects.create(name="Armor", cost=2)
+        self.low_trait4 = ApocalypticFormTrait.objects.create(name="Speed", cost=2)
+        self.high_trait1 = ApocalypticFormTrait.objects.create(name="Fire Breath", cost=2)
+        self.high_trait2 = ApocalypticFormTrait.objects.create(name="Shadow Form", cost=2)
+        self.high_trait3 = ApocalypticFormTrait.objects.create(name="Terror", cost=2)
+        self.high_trait4 = ApocalypticFormTrait.objects.create(name="Poison", cost=2)
+
+    def test_has_apocalyptic_form_false_initially(self):
+        """has_apocalyptic_form returns False when no form."""
+        self.assertFalse(self.demon.has_apocalyptic_form())
+
+    def test_has_apocalyptic_form_false_invalid_form(self):
+        """has_apocalyptic_form returns False with invalid form."""
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        # Form has no traits, so invalid
+        self.assertFalse(self.demon.has_apocalyptic_form())
+
+    def test_has_apocalyptic_form_true_valid_form(self):
+        """has_apocalyptic_form returns True with valid form."""
+        # Add 4 low and 4 high traits
+        self.form.low_torment_traits.add(
+            self.low_trait1, self.low_trait2, self.low_trait3, self.low_trait4
+        )
+        self.form.high_torment_traits.add(
+            self.high_trait1, self.high_trait2, self.high_trait3, self.high_trait4
+        )
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        self.assertTrue(self.demon.has_apocalyptic_form())
+
+    def test_get_low_torment_traits_with_no_form(self):
+        """get_low_torment_traits returns empty queryset with no form."""
+        traits = self.demon.get_low_torment_traits()
+        self.assertEqual(traits.count(), 0)
+
+    def test_get_low_torment_traits_with_form(self):
+        """get_low_torment_traits returns traits from form."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        traits = self.demon.get_low_torment_traits()
+        self.assertEqual(traits.count(), 2)
+
+    def test_get_high_torment_traits_with_no_form(self):
+        """get_high_torment_traits returns empty queryset with no form."""
+        traits = self.demon.get_high_torment_traits()
+        self.assertEqual(traits.count(), 0)
+
+    def test_get_high_torment_traits_with_form(self):
+        """get_high_torment_traits returns traits from form."""
+        self.form.high_torment_traits.add(self.high_trait1, self.high_trait2)
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        traits = self.demon.get_high_torment_traits()
+        self.assertEqual(traits.count(), 2)
+
+    def test_apocalyptic_form_counts_with_no_form(self):
+        """Count methods return 0 with no form."""
+        self.assertEqual(self.demon.apocalyptic_form_low_torment_count(), 0)
+        self.assertEqual(self.demon.apocalyptic_form_high_torment_count(), 0)
+
+    def test_apocalyptic_form_counts_with_form(self):
+        """Count methods return correct counts."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)
+        self.form.high_torment_traits.add(self.high_trait1)
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        self.assertEqual(self.demon.apocalyptic_form_low_torment_count(), 2)
+        self.assertEqual(self.demon.apocalyptic_form_high_torment_count(), 1)
+
+    def test_apocalyptic_form_points_spent_with_no_form(self):
+        """Points spent returns 0 with no form."""
+        self.assertEqual(self.demon.apocalyptic_form_points_spent(), 0)
+
+    def test_apocalyptic_form_points_spent_with_form(self):
+        """Points spent returns sum of trait costs."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)  # 4 points
+        self.form.high_torment_traits.add(self.high_trait1)  # 2 points
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        self.assertEqual(self.demon.apocalyptic_form_points_spent(), 6)
+
+    def test_apocalyptic_form_points_remaining_with_no_form(self):
+        """Points remaining returns 16 with no form."""
+        self.assertEqual(self.demon.apocalyptic_form_points_remaining(), 16)
+
+    def test_apocalyptic_form_points_remaining_with_form(self):
+        """Points remaining calculated correctly."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)  # 4 points
+        self.form.high_torment_traits.add(self.high_trait1)  # 2 points
+        self.demon.apocalyptic_form = self.form
+        self.demon.save()
+        self.assertEqual(self.demon.apocalyptic_form_points_remaining(), 10)
+
+
+class DemonRitualTests(TestCase):
+    """Tests for ritual-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.house = DemonHouse.objects.create(
+            name="Devils",
+            celestial_name="Namaru",
+            starting_torment=4,
+        )
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user, house=self.house)
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+        self.ritual = Ritual.objects.create(
+            name="Binding of Fire",
+            house=self.house,
+            primary_lore=self.lore,
+            primary_lore_rating=2,
+        )
+
+    def test_get_rituals_empty_initially(self):
+        """get_rituals returns empty queryset initially."""
+        rituals = self.demon.get_rituals()
+        self.assertEqual(rituals.count(), 0)
+
+    def test_get_rituals_returns_rituals(self):
+        """get_rituals returns known rituals."""
+        self.demon.rituals.add(self.ritual)
+        rituals = self.demon.get_rituals()
+        self.assertEqual(rituals.count(), 1)
+        self.assertIn(self.ritual, rituals)
+
+    def test_knows_ritual_false_initially(self):
+        """knows_ritual returns False initially."""
+        self.assertFalse(self.demon.knows_ritual(self.ritual))
+
+    def test_knows_ritual_true_after_learning(self):
+        """knows_ritual returns True after adding ritual."""
+        self.demon.rituals.add(self.ritual)
+        self.assertTrue(self.demon.knows_ritual(self.ritual))
+
+    def test_add_ritual_adds_ritual(self):
+        """add_ritual adds a ritual."""
+        result = self.demon.add_ritual(self.ritual)
+        self.assertTrue(result)
+        self.assertIn(self.ritual, self.demon.rituals.all())
+
+    def test_add_ritual_returns_false_for_duplicate(self):
+        """add_ritual returns False if already known."""
+        self.demon.rituals.add(self.ritual)
+        result = self.demon.add_ritual(self.ritual)
+        self.assertFalse(result)
+
+    def test_remove_ritual_removes_ritual(self):
+        """remove_ritual removes a ritual."""
+        self.demon.rituals.add(self.ritual)
+        result = self.demon.remove_ritual(self.ritual)
+        self.assertTrue(result)
+        self.assertNotIn(self.ritual, self.demon.rituals.all())
+
+    def test_remove_ritual_returns_false_if_not_known(self):
+        """remove_ritual returns False if not known."""
+        result = self.demon.remove_ritual(self.ritual)
+        self.assertFalse(result)
+
+    def test_get_available_rituals_with_no_house(self):
+        """get_available_rituals returns empty with no house."""
+        self.demon.house = None
+        self.demon.save()
+        rituals = self.demon.get_available_rituals()
+        self.assertEqual(rituals.count(), 0)
+
+    def test_get_available_rituals_with_insufficient_lore(self):
+        """get_available_rituals excludes rituals with insufficient lore."""
+        # Demon has no flame lore, ritual requires 2
+        rituals = self.demon.get_available_rituals()
+        self.assertEqual(rituals.count(), 0)
+
+    def test_get_available_rituals_with_sufficient_lore(self):
+        """get_available_rituals includes rituals with sufficient lore."""
+        self.demon.lore_of_flame = 3
+        self.demon.save()
+        rituals = self.demon.get_available_rituals()
+        self.assertEqual(rituals.count(), 1)
+        self.assertIn(self.ritual, rituals)
+
+    def test_get_available_rituals_excludes_known(self):
+        """get_available_rituals excludes already known rituals."""
+        self.demon.lore_of_flame = 3
+        self.demon.rituals.add(self.ritual)
+        self.demon.save()
+        rituals = self.demon.get_available_rituals()
+        self.assertEqual(rituals.count(), 0)
+
+
+class DemonPactTests(TestCase):
+    """Tests for pact-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_get_pacts_empty_initially(self):
+        """get_pacts returns empty queryset initially."""
+        pacts = self.demon.get_pacts()
+        self.assertEqual(pacts.count(), 0)
+
+    def test_get_pacts_returns_pacts(self):
+        """get_pacts returns demon's pacts."""
+        pact = Pact.objects.create(demon=self.demon, thrall=self.thrall)
+        pacts = self.demon.get_pacts()
+        self.assertEqual(pacts.count(), 1)
+        self.assertIn(pact, pacts)
+
+    def test_add_pact_creates_pact(self):
+        """add_pact creates a new pact."""
+        pact = self.demon.add_pact(
+            thrall=self.thrall,
+            terms="Power for service",
+            faith_payment=2,
+            enhancements=["Enhanced Strength"],
+        )
+        self.assertIsNotNone(pact)
+        self.assertEqual(pact.demon, self.demon)
+        self.assertEqual(pact.thrall, self.thrall)
+        self.assertEqual(pact.terms, "Power for service")
+        self.assertEqual(pact.faith_payment, 2)
+        self.assertEqual(pact.enhancements, ["Enhanced Strength"])
+
+    def test_add_pact_with_defaults(self):
+        """add_pact creates pact with default values."""
+        pact = self.demon.add_pact(thrall=self.thrall)
+        self.assertEqual(pact.terms, "")
+        self.assertEqual(pact.faith_payment, 0)
+        self.assertEqual(pact.enhancements, [])
+
+    def test_total_pacts_counts_active_only(self):
+        """total_pacts counts only active pacts."""
+        pact1 = Pact.objects.create(demon=self.demon, thrall=self.thrall, active=True)
+        pact2 = Pact.objects.create(demon=self.demon, thrall=self.thrall, active=False)
+        self.assertEqual(self.demon.total_pacts(), 1)
+
+
+class DemonHistoryTests(TestCase):
+    """Tests for history-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+
+    def test_has_demon_history_false_initially(self):
+        """has_demon_history returns False with no history."""
+        self.assertFalse(self.demon.has_demon_history())
+
+    def test_has_demon_history_false_missing_celestial_name(self):
+        """has_demon_history returns False without celestial name."""
+        self.demon.age_of_fall = 5
+        self.demon.save()
+        self.assertFalse(self.demon.has_demon_history())
+
+    def test_has_demon_history_false_missing_age(self):
+        """has_demon_history returns False without age_of_fall."""
+        self.demon.celestial_name = "Hasmed"
+        self.demon.save()
+        self.assertFalse(self.demon.has_demon_history())
+
+    def test_has_demon_history_true_with_both(self):
+        """has_demon_history returns True with both fields."""
+        self.demon.celestial_name = "Hasmed"
+        self.demon.age_of_fall = 5
+        self.demon.save()
+        self.assertTrue(self.demon.has_demon_history())
+
+
+class DemonXPTests(TestCase):
+    """Tests for XP-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user, xp=100)
+        self.demon.house = self.house
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+        self.demon.save()
+
+    def test_xp_frequencies_returns_dict(self):
+        """xp_frequencies returns correct dictionary."""
+        freq = self.demon.xp_frequencies()
+        self.assertIn("attribute", freq)
+        self.assertIn("ability", freq)
+        self.assertIn("background", freq)
+        self.assertIn("willpower", freq)
+        self.assertIn("lore", freq)
+        self.assertIn("faith", freq)
+        self.assertIn("virtue", freq)
+
+
+class DemonFreebieTests(TestCase):
+    """Tests for freebie-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user, freebies=50)
+        self.demon.house = self.house
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+        self.demon.save()
+
+    def test_freebie_frequencies_returns_dict(self):
+        """freebie_frequencies returns correct dictionary."""
+        freq = self.demon.freebie_frequencies()
+        self.assertIn("attribute", freq)
+        self.assertIn("ability", freq)
+        self.assertIn("background", freq)
+        self.assertIn("willpower", freq)
+        self.assertIn("meritflaw", freq)
+        self.assertIn("lore", freq)
+        self.assertIn("faith", freq)
+        self.assertIn("virtue", freq)
+        self.assertIn("temporary_faith", freq)
+
+    def test_freebie_costs_returns_dict(self):
+        """freebie_costs returns correct costs."""
+        costs = self.demon.freebie_costs()
+        self.assertEqual(costs["lore"], 7)
+        self.assertEqual(costs["other_lore"], 10)
+        self.assertEqual(costs["faith"], 7)
+        self.assertEqual(costs["virtue"], 2)
+        self.assertEqual(costs["temporary_faith"], 1)
+
+    def test_freebie_cost_lore(self):
+        """freebie_cost returns correct cost for lore."""
+        self.assertEqual(self.demon.freebie_cost("lore"), 7)
+
+    def test_freebie_cost_other_lore(self):
+        """freebie_cost returns correct cost for non-house lore."""
+        self.assertEqual(self.demon.freebie_cost("other_lore"), 10)
+
+    def test_freebie_cost_faith(self):
+        """freebie_cost returns correct cost for faith."""
+        self.assertEqual(self.demon.freebie_cost("faith"), 7)
+
+    def test_freebie_cost_virtue(self):
+        """freebie_cost returns correct cost for virtue."""
+        self.assertEqual(self.demon.freebie_cost("virtue"), 2)
+
+    def test_freebie_cost_temporary_faith(self):
+        """freebie_cost returns correct cost for temporary_faith."""
+        self.assertEqual(self.demon.freebie_cost("temporary_faith"), 1)
+
+    def test_spend_freebies_faith(self):
+        """spend_freebies increases faith and deducts freebies."""
+        initial_faith = self.demon.faith
+        initial_freebies = self.demon.freebies
+        result = self.demon.spend_freebies("faith")
+        self.assertTrue(result)
+        self.assertEqual(self.demon.faith, initial_faith + 1)
+        self.assertEqual(self.demon.freebies, initial_freebies - 7)
+
+    def test_spend_freebies_faith_insufficient_freebies(self):
+        """spend_freebies returns False with insufficient freebies."""
+        self.demon.freebies = 1
+        self.demon.save()
+        result = self.demon.spend_freebies("faith")
+        self.assertFalse(result)
+
+    def test_spend_freebies_temporary_faith(self):
+        """spend_freebies increases temporary_faith and deducts freebies."""
+        initial_tf = self.demon.temporary_faith
+        result = self.demon.spend_freebies("temporary_faith")
+        self.assertTrue(result)
+        self.assertEqual(self.demon.temporary_faith, initial_tf + 1)
+
+    def test_spend_freebies_virtue(self):
+        """spend_freebies increases virtue and deducts freebies."""
+        initial_conviction = self.demon.conviction
+        result = self.demon.spend_freebies("conviction")
+        self.assertTrue(result)
+        self.assertEqual(self.demon.conviction, initial_conviction + 1)
 
 
 class LoreRatingDeleteBehaviorTests(TestCase):
@@ -104,3 +754,33 @@ class LoreRatingDeleteBehaviorTests(TestCase):
     def test_related_name_demon_ratings_on_lore(self):
         """Lore should have demon_ratings related manager."""
         self.assertIn(self.rating, self.lore.demon_ratings.all())
+
+    def test_lore_rating_str(self):
+        """Test LoreRating __str__ method."""
+        self.assertEqual(str(self.rating), "Test Demon: Lore of the Fundament: 3")
+
+    def test_lore_rating_str_no_demon(self):
+        """Test LoreRating __str__ with no demon."""
+        self.rating.demon = None
+        self.rating.save()
+        self.assertEqual(str(self.rating), "No Demon: Lore of the Fundament: 3")
+
+    def test_lore_rating_str_no_lore(self):
+        """Test LoreRating __str__ with no lore."""
+        self.rating.lore = None
+        self.rating.save()
+        self.assertEqual(str(self.rating), "Test Demon: No Lore: 3")
+
+
+class DemonRitualKnowledgeXPCostTests(TestCase):
+    """Tests for ritual knowledge XP cost calculation."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+
+    def test_ritual_knowledge_xp_cost_with_no_background(self):
+        """ritual_knowledge_xp_cost returns 0 with no background."""
+        cost = self.demon.ritual_knowledge_xp_cost()
+        self.assertEqual(cost, 0)

--- a/characters/tests/models/demon/test_earthbound.py
+++ b/characters/tests/models/demon/test_earthbound.py
@@ -1,5 +1,380 @@
-"""Tests for earthbound module."""
+"""Tests for Earthbound model."""
 
+from characters.models.demon.apocalyptic_form import ApocalypticForm, ApocalypticFormTrait
+from characters.models.demon.earthbound import Earthbound
+from characters.models.demon.house import DemonHouse
+from characters.models.demon.visage import Visage
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class EarthboundModelTests(TestCase):
+    """Tests for Earthbound model functionality."""
+
+    def setUp(self):
+        """Create a test user for earthbound ownership."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_type(self):
+        """Test type value."""
+        self.assertEqual(self.earthbound.type, "earthbound")
+
+    def test_freebie_step(self):
+        """Test freebie step value."""
+        self.assertEqual(self.earthbound.freebie_step, 7)
+
+    def test_default_values(self):
+        """Test default values for Earthbound fields."""
+        self.assertEqual(self.earthbound.faith, 3)
+        self.assertEqual(self.earthbound.temporary_faith, 10)
+        self.assertEqual(self.earthbound.max_faith, 10)
+        self.assertEqual(self.earthbound.torment, 6)
+        self.assertEqual(self.earthbound.temporary_torment, 0)
+        self.assertEqual(self.earthbound.conviction, 1)
+        self.assertEqual(self.earthbound.courage, 1)
+        self.assertEqual(self.earthbound.conscience, 1)
+        self.assertEqual(self.earthbound.urge_flesh, 1)
+        self.assertEqual(self.earthbound.urge_thought, 1)
+        self.assertEqual(self.earthbound.urge_emotion, 1)
+        self.assertEqual(self.earthbound.reliquary_type, "perfect")
+        self.assertEqual(self.earthbound.reliquary_max_health, 10)
+        self.assertEqual(self.earthbound.reliquary_current_health, 10)
+        self.assertEqual(self.earthbound.reliquary_soak, 0)
+        self.assertTrue(self.earthbound.can_manifest)
+        self.assertEqual(self.earthbound.manifestation_range, 0)
+        self.assertEqual(self.earthbound.mastery_rating, 0)
+        self.assertEqual(self.earthbound.known_celestial_names, [])
+        self.assertEqual(self.earthbound.known_true_names, [])
+
+    def test_earthbound_specific_abilities_default(self):
+        """Test Earthbound-specific abilities default to 0."""
+        self.assertEqual(self.earthbound.indoctrination, 0)
+        self.assertEqual(self.earthbound.recall, 0)
+        self.assertEqual(self.earthbound.tactics, 0)
+        self.assertEqual(self.earthbound.torture, 0)
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url returns correct URL."""
+        url = self.earthbound.get_absolute_url()
+        self.assertEqual(url, f"/characters/demon/earthbound/{self.earthbound.pk}/")
+
+    def test_get_heading(self):
+        """Test get_heading returns DTF heading."""
+        self.assertEqual(self.earthbound.get_heading(), "dtf_heading")
+
+    def test_verbose_name(self):
+        """Test verbose names."""
+        self.assertEqual(Earthbound._meta.verbose_name, "Earthbound")
+        self.assertEqual(Earthbound._meta.verbose_name_plural, "Earthbound")
+
+
+class EarthboundReliquaryTypeTests(TestCase):
+    """Tests for reliquary type choices."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_perfect_reliquary(self):
+        """Test perfect reliquary type."""
+        self.earthbound.reliquary_type = "perfect"
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.reliquary_type, "perfect")
+
+    def test_improvised_reliquary(self):
+        """Test improvised reliquary type."""
+        self.earthbound.reliquary_type = "improvised"
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.reliquary_type, "improvised")
+
+    def test_location_reliquary(self):
+        """Test location reliquary type."""
+        self.earthbound.reliquary_type = "location"
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.reliquary_type, "location")
+
+
+class EarthboundFinalDamnationTests(TestCase):
+    """Tests for Final Damnation (Torment 10) method."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_is_final_damnation_false(self):
+        """is_final_damnation returns False when torment < 10."""
+        self.earthbound.torment = 9
+        self.assertFalse(self.earthbound.is_final_damnation())
+
+    def test_is_final_damnation_true_at_10(self):
+        """is_final_damnation returns True when torment = 10."""
+        self.earthbound.torment = 10
+        self.assertTrue(self.earthbound.is_final_damnation())
+
+
+class EarthboundFaithPerManifestationTests(TestCase):
+    """Tests for Faith cost per manifestation turn."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_improvised_costs_1(self):
+        """Improvised reliquary costs 1 Faith per turn."""
+        self.earthbound.reliquary_type = "improvised"
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.get_faith_per_manifestation_turn(), 1)
+
+    def test_perfect_costs_2(self):
+        """Perfect reliquary costs 2 Faith per turn."""
+        self.earthbound.reliquary_type = "perfect"
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.get_faith_per_manifestation_turn(), 2)
+
+    def test_location_costs_2(self):
+        """Location reliquary costs 2 Faith per turn."""
+        self.earthbound.reliquary_type = "location"
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.get_faith_per_manifestation_turn(), 2)
+
+
+class EarthboundMaxFaithTests(TestCase):
+    """Tests for max Faith from Hoard background."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_get_max_faith_from_hoard(self):
+        """get_max_faith_from_hoard returns stored value."""
+        self.earthbound.max_faith = 25
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.get_max_faith_from_hoard(), 25)
+
+    def test_default_max_faith(self):
+        """Default max_faith is 10."""
+        self.assertEqual(self.earthbound.get_max_faith_from_hoard(), 10)
+
+
+class EarthboundReliquaryHealthTests(TestCase):
+    """Tests for reliquary health calculations."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_calculate_health_perfect(self):
+        """Perfect reliquary health = faith."""
+        self.earthbound.reliquary_type = "perfect"
+        self.earthbound.faith = 5
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.calculate_reliquary_health(), 5)
+
+    def test_calculate_health_improvised(self):
+        """Improvised reliquary health = faith."""
+        self.earthbound.reliquary_type = "improvised"
+        self.earthbound.faith = 4
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.calculate_reliquary_health(), 4)
+
+    def test_calculate_health_location(self):
+        """Location reliquary health = (faith + willpower) * 2."""
+        self.earthbound.reliquary_type = "location"
+        self.earthbound.faith = 5
+        self.earthbound.willpower = 3
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.calculate_reliquary_health(), 16)  # (5+3)*2
+
+
+class EarthboundRegenerationTests(TestCase):
+    """Tests for reliquary regeneration."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+
+    def test_can_regenerate_with_faith_and_damage(self):
+        """can_regenerate_reliquary True with faith and damage."""
+        self.earthbound.temporary_faith = 5
+        self.earthbound.reliquary_current_health = 5
+        self.earthbound.reliquary_max_health = 10
+        self.assertTrue(self.earthbound.can_regenerate_reliquary())
+
+    def test_cannot_regenerate_no_faith(self):
+        """can_regenerate_reliquary False with no faith."""
+        self.earthbound.temporary_faith = 0
+        self.earthbound.reliquary_current_health = 5
+        self.earthbound.reliquary_max_health = 10
+        self.assertFalse(self.earthbound.can_regenerate_reliquary())
+
+    def test_cannot_regenerate_full_health(self):
+        """can_regenerate_reliquary False at full health."""
+        self.earthbound.temporary_faith = 5
+        self.earthbound.reliquary_current_health = 10
+        self.earthbound.reliquary_max_health = 10
+        self.assertFalse(self.earthbound.can_regenerate_reliquary())
+
+
+class EarthboundApocalypticFormTests(TestCase):
+    """Tests for apocalyptic form-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+        self.form = ApocalypticForm.objects.create(name="Test Form")
+        self.low_trait1 = ApocalypticFormTrait.objects.create(name="Wings", cost=2)
+        self.low_trait2 = ApocalypticFormTrait.objects.create(name="Claws", cost=2)
+        self.low_trait3 = ApocalypticFormTrait.objects.create(name="Armor", cost=2)
+        self.low_trait4 = ApocalypticFormTrait.objects.create(name="Speed", cost=2)
+        self.high_trait1 = ApocalypticFormTrait.objects.create(name="Fire Breath", cost=2)
+        self.high_trait2 = ApocalypticFormTrait.objects.create(name="Shadow Form", cost=2)
+        self.high_trait3 = ApocalypticFormTrait.objects.create(name="Terror", cost=2)
+        self.high_trait4 = ApocalypticFormTrait.objects.create(name="Poison", cost=2)
+
+    def test_has_apocalyptic_form_false_initially(self):
+        """has_apocalyptic_form returns False when no form."""
+        self.assertFalse(self.earthbound.has_apocalyptic_form())
+
+    def test_has_apocalyptic_form_false_invalid(self):
+        """has_apocalyptic_form returns False with invalid form."""
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        self.assertFalse(self.earthbound.has_apocalyptic_form())
+
+    def test_has_apocalyptic_form_true_valid(self):
+        """has_apocalyptic_form returns True with valid form."""
+        self.form.low_torment_traits.add(
+            self.low_trait1, self.low_trait2, self.low_trait3, self.low_trait4
+        )
+        self.form.high_torment_traits.add(
+            self.high_trait1, self.high_trait2, self.high_trait3, self.high_trait4
+        )
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        self.assertTrue(self.earthbound.has_apocalyptic_form())
+
+    def test_get_low_torment_traits_no_form(self):
+        """get_low_torment_traits returns empty queryset with no form."""
+        traits = self.earthbound.get_low_torment_traits()
+        self.assertEqual(traits.count(), 0)
+
+    def test_get_low_torment_traits_with_form(self):
+        """get_low_torment_traits returns traits from form."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        traits = self.earthbound.get_low_torment_traits()
+        self.assertEqual(traits.count(), 2)
+
+    def test_get_high_torment_traits_no_form(self):
+        """get_high_torment_traits returns empty queryset with no form."""
+        traits = self.earthbound.get_high_torment_traits()
+        self.assertEqual(traits.count(), 0)
+
+    def test_get_high_torment_traits_with_form(self):
+        """get_high_torment_traits returns traits from form."""
+        self.form.high_torment_traits.add(self.high_trait1, self.high_trait2)
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        traits = self.earthbound.get_high_torment_traits()
+        self.assertEqual(traits.count(), 2)
+
+    def test_apocalyptic_form_counts_no_form(self):
+        """Count methods return 0 with no form."""
+        self.assertEqual(self.earthbound.apocalyptic_form_low_torment_count(), 0)
+        self.assertEqual(self.earthbound.apocalyptic_form_high_torment_count(), 0)
+
+    def test_apocalyptic_form_counts_with_form(self):
+        """Count methods return correct counts."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)
+        self.form.high_torment_traits.add(self.high_trait1)
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.apocalyptic_form_low_torment_count(), 2)
+        self.assertEqual(self.earthbound.apocalyptic_form_high_torment_count(), 1)
+
+    def test_apocalyptic_form_points_spent_no_form(self):
+        """Points spent returns 0 with no form."""
+        self.assertEqual(self.earthbound.apocalyptic_form_points_spent(), 0)
+
+    def test_apocalyptic_form_points_spent_with_form(self):
+        """Points spent returns sum of trait costs."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)  # 4 points
+        self.form.high_torment_traits.add(self.high_trait1)  # 2 points
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.apocalyptic_form_points_spent(), 6)
+
+    def test_apocalyptic_form_points_remaining_no_form(self):
+        """Points remaining returns 16 with no form."""
+        self.assertEqual(self.earthbound.apocalyptic_form_points_remaining(), 16)
+
+    def test_apocalyptic_form_points_remaining_with_form(self):
+        """Points remaining calculated correctly."""
+        self.form.low_torment_traits.add(self.low_trait1, self.low_trait2)  # 4 points
+        self.form.high_torment_traits.add(self.high_trait1)  # 2 points
+        self.earthbound.apocalyptic_form = self.form
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.apocalyptic_form_points_remaining(), 10)
+
+
+class EarthboundHouseAndVisageTests(TestCase):
+    """Tests for house and visage relationships."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.earthbound = Earthbound.objects.create(name="Test Earthbound", owner=self.user)
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.visage = Visage.objects.create(name="Bel")
+
+    def test_house_can_be_set(self):
+        """House can be set."""
+        self.earthbound.house = self.house
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.house, self.house)
+
+    def test_house_can_be_null(self):
+        """House can be null."""
+        self.assertIsNone(self.earthbound.house)
+
+    def test_visage_can_be_set(self):
+        """Visage can be set."""
+        self.earthbound.visage = self.visage
+        self.earthbound.save()
+        self.assertEqual(self.earthbound.visage, self.visage)
+
+    def test_visage_can_be_null(self):
+        """Visage can be null."""
+        self.assertIsNone(self.earthbound.visage)
+
+
+class EarthboundAllowedBackgroundsTests(TestCase):
+    """Tests for Earthbound-specific allowed backgrounds."""
+
+    def test_allowed_backgrounds_includes_earthbound_specific(self):
+        """allowed_backgrounds includes Earthbound-specific backgrounds."""
+        self.assertIn("codex", Earthbound.allowed_backgrounds)
+        self.assertIn("cult", Earthbound.allowed_backgrounds)
+        self.assertIn("hoard", Earthbound.allowed_backgrounds)
+        self.assertIn("mastery", Earthbound.allowed_backgrounds)
+        self.assertIn("thralls", Earthbound.allowed_backgrounds)
+        self.assertIn("worship", Earthbound.allowed_backgrounds)
+
+    def test_allowed_backgrounds_includes_common(self):
+        """allowed_backgrounds includes common backgrounds."""
+        self.assertIn("contacts", Earthbound.allowed_backgrounds)
+        self.assertIn("mentor", Earthbound.allowed_backgrounds)
+        self.assertIn("allies", Earthbound.allowed_backgrounds)
+        self.assertIn("influence", Earthbound.allowed_backgrounds)
+        self.assertIn("resources", Earthbound.allowed_backgrounds)

--- a/characters/tests/models/demon/test_ritual.py
+++ b/characters/tests/models/demon/test_ritual.py
@@ -1,5 +1,339 @@
-"""Tests for ritual module."""
+"""Tests for Ritual model."""
 
+from characters.models.demon.house import DemonHouse
+from characters.models.demon.lore import Lore
+from characters.models.demon.ritual import Ritual
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class RitualModelTests(TestCase):
+    """Tests for Ritual model functionality."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+        self.ritual = Ritual.objects.create(
+            name="Binding of Fire",
+            house=self.house,
+            primary_lore=self.lore,
+            primary_lore_rating=2,
+        )
+
+    def test_str(self):
+        """Test __str__ returns ritual name."""
+        self.assertEqual(str(self.ritual), "Binding of Fire")
+
+    def test_ordering_by_house_then_name(self):
+        """Rituals should be ordered by house name then ritual name."""
+        house2 = DemonHouse.objects.create(
+            name="Scourges", celestial_name="Asharu", starting_torment=3
+        )
+        lore2 = Lore.objects.create(name="Lore of Awakening", property_name="awakening")
+        lore2.houses.add(house2)
+
+        ritual_c = Ritual.objects.create(
+            name="Conjuration", house=self.house, primary_lore=self.lore, primary_lore_rating=1
+        )
+        ritual_a = Ritual.objects.create(
+            name="Awakening", house=house2, primary_lore=lore2, primary_lore_rating=1
+        )
+
+        # Devils comes before Scourges, so Devils rituals first
+        rituals = list(Ritual.objects.all())
+        # First should be Devils rituals (Binding of Fire, then Conjuration alphabetically)
+        # Then Scourges rituals (Awakening)
+        self.assertEqual(rituals[0].house, self.house)
+
+    def test_default_values(self):
+        """Test default values for Ritual fields."""
+        self.assertEqual(self.ritual.system, "")
+        self.assertEqual(self.ritual.base_cost, 6)
+        self.assertEqual(self.ritual.minimum_casting_time, 10)
+        self.assertEqual(self.ritual.restrictions, "")
+        self.assertEqual(self.ritual.torment_effect, "")
+        self.assertEqual(self.ritual.variations, "")
+        self.assertEqual(self.ritual.flavor_text, "")
+        self.assertEqual(self.ritual.source_page, "")
+        self.assertEqual(self.ritual.secondary_lore_requirements, [])
+
+    def test_house_relationship(self):
+        """Test house FK relationship."""
+        self.assertEqual(self.ritual.house, self.house)
+        self.assertIn(self.ritual, self.house.rituals.all())
+
+    def test_primary_lore_relationship(self):
+        """Test primary_lore FK relationship."""
+        self.assertEqual(self.ritual.primary_lore, self.lore)
+        self.assertEqual(self.ritual.primary_lore_rating, 2)
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url returns correct URL."""
+        url = self.ritual.get_absolute_url()
+        self.assertEqual(url, f"/characters/demon/ritual/{self.ritual.pk}/")
+
+    def test_get_heading(self):
+        """Test get_heading returns DTF heading."""
+        self.assertEqual(self.ritual.get_heading(), "dtf_heading")
+
+
+class RitualWithSecondaryLoreTests(TestCase):
+    """Tests for rituals with secondary lore requirements."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.primary_lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.primary_lore.houses.add(self.house)
+        self.secondary_lore = Lore.objects.create(
+            name="Lore of the Fundament", property_name="fundament"
+        )
+        self.secondary_lore.houses.add(self.house)
+        self.ritual = Ritual.objects.create(
+            name="Complex Ritual",
+            house=self.house,
+            primary_lore=self.primary_lore,
+            primary_lore_rating=3,
+            secondary_lore_requirements=[
+                {"lore_id": self.secondary_lore.pk, "rating": 2}
+            ],
+        )
+
+    def test_secondary_lore_requirements(self):
+        """Test secondary lore requirements are stored correctly."""
+        self.assertEqual(len(self.ritual.secondary_lore_requirements), 1)
+        self.assertEqual(self.ritual.secondary_lore_requirements[0]["rating"], 2)
+
+    def test_get_secondary_lores(self):
+        """Test get_secondary_lores method."""
+        lores = self.ritual.get_secondary_lores()
+        self.assertEqual(len(lores), 1)
+        self.assertEqual(lores[0]["lore"], self.secondary_lore)
+        self.assertEqual(lores[0]["rating"], 2)
+
+    def test_total_lore_dots(self):
+        """Test total_lore_dots calculation."""
+        # 3 from primary + 2 from secondary = 5
+        self.assertEqual(self.ritual.total_lore_dots(), 5)
+
+    def test_total_lore_paths(self):
+        """Test total_lore_paths calculation."""
+        # 1 primary + 1 secondary = 2
+        self.assertEqual(self.ritual.total_lore_paths(), 2)
+
+    def test_ritual_with_system(self):
+        """Test ritual with system text."""
+        self.ritual.system = "Roll Manipulation + Lore of Flame"
+        self.ritual.save()
+        self.assertEqual(self.ritual.system, "Roll Manipulation + Lore of Flame")
+
+
+class RitualBaseCostTests(TestCase):
+    """Tests for ritual base cost values."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+
+    def test_default_base_cost(self):
+        """Default base_cost should be 6."""
+        ritual = Ritual.objects.create(
+            name="Standard Ritual", house=self.house, primary_lore=self.lore, primary_lore_rating=1
+        )
+        self.assertEqual(ritual.base_cost, 6)
+
+    def test_custom_base_cost(self):
+        """Base cost can be set to custom values."""
+        ritual = Ritual.objects.create(
+            name="Hard Ritual",
+            house=self.house,
+            primary_lore=self.lore,
+            primary_lore_rating=3,
+            base_cost=10,
+        )
+        self.assertEqual(ritual.base_cost, 10)
+
+
+class RitualHouseLoreRelationshipTests(TestCase):
+    """Tests for house and lore FK relationships."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house1 = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.house2 = DemonHouse.objects.create(
+            name="Scourges", celestial_name="Asharu", starting_torment=3
+        )
+        self.lore1 = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore1.houses.add(self.house1)
+        self.lore2 = Lore.objects.create(name="Lore of the Firmament", property_name="firmament")
+        self.lore2.houses.add(self.house2)
+
+    def test_ritual_belongs_to_house(self):
+        """Ritual belongs to a specific house."""
+        ritual = Ritual.objects.create(
+            name="Test Ritual", house=self.house1, primary_lore=self.lore1, primary_lore_rating=1
+        )
+        self.assertEqual(ritual.house, self.house1)
+        self.assertNotEqual(ritual.house, self.house2)
+
+    def test_house_rituals_related_name(self):
+        """Test house.rituals related name."""
+        ritual1 = Ritual.objects.create(
+            name="Ritual 1", house=self.house1, primary_lore=self.lore1, primary_lore_rating=1
+        )
+        ritual2 = Ritual.objects.create(
+            name="Ritual 2", house=self.house1, primary_lore=self.lore1, primary_lore_rating=2
+        )
+        ritual3 = Ritual.objects.create(
+            name="Ritual 3", house=self.house2, primary_lore=self.lore2, primary_lore_rating=1
+        )
+
+        house1_rituals = self.house1.rituals.all()
+        self.assertEqual(house1_rituals.count(), 2)
+        self.assertIn(ritual1, house1_rituals)
+        self.assertIn(ritual2, house1_rituals)
+        self.assertNotIn(ritual3, house1_rituals)
+
+    def test_lore_can_be_used_by_multiple_rituals(self):
+        """Multiple rituals can use the same lore."""
+        ritual1 = Ritual.objects.create(
+            name="Ritual 1", house=self.house1, primary_lore=self.lore1, primary_lore_rating=1
+        )
+        ritual2 = Ritual.objects.create(
+            name="Ritual 2", house=self.house1, primary_lore=self.lore1, primary_lore_rating=2
+        )
+        self.assertEqual(ritual1.primary_lore, self.lore1)
+        self.assertEqual(ritual2.primary_lore, self.lore1)
+
+
+class RitualDeleteBehaviorTests(TestCase):
+    """Tests for deletion behavior of Ritual relationships."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+        self.ritual = Ritual.objects.create(
+            name="Test Ritual", house=self.house, primary_lore=self.lore, primary_lore_rating=2
+        )
+
+    def test_deleting_house_sets_null(self):
+        """Deleting a house should set ritual house FK to NULL."""
+        ritual_id = self.ritual.id
+        self.house.delete()
+        ritual = Ritual.objects.get(id=ritual_id)
+        self.assertIsNone(ritual.house)
+
+    def test_deleting_lore_sets_null(self):
+        """Deleting a lore should set ritual lore FKs to NULL."""
+        ritual_id = self.ritual.id
+        self.lore.delete()
+        ritual = Ritual.objects.get(id=ritual_id)
+        self.assertIsNone(ritual.primary_lore)
+
+
+class RitualDisplayMethodsTests(TestCase):
+    """Tests for ritual display methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.primary_lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.primary_lore.houses.add(self.house)
+        self.secondary_lore = Lore.objects.create(
+            name="Lore of the Fundament", property_name="fundament"
+        )
+        self.secondary_lore.houses.add(self.house)
+        self.ritual = Ritual.objects.create(
+            name="Complex Ritual",
+            house=self.house,
+            primary_lore=self.primary_lore,
+            primary_lore_rating=3,
+            secondary_lore_requirements=[
+                {"lore_id": self.secondary_lore.pk, "rating": 2}
+            ],
+        )
+
+    def test_get_primary_lore_display(self):
+        """Test get_primary_lore_display formatting."""
+        display = self.ritual.get_primary_lore_display()
+        self.assertEqual(display, "Lore of Flame •••")
+
+    def test_get_primary_lore_display_no_lore(self):
+        """Test get_primary_lore_display with no lore."""
+        self.ritual.primary_lore = None
+        self.ritual.save()
+        display = self.ritual.get_primary_lore_display()
+        self.assertEqual(display, "")
+
+    def test_get_secondary_lore_display(self):
+        """Test get_secondary_lore_display formatting."""
+        displays = self.ritual.get_secondary_lore_display()
+        self.assertEqual(len(displays), 1)
+        self.assertEqual(displays[0], "Lore of the Fundament ••")
+
+    def test_get_secondary_lores_with_invalid_id(self):
+        """Test get_secondary_lores handles invalid lore IDs."""
+        self.ritual.secondary_lore_requirements = [
+            {"lore_id": 99999, "rating": 2}  # Non-existent ID
+        ]
+        self.ritual.save()
+        lores = self.ritual.get_secondary_lores()
+        self.assertEqual(len(lores), 0)
+
+
+class RitualCastingTimeTests(TestCase):
+    """Tests for ritual casting time."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.house = DemonHouse.objects.create(
+            name="Devils", celestial_name="Namaru", starting_torment=4
+        )
+        self.lore = Lore.objects.create(name="Lore of Flame", property_name="flame")
+        self.lore.houses.add(self.house)
+
+    def test_default_casting_time(self):
+        """Default minimum_casting_time should be 10 minutes."""
+        ritual = Ritual.objects.create(
+            name="Standard Ritual", house=self.house, primary_lore=self.lore, primary_lore_rating=1
+        )
+        self.assertEqual(ritual.minimum_casting_time, 10)
+
+    def test_custom_casting_time(self):
+        """Casting time can be customized."""
+        ritual = Ritual.objects.create(
+            name="Quick Ritual",
+            house=self.house,
+            primary_lore=self.lore,
+            primary_lore_rating=1,
+            minimum_casting_time=5,
+        )
+        self.assertEqual(ritual.minimum_casting_time, 5)
+
+    def test_long_casting_time(self):
+        """Test longer casting times."""
+        ritual = Ritual.objects.create(
+            name="Long Ritual",
+            house=self.house,
+            primary_lore=self.lore,
+            primary_lore_rating=5,
+            minimum_casting_time=60,  # 1 hour
+        )
+        self.assertEqual(ritual.minimum_casting_time, 60)

--- a/characters/tests/models/demon/test_thrall.py
+++ b/characters/tests/models/demon/test_thrall.py
@@ -1,5 +1,310 @@
-"""Tests for thrall module."""
+"""Tests for Thrall model."""
 
+from characters.models.demon import Demon
+from characters.models.demon.pact import Pact
+from characters.models.demon.thrall import Thrall
+from django.contrib.auth.models import User
 from django.test import TestCase
 
-# TODO: Move relevant tests from existing test files here
+
+class ThrallModelTests(TestCase):
+    """Tests for Thrall model functionality."""
+
+    def setUp(self):
+        """Create a test user for thrall ownership."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_default_values(self):
+        """Test default values for Thrall fields."""
+        self.assertEqual(self.thrall.faith_potential, 1)
+        self.assertEqual(self.thrall.daily_faith_offered, 1)
+        self.assertEqual(self.thrall.conviction, 1)
+        self.assertEqual(self.thrall.courage, 1)
+        self.assertEqual(self.thrall.conscience, 1)
+        self.assertEqual(self.thrall.background_points, 5)
+        self.assertEqual(self.thrall.enhancements, [])
+
+    def test_type_and_gameline(self):
+        """Test type and gameline values."""
+        self.assertEqual(self.thrall.type, "thrall")
+        self.assertEqual(self.thrall.gameline, "dtf")
+
+    def test_freebie_step(self):
+        """Test freebie step value."""
+        self.assertEqual(self.thrall.freebie_step, 6)
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url returns correct URL."""
+        url = self.thrall.get_absolute_url()
+        self.assertEqual(url, f"/characters/demon/thrall/{self.thrall.pk}/")
+
+    def test_get_update_url(self):
+        """Test get_update_url returns correct URL."""
+        url = self.thrall.get_update_url()
+        self.assertEqual(url, f"/characters/demon/update/thrall/{self.thrall.pk}/")
+
+    def test_get_creation_url(self):
+        """Test get_creation_url returns correct URL."""
+        url = Thrall.get_creation_url()
+        self.assertEqual(url, "/characters/demon/create/thrall/")
+
+    def test_get_heading(self):
+        """Test get_heading returns DTF heading."""
+        self.assertEqual(self.thrall.get_heading(), "dtf_heading")
+
+    def test_ordering_by_name(self):
+        """Thralls should be ordered by name by default."""
+        thrall_c = Thrall.objects.create(name="Charlie", owner=self.user)
+        thrall_a = Thrall.objects.create(name="Alice", owner=self.user)
+        thrall_b = Thrall.objects.create(name="Bob", owner=self.user)
+
+        thralls = list(Thrall.objects.exclude(pk=self.thrall.pk))
+        self.assertEqual(thralls[0], thrall_a)
+        self.assertEqual(thralls[1], thrall_b)
+        self.assertEqual(thralls[2], thrall_c)
+
+
+class ThrallFaithPotentialTests(TestCase):
+    """Tests for Faith Potential-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_add_faith_potential_increases(self):
+        """add_faith_potential increases faith potential by 1."""
+        initial = self.thrall.faith_potential
+        result = self.thrall.add_faith_potential()
+        self.assertTrue(result)
+        self.assertEqual(self.thrall.faith_potential, initial + 1)
+
+    def test_add_faith_potential_returns_false_at_max(self):
+        """add_faith_potential returns False at max (5)."""
+        self.thrall.faith_potential = 5
+        self.thrall.save()
+        result = self.thrall.add_faith_potential()
+        self.assertFalse(result)
+        self.assertEqual(self.thrall.faith_potential, 5)
+
+    def test_has_faith_potential_true(self):
+        """has_faith_potential returns True when >= 1."""
+        self.assertTrue(self.thrall.has_faith_potential())
+
+    def test_has_faith_potential_false(self):
+        """has_faith_potential returns False when < 1."""
+        self.thrall.faith_potential = 0
+        self.assertFalse(self.thrall.has_faith_potential())
+
+    def test_calculate_daily_faith_round_up(self):
+        """calculate_daily_faith rounds up correctly."""
+        self.thrall.faith_potential = 1
+        result = self.thrall.calculate_daily_faith()
+        self.assertEqual(result, 1)  # (1+1)//2 = 1
+
+        self.thrall.faith_potential = 3
+        result = self.thrall.calculate_daily_faith()
+        self.assertEqual(result, 2)  # (3+1)//2 = 2
+
+        self.thrall.faith_potential = 5
+        result = self.thrall.calculate_daily_faith()
+        self.assertEqual(result, 3)  # (5+1)//2 = 3
+
+
+class ThrallVirtuesTests(TestCase):
+    """Tests for virtue-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_has_virtues_false_with_wrong_sum(self):
+        """has_virtues returns False when sum isn't 6."""
+        self.thrall.conviction = 1
+        self.thrall.courage = 1
+        self.thrall.conscience = 1
+        self.assertFalse(self.thrall.has_virtues())
+
+    def test_has_virtues_true_with_correct_sum(self):
+        """has_virtues returns True when sum is 6."""
+        self.thrall.conviction = 2
+        self.thrall.courage = 2
+        self.thrall.conscience = 2
+        self.assertTrue(self.thrall.has_virtues())
+
+
+class ThrallPactTests(TestCase):
+    """Tests for pact-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_get_pacts_empty(self):
+        """get_pacts returns empty queryset initially."""
+        pacts = self.thrall.get_pacts()
+        self.assertEqual(pacts.count(), 0)
+
+    def test_get_pacts_returns_pacts(self):
+        """get_pacts returns thrall's pacts."""
+        pact = Pact.objects.create(demon=self.demon, thrall=self.thrall)
+        pacts = self.thrall.get_pacts()
+        self.assertEqual(pacts.count(), 1)
+        self.assertIn(pact, pacts)
+
+    def test_get_active_pacts(self):
+        """get_active_pacts returns only active pacts."""
+        pact1 = Pact.objects.create(demon=self.demon, thrall=self.thrall, active=True)
+        pact2 = Pact.objects.create(demon=self.demon, thrall=self.thrall, active=False)
+        active_pacts = self.thrall.get_active_pacts()
+        self.assertEqual(active_pacts.count(), 1)
+        self.assertIn(pact1, active_pacts)
+        self.assertNotIn(pact2, active_pacts)
+
+    def test_total_pacts_counts_active_only(self):
+        """total_pacts counts only active pacts."""
+        Pact.objects.create(demon=self.demon, thrall=self.thrall, active=True)
+        Pact.objects.create(demon=self.demon, thrall=self.thrall, active=False)
+        self.assertEqual(self.thrall.total_pacts(), 1)
+
+
+class ThrallEnhancementTests(TestCase):
+    """Tests for enhancement-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_add_enhancement_adds_new(self):
+        """add_enhancement adds a new enhancement."""
+        result = self.thrall.add_enhancement("Enhanced Strength")
+        self.assertTrue(result)
+        self.assertIn("Enhanced Strength", self.thrall.enhancements)
+
+    def test_add_enhancement_returns_false_duplicate(self):
+        """add_enhancement returns False for duplicate."""
+        self.thrall.enhancements = ["Enhanced Strength"]
+        self.thrall.save()
+        result = self.thrall.add_enhancement("Enhanced Strength")
+        self.assertFalse(result)
+
+    def test_remove_enhancement_removes(self):
+        """remove_enhancement removes an enhancement."""
+        self.thrall.enhancements = ["Enhanced Strength", "Night Vision"]
+        self.thrall.save()
+        result = self.thrall.remove_enhancement("Enhanced Strength")
+        self.assertTrue(result)
+        self.assertNotIn("Enhanced Strength", self.thrall.enhancements)
+        self.assertIn("Night Vision", self.thrall.enhancements)
+
+    def test_remove_enhancement_returns_false_not_found(self):
+        """remove_enhancement returns False if not found."""
+        result = self.thrall.remove_enhancement("Not Present")
+        self.assertFalse(result)
+
+
+class ThrallXPTests(TestCase):
+    """Tests for XP-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user, xp=100)
+
+    def test_xp_frequencies_returns_dict(self):
+        """xp_frequencies returns correct dictionary."""
+        freq = self.thrall.xp_frequencies()
+        self.assertIn("attribute", freq)
+        self.assertIn("ability", freq)
+        self.assertIn("background", freq)
+        self.assertIn("willpower", freq)
+        self.assertIn("faith_potential", freq)
+        self.assertIn("virtue", freq)
+
+
+class ThrallFreebieTests(TestCase):
+    """Tests for freebie-related methods."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user, freebies=50)
+
+    def test_freebie_frequencies_returns_dict(self):
+        """freebie_frequencies returns correct dictionary."""
+        freq = self.thrall.freebie_frequencies()
+        self.assertIn("attribute", freq)
+        self.assertIn("ability", freq)
+        self.assertIn("background", freq)
+        self.assertIn("willpower", freq)
+        self.assertIn("meritflaw", freq)
+        self.assertIn("faith_potential", freq)
+        self.assertIn("virtue", freq)
+
+    def test_freebie_costs_returns_dict(self):
+        """freebie_costs returns correct costs."""
+        costs = self.thrall.freebie_costs()
+        self.assertEqual(costs["faith_potential"], 7)
+        self.assertEqual(costs["virtue"], 2)
+
+    def test_freebie_cost_faith_potential(self):
+        """freebie_cost returns correct cost for faith_potential."""
+        self.assertEqual(self.thrall.freebie_cost("faith_potential"), 7)
+
+    def test_freebie_cost_virtue(self):
+        """freebie_cost returns correct cost for virtue."""
+        self.assertEqual(self.thrall.freebie_cost("virtue"), 2)
+
+    def test_spend_freebies_faith_potential(self):
+        """spend_freebies increases faith_potential and deducts freebies."""
+        initial_fp = self.thrall.faith_potential
+        initial_freebies = self.thrall.freebies
+        result = self.thrall.spend_freebies("faith_potential")
+        self.assertTrue(result)
+        self.assertEqual(self.thrall.faith_potential, initial_fp + 1)
+        self.assertEqual(self.thrall.freebies, initial_freebies - 7)
+
+    def test_spend_freebies_faith_potential_insufficient(self):
+        """spend_freebies returns False with insufficient freebies."""
+        self.thrall.freebies = 1
+        self.thrall.save()
+        result = self.thrall.spend_freebies("faith_potential")
+        self.assertFalse(result)
+
+    def test_spend_freebies_virtue(self):
+        """spend_freebies increases virtue and deducts freebies."""
+        initial_conviction = self.thrall.conviction
+        result = self.thrall.spend_freebies("conviction")
+        self.assertTrue(result)
+        self.assertEqual(self.thrall.conviction, initial_conviction + 1)
+
+
+class ThrallMasterTests(TestCase):
+    """Tests for master relationship."""
+
+    def setUp(self):
+        """Create test fixtures."""
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.demon = Demon.objects.create(name="Test Demon", owner=self.user)
+        self.thrall = Thrall.objects.create(name="Test Thrall", owner=self.user)
+
+    def test_master_can_be_set(self):
+        """Master demon can be set."""
+        self.thrall.master = self.demon
+        self.thrall.save()
+        self.assertEqual(self.thrall.master, self.demon)
+
+    def test_master_can_be_null(self):
+        """Master demon can be null."""
+        self.assertIsNone(self.thrall.master)
+
+    def test_primary_thralls_related_name(self):
+        """Test primary_thralls related name on Demon."""
+        self.thrall.master = self.demon
+        self.thrall.save()
+        self.assertIn(self.thrall, self.demon.primary_thralls.all())


### PR DESCRIPTION
## Summary
- Add comprehensive tests for Demon: the Fallen (DtF) models achieving 73% coverage (exceeds 70% target)
- Fix model field validation issues (add `blank=True` for empty string defaults)
- Add 240 tests covering Demon, Thrall, Earthbound, Ritual, and ApocalypticForm models

## Test plan
- [x] Run `python manage.py test characters.tests.models.demon` - 240 tests pass
- [x] Run `coverage report` - 73% coverage on DtF files
- [x] Verify model field fixes don't break existing functionality

## Coverage Results
| File | Coverage |
|------|----------|
| apocalyptic_form.py | 93% |
| conclave.py | 80% |
| demon.py | 70% |
| dtf_human.py | 91% |
| earthbound.py | 100% |
| faction.py | 80% |
| house.py | 79% |
| lore.py | 84% |
| lore_block.py | 94% |
| pact.py | 72% |
| ritual.py | 97% |
| thrall.py | 65% |
| visage.py | 79% |
| **TOTAL** | **73%** |

## Notes
- XP-related tests excluded due to signature mismatch in parent `Human.xp_cost()` method (existing bug, out of scope)
- Forms coverage is lower (~35-42%) as they are tested through views in separate test directories

Closes #1179

🤖 Generated with [Claude Code](https://claude.com/claude-code)