### PR TITLE
Implement LinearMagicPath and LinearMagicRitual views

### DIFF
--- a/characters/templates/characters/mage/linear_magic_path/form.html
+++ b/characters/templates/characters/mage/linear_magic_path/form.html
@@ -1,0 +1,27 @@
+{% extends "core/form.html" %}
+{% block creation_title %}
+    {% if object %}
+        Edit {{ object.name }}
+    {% else %}
+        Create Linear Magic Path
+    {% endif %}
+{% endblock creation_title %}
+{% block contents %}
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_name" class="form-label">Name</label></div>
+        <div class="col-sm-9">{{ form.name }}</div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_numina_type" class="form-label">Type</label></div>
+        <div class="col-sm-9">{{ form.numina_type }}</div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_description" class="form-label">Description</label></div>
+        <div class="col-sm-9">{{ form.description }}</div>
+    </div>
+{% endblock contents %}
+{% block buttons %}
+    <button type="submit" class="btn btn-primary">
+        <i class="fas fa-save"></i> Save Path
+    </button>
+{% endblock buttons %}

--- a/characters/templates/characters/mage/linear_magic_path/list.html
+++ b/characters/templates/characters/mage/linear_magic_path/list.html
@@ -1,0 +1,152 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Linear Magic Paths
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="mta">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title mta_heading">Linear Magic Paths</h1>
+            </div>
+        </div>
+
+        <!-- Filter Controls -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header d-flex justify-content-between align-items-center">
+                <h5 class="tg-card-title mb-0">Filters</h5>
+                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#filterPanel" aria-expanded="false" aria-controls="filterPanel">
+                    Toggle Filters
+                </button>
+            </div>
+            <div class="collapse show" id="filterPanel">
+                <div class="tg-card-body" style="padding: 20px;">
+                    <!-- Search Filter -->
+                    <div class="mb-3">
+                        <label for="nameFilter" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Search by Name</label>
+                        <input type="text" class="form-control" id="nameFilter" placeholder="Type to filter by name...">
+                    </div>
+
+                    <!-- Type Filter -->
+                    <div class="mb-3">
+                        <label for="typeFilter" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Filter by Type</label>
+                        <select class="form-control" id="typeFilter">
+                            <option value="">All Types</option>
+                            <option value="hedge_magic">Hedge Magic</option>
+                            <option value="psychic">Psychic Phenomenon</option>
+                        </select>
+                    </div>
+
+                    <!-- Clear Filters -->
+                    <div class="d-flex justify-content-between align-items-center">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="clearFilters">Clear All Filters</button>
+                        <span id="resultCount" style="font-size: 0.875rem; color: var(--theme-text-secondary);"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Path List -->
+        <div class="row" id="pathList">
+            {% for obj in object_list %}
+                <div class="col-md-4 col-sm-6 mb-3 path-item"
+                     data-name="{{ obj.name|lower }}"
+                     data-type="{{ obj.numina_type }}">
+                    <div class="tg-card h-100">
+                        <div class="tg-card-body" style="padding: 16px;">
+                            <h6 class="tg-card-title mb-2">
+                                <a href="{{ obj.get_absolute_url }}" style="text-decoration: none; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                            </h6>
+                            <div style="font-size: 0.75rem; color: var(--theme-text-secondary);">
+                                {{ obj.get_numina_type_display }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% empty %}
+                <div class="col-12">
+                    <div class="tg-card">
+                        <div class="tg-card-body text-center" style="padding: 20px;">
+                            <p style="color: var(--theme-text-secondary); margin: 0;">No linear magic paths found.</p>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+        <!-- No Results Message -->
+        <div id="noResults" class="tg-card" style="display: none;">
+            <div class="tg-card-body text-center" style="padding: 20px;">
+                <p style="color: var(--theme-text-secondary); margin: 0;">No paths match the current filters.</p>
+            </div>
+        </div>
+    </div>
+{% endblock content %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const nameFilter = document.getElementById('nameFilter');
+    const typeFilter = document.getElementById('typeFilter');
+    const pathItems = document.querySelectorAll('.path-item');
+    const clearButton = document.getElementById('clearFilters');
+    const resultCount = document.getElementById('resultCount');
+    const noResults = document.getElementById('noResults');
+
+    function updateFilters() {
+        const nameQuery = nameFilter.value.toLowerCase().trim();
+        const selectedType = typeFilter.value;
+
+        let visibleCount = 0;
+
+        pathItems.forEach(item => {
+            let show = true;
+
+            // Name filter
+            if (nameQuery && !item.dataset.name.includes(nameQuery)) {
+                show = false;
+            }
+
+            // Type filter
+            if (selectedType && item.dataset.type !== selectedType) {
+                show = false;
+            }
+
+            if (show) {
+                item.style.display = '';
+                visibleCount++;
+            } else {
+                item.style.display = 'none';
+            }
+        });
+
+        // Update result count
+        const totalCount = pathItems.length;
+        if (nameQuery || selectedType) {
+            resultCount.textContent = `Showing ${visibleCount} of ${totalCount} paths`;
+        } else {
+            resultCount.textContent = `${totalCount} paths`;
+        }
+
+        // Show/hide no results message
+        if (visibleCount === 0 && totalCount > 0) {
+            noResults.style.display = '';
+        } else {
+            noResults.style.display = 'none';
+        }
+    }
+
+    // Event listeners
+    nameFilter.addEventListener('input', updateFilters);
+    typeFilter.addEventListener('change', updateFilters);
+
+    clearButton.addEventListener('click', function() {
+        nameFilter.value = '';
+        typeFilter.value = '';
+        updateFilters();
+    });
+
+    // Initial count
+    updateFilters();
+});
+</script>
+{% endblock extra_js %}

--- a/characters/templates/characters/mage/linear_magic_ritual/form.html
+++ b/characters/templates/characters/mage/linear_magic_ritual/form.html
@@ -1,0 +1,31 @@
+{% extends "core/form.html" %}
+{% block creation_title %}
+    {% if object %}
+        Edit {{ object.name }}
+    {% else %}
+        Create Linear Magic Ritual
+    {% endif %}
+{% endblock creation_title %}
+{% block contents %}
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_name" class="form-label">Name</label></div>
+        <div class="col-sm-9">{{ form.name }}</div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_path" class="form-label">Path</label></div>
+        <div class="col-sm-9">{{ form.path }}</div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_level" class="form-label">Level</label></div>
+        <div class="col-sm-9">{{ form.level }}</div>
+    </div>
+    <div class="row mb-3">
+        <div class="col-sm-3"><label for="id_description" class="form-label">Description</label></div>
+        <div class="col-sm-9">{{ form.description }}</div>
+    </div>
+{% endblock contents %}
+{% block buttons %}
+    <button type="submit" class="btn btn-primary">
+        <i class="fas fa-save"></i> Save Ritual
+    </button>
+{% endblock buttons %}

--- a/characters/templates/characters/mage/linear_magic_ritual/list.html
+++ b/characters/templates/characters/mage/linear_magic_ritual/list.html
@@ -1,0 +1,177 @@
+{% extends "core/base.html" %}
+{% load dots %}
+{% block title %}
+    Linear Magic Rituals
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="mta">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title mta_heading">Linear Magic Rituals</h1>
+            </div>
+        </div>
+
+        <!-- Filter Controls -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header d-flex justify-content-between align-items-center">
+                <h5 class="tg-card-title mb-0">Filters</h5>
+                <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#filterPanel" aria-expanded="false" aria-controls="filterPanel">
+                    Toggle Filters
+                </button>
+            </div>
+            <div class="collapse show" id="filterPanel">
+                <div class="tg-card-body" style="padding: 20px;">
+                    <!-- Search Filter -->
+                    <div class="mb-3">
+                        <label for="nameFilter" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Search by Name</label>
+                        <input type="text" class="form-control" id="nameFilter" placeholder="Type to filter by name...">
+                    </div>
+
+                    <!-- Path Filter -->
+                    <div class="mb-3">
+                        <label for="pathFilter" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Filter by Path</label>
+                        <select class="form-control" id="pathFilter">
+                            <option value="">All Paths</option>
+                            {% for path in paths %}
+                                <option value="{{ path.id }}">{{ path.name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+
+                    <!-- Level Filter -->
+                    <div class="mb-3">
+                        <label for="levelFilter" style="font-weight: 600; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.5px; color: var(--theme-text-secondary);">Max Level</label>
+                        <input type="number" class="form-control" id="levelFilter" min="1" max="5" placeholder="Filter by max level...">
+                    </div>
+
+                    <!-- Clear Filters -->
+                    <div class="d-flex justify-content-between align-items-center">
+                        <button type="button" class="btn btn-sm btn-outline-secondary" id="clearFilters">Clear All Filters</button>
+                        <span id="resultCount" style="font-size: 0.875rem; color: var(--theme-text-secondary);"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Ritual List -->
+        <div class="row" id="ritualList">
+            {% for obj in object_list %}
+                <div class="col-md-4 col-sm-6 mb-3 ritual-item"
+                     data-name="{{ obj.name|lower }}"
+                     data-path="{{ obj.path.id|default:'' }}"
+                     data-level="{{ obj.level }}">
+                    <div class="tg-card h-100">
+                        <div class="tg-card-body" style="padding: 16px;">
+                            <h6 class="tg-card-title mb-2">
+                                <a href="{{ obj.get_absolute_url }}" style="text-decoration: none; color: var(--theme-text-primary);">{{ obj.name }}</a>
+                            </h6>
+                            <div class="d-flex justify-content-between align-items-center">
+                                {% if obj.path %}
+                                    <span style="font-size: 0.75rem; color: var(--theme-text-secondary);">
+                                        <a href="{{ obj.path.get_absolute_url }}" style="text-decoration: none; color: var(--theme-text-secondary);">{{ obj.path.name }}</a>
+                                    </span>
+                                {% else %}
+                                    <span style="font-size: 0.75rem; color: var(--theme-text-secondary);">No Path</span>
+                                {% endif %}
+                                <span class="dots">{{ obj.level|dots:5 }}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% empty %}
+                <div class="col-12">
+                    <div class="tg-card">
+                        <div class="tg-card-body text-center" style="padding: 20px;">
+                            <p style="color: var(--theme-text-secondary); margin: 0;">No linear magic rituals found.</p>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+        <!-- No Results Message -->
+        <div id="noResults" class="tg-card" style="display: none;">
+            <div class="tg-card-body text-center" style="padding: 20px;">
+                <p style="color: var(--theme-text-secondary); margin: 0;">No rituals match the current filters.</p>
+            </div>
+        </div>
+    </div>
+{% endblock content %}
+
+{% block extra_js %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const nameFilter = document.getElementById('nameFilter');
+    const pathFilter = document.getElementById('pathFilter');
+    const levelFilter = document.getElementById('levelFilter');
+    const ritualItems = document.querySelectorAll('.ritual-item');
+    const clearButton = document.getElementById('clearFilters');
+    const resultCount = document.getElementById('resultCount');
+    const noResults = document.getElementById('noResults');
+
+    function updateFilters() {
+        const nameQuery = nameFilter.value.toLowerCase().trim();
+        const selectedPath = pathFilter.value;
+        const maxLevel = levelFilter.value ? parseInt(levelFilter.value) : null;
+
+        let visibleCount = 0;
+
+        ritualItems.forEach(item => {
+            let show = true;
+
+            // Name filter
+            if (nameQuery && !item.dataset.name.includes(nameQuery)) {
+                show = false;
+            }
+
+            // Path filter
+            if (selectedPath && item.dataset.path !== selectedPath) {
+                show = false;
+            }
+
+            // Level filter
+            if (maxLevel !== null && parseInt(item.dataset.level) > maxLevel) {
+                show = false;
+            }
+
+            if (show) {
+                item.style.display = '';
+                visibleCount++;
+            } else {
+                item.style.display = 'none';
+            }
+        });
+
+        // Update result count
+        const totalCount = ritualItems.length;
+        if (nameQuery || selectedPath || maxLevel !== null) {
+            resultCount.textContent = `Showing ${visibleCount} of ${totalCount} rituals`;
+        } else {
+            resultCount.textContent = `${totalCount} rituals`;
+        }
+
+        // Show/hide no results message
+        if (visibleCount === 0 && totalCount > 0) {
+            noResults.style.display = '';
+        } else {
+            noResults.style.display = 'none';
+        }
+    }
+
+    // Event listeners
+    nameFilter.addEventListener('input', updateFilters);
+    pathFilter.addEventListener('change', updateFilters);
+    levelFilter.addEventListener('input', updateFilters);
+
+    clearButton.addEventListener('click', function() {
+        nameFilter.value = '';
+        pathFilter.value = '';
+        levelFilter.value = '';
+        updateFilters();
+    });
+
+    // Initial count
+    updateFilters();
+});
+</script>
+{% endblock extra_js %}

--- a/characters/tests/views/mage/test_linear_magic.py
+++ b/characters/tests/views/mage/test_linear_magic.py
@@ -1,0 +1,323 @@
+"""Tests for LinearMagicPath and LinearMagicRitual views."""
+
+from characters.models.mage.sorcerer import LinearMagicPath, LinearMagicRitual
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+
+
+class TestPathListView(TestCase):
+    """Test PathListView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path_hedge = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+        )
+        self.path_psychic = LinearMagicPath.objects.create(
+            name="Telepathy",
+            numina_type="psychic",
+        )
+
+    def test_list_view_accessible_without_login(self):
+        """Test that path list view is accessible without login."""
+        response = self.client.get(reverse("characters:mage:list:path"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_uses_correct_template(self):
+        """Test that correct template is used for path list view."""
+        response = self.client.get(reverse("characters:mage:list:path"))
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_path/list.html")
+
+    def test_list_view_contains_paths(self):
+        """Test that list view contains created paths."""
+        response = self.client.get(reverse("characters:mage:list:path"))
+        self.assertContains(response, "Alchemy")
+        self.assertContains(response, "Telepathy")
+
+
+class TestPathDetailView(TestCase):
+    """Test PathDetailView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+            description="The art of transmutation",
+        )
+
+    def test_detail_view_accessible_without_login(self):
+        """Test that path detail view is accessible without login."""
+        response = self.client.get(self.path.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_uses_correct_template(self):
+        """Test that correct template is used for path detail view."""
+        response = self.client.get(self.path.get_absolute_url())
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_path/detail.html")
+
+    def test_detail_view_contains_path_info(self):
+        """Test that detail view contains path information."""
+        response = self.client.get(self.path.get_absolute_url())
+        self.assertContains(response, "Alchemy")
+        self.assertContains(response, "Hedge Magic")
+
+
+class TestPathCreateView(TestCase):
+    """Test PathCreateView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+
+    def test_create_view_accessible_when_logged_in(self):
+        """Test that path create view is accessible when logged in."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(reverse("characters:mage:create:path"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_uses_correct_template(self):
+        """Test that correct template is used for path create view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(reverse("characters:mage:create:path"))
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_path/form.html")
+
+    def test_create_view_can_create_path(self):
+        """Test that path can be created through the view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.post(
+            reverse("characters:mage:create:path"),
+            {
+                "name": "Test Path",
+                "description": "A test path",
+                "numina_type": "hedge_magic",
+            },
+        )
+        self.assertTrue(LinearMagicPath.objects.filter(name="Test Path").exists())
+
+
+class TestPathUpdateView(TestCase):
+    """Test PathUpdateView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+        )
+
+    def test_update_view_accessible_when_logged_in(self):
+        """Test that path update view is accessible when logged in."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:mage:update:path", kwargs={"pk": self.path.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_uses_correct_template(self):
+        """Test that correct template is used for path update view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:mage:update:path", kwargs={"pk": self.path.pk})
+        )
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_path/form.html")
+
+    def test_update_view_can_update_path(self):
+        """Test that path can be updated through the view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.post(
+            reverse("characters:mage:update:path", kwargs={"pk": self.path.pk}),
+            {
+                "name": "Updated Alchemy",
+                "description": "Updated description",
+                "numina_type": "hedge_magic",
+            },
+        )
+        self.path.refresh_from_db()
+        self.assertEqual(self.path.name, "Updated Alchemy")
+
+
+class TestRitualListView(TestCase):
+    """Test RitualListView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+        )
+        self.ritual1 = LinearMagicRitual.objects.create(
+            name="Purify Water",
+            path=self.path,
+            level=1,
+        )
+        self.ritual2 = LinearMagicRitual.objects.create(
+            name="Transmute Gold",
+            path=self.path,
+            level=3,
+        )
+
+    def test_list_view_accessible_without_login(self):
+        """Test that ritual list view is accessible without login."""
+        response = self.client.get(reverse("characters:mage:list:ritual"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_uses_correct_template(self):
+        """Test that correct template is used for ritual list view."""
+        response = self.client.get(reverse("characters:mage:list:ritual"))
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_ritual/list.html")
+
+    def test_list_view_contains_rituals(self):
+        """Test that list view contains created rituals."""
+        response = self.client.get(reverse("characters:mage:list:ritual"))
+        self.assertContains(response, "Purify Water")
+        self.assertContains(response, "Transmute Gold")
+
+    def test_list_view_context_contains_paths(self):
+        """Test that list view context contains paths for filtering."""
+        response = self.client.get(reverse("characters:mage:list:ritual"))
+        self.assertIn("paths", response.context)
+        self.assertIn(self.path, response.context["paths"])
+
+
+class TestRitualDetailView(TestCase):
+    """Test RitualDetailView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+        )
+        self.ritual = LinearMagicRitual.objects.create(
+            name="Purify Water",
+            path=self.path,
+            level=1,
+            description="Purifies a quantity of water",
+        )
+
+    def test_detail_view_accessible_without_login(self):
+        """Test that ritual detail view is accessible without login."""
+        response = self.client.get(self.ritual.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_uses_correct_template(self):
+        """Test that correct template is used for ritual detail view."""
+        response = self.client.get(self.ritual.get_absolute_url())
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_ritual/detail.html")
+
+    def test_detail_view_contains_ritual_info(self):
+        """Test that detail view contains ritual information."""
+        response = self.client.get(self.ritual.get_absolute_url())
+        self.assertContains(response, "Purify Water")
+        self.assertContains(response, "Alchemy")
+
+
+class TestRitualCreateView(TestCase):
+    """Test RitualCreateView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+        )
+
+    def test_create_view_accessible_when_logged_in(self):
+        """Test that ritual create view is accessible when logged in."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(reverse("characters:mage:create:ritual"))
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_uses_correct_template(self):
+        """Test that correct template is used for ritual create view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(reverse("characters:mage:create:ritual"))
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_ritual/form.html")
+
+    def test_create_view_can_create_ritual(self):
+        """Test that ritual can be created through the view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.post(
+            reverse("characters:mage:create:ritual"),
+            {
+                "name": "Test Ritual",
+                "description": "A test ritual",
+                "path": self.path.pk,
+                "level": 2,
+            },
+        )
+        self.assertTrue(LinearMagicRitual.objects.filter(name="Test Ritual").exists())
+
+
+class TestRitualUpdateView(TestCase):
+    """Test RitualUpdateView functionality."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.path = LinearMagicPath.objects.create(
+            name="Alchemy",
+            numina_type="hedge_magic",
+        )
+        self.ritual = LinearMagicRitual.objects.create(
+            name="Purify Water",
+            path=self.path,
+            level=1,
+        )
+
+    def test_update_view_accessible_when_logged_in(self):
+        """Test that ritual update view is accessible when logged in."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:mage:update:ritual", kwargs={"pk": self.ritual.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_uses_correct_template(self):
+        """Test that correct template is used for ritual update view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:mage:update:ritual", kwargs={"pk": self.ritual.pk})
+        )
+        self.assertTemplateUsed(response, "characters/mage/linear_magic_ritual/form.html")
+
+    def test_update_view_can_update_ritual(self):
+        """Test that ritual can be updated through the view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.post(
+            reverse("characters:mage:update:ritual", kwargs={"pk": self.ritual.pk}),
+            {
+                "name": "Updated Purify Water",
+                "description": "Updated description",
+                "path": self.path.pk,
+                "level": 2,
+            },
+        )
+        self.ritual.refresh_from_db()
+        self.assertEqual(self.ritual.name, "Updated Purify Water")
+        self.assertEqual(self.ritual.level, 2)

--- a/characters/urls/mage/create.py
+++ b/characters/urls/mage/create.py
@@ -59,6 +59,16 @@ urls = [
         name="rote",
     ),
     path(
+        "paths/",
+        views.mage.PathCreateView.as_view(),
+        name="path",
+    ),
+    path(
+        "rituals/",
+        views.mage.RitualCreateView.as_view(),
+        name="ritual",
+    ),
+    path(
         "mtahuman/",
         views.mage.MtAHumanBasicsView.as_view(),
         name="mta_human",

--- a/characters/urls/mage/index.py
+++ b/characters/urls/mage/index.py
@@ -44,5 +44,7 @@ urls = [
         name="sorcerer_fellowship",
     ),
     path("rotes/", views.mage.RoteListView.as_view(), name="rote"),
+    path("paths/", views.mage.PathListView.as_view(), name="path"),
+    path("rituals/", views.mage.RitualListView.as_view(), name="ritual"),
     path("cabal/", views.mage.CabalListView.as_view(), name="cabal"),
 ]

--- a/characters/urls/mage/update.py
+++ b/characters/urls/mage/update.py
@@ -59,6 +59,16 @@ urls = [
         name="rote",
     ),
     path(
+        "paths/<pk>/",
+        views.mage.PathUpdateView.as_view(),
+        name="path",
+    ),
+    path(
+        "rituals/<pk>/",
+        views.mage.RitualUpdateView.as_view(),
+        name="ritual",
+    ),
+    path(
         "mtahuman/<pk>/",
         views.mage.MtAHumanUpdateView.as_view(),
         name="mta_human",

--- a/characters/views/mage/__init__.py
+++ b/characters/views/mage/__init__.py
@@ -44,7 +44,16 @@ from .focus import (
     TenetListView,
     TenetUpdateView,
 )
-from .hedge_magic import PathDetailView, RitualDetailView
+from .hedge_magic import (
+    PathCreateView,
+    PathDetailView,
+    PathListView,
+    PathUpdateView,
+    RitualCreateView,
+    RitualDetailView,
+    RitualListView,
+    RitualUpdateView,
+)
 from .mage import (
     MageBasicsView,
     MageCharacterCreationView,

--- a/characters/views/mage/hedge_magic.py
+++ b/characters/views/mage/hedge_magic.py
@@ -1,5 +1,6 @@
 from characters.models.mage.sorcerer import LinearMagicPath, LinearMagicRitual
-from django.views.generic import DetailView
+from core.mixins import MessageMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
 
 
 class PathDetailView(DetailView):
@@ -7,6 +8,55 @@ class PathDetailView(DetailView):
     template_name = "characters/mage/linear_magic_path/detail.html"
 
 
+class PathCreateView(MessageMixin, CreateView):
+    model = LinearMagicPath
+    fields = ["name", "description", "numina_type"]
+    template_name = "characters/mage/linear_magic_path/form.html"
+    success_message = "Linear Magic Path created successfully."
+    error_message = "There was an error creating the Linear Magic Path."
+
+
+class PathUpdateView(MessageMixin, UpdateView):
+    model = LinearMagicPath
+    fields = ["name", "description", "numina_type"]
+    template_name = "characters/mage/linear_magic_path/form.html"
+    success_message = "Linear Magic Path updated successfully."
+    error_message = "There was an error updating the Linear Magic Path."
+
+
+class PathListView(ListView):
+    model = LinearMagicPath
+    ordering = ["name"]
+    template_name = "characters/mage/linear_magic_path/list.html"
+
+
 class RitualDetailView(DetailView):
     model = LinearMagicRitual
     template_name = "characters/mage/linear_magic_ritual/detail.html"
+
+
+class RitualCreateView(MessageMixin, CreateView):
+    model = LinearMagicRitual
+    fields = ["name", "description", "path", "level"]
+    template_name = "characters/mage/linear_magic_ritual/form.html"
+    success_message = "Linear Magic Ritual created successfully."
+    error_message = "There was an error creating the Linear Magic Ritual."
+
+
+class RitualUpdateView(MessageMixin, UpdateView):
+    model = LinearMagicRitual
+    fields = ["name", "description", "path", "level"]
+    template_name = "characters/mage/linear_magic_ritual/form.html"
+    success_message = "Linear Magic Ritual updated successfully."
+    error_message = "There was an error updating the Linear Magic Ritual."
+
+
+class RitualListView(ListView):
+    model = LinearMagicRitual
+    ordering = ["path", "level", "name"]
+    template_name = "characters/mage/linear_magic_ritual/list.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["paths"] = LinearMagicPath.objects.all().order_by("name")
+        return context


### PR DESCRIPTION
## Summary
- Add complete CRUD views for LinearMagicPath (hedge magic/psychic paths) and LinearMagicRitual (rituals associated with paths)
- Create list and form templates with filtering capabilities for both models
- Add URL patterns for list, create, update, and detail views
- Add 25 comprehensive tests covering all view functionality

Fixes #1082

## Test plan
- [x] Run `python manage.py test characters.tests.views.mage.test_linear_magic` - all 25 tests pass
- [x] Run `python manage.py test characters.tests.views.mage` - all 84 tests pass
- [ ] Manual testing: Navigate to `/characters/mage/list/paths/` to see path list
- [ ] Manual testing: Navigate to `/characters/mage/list/rituals/` to see ritual list
- [ ] Manual testing: Create, update, and view paths and rituals via the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)