### PR TITLE
Fix #1055: Add form field error display to VampireArtifact and VampireFreebies forms

### DIFF
--- a/characters/templates/characters/vampire/vampire/freebies_form.html
+++ b/characters/templates/characters/vampire/vampire/freebies_form.html
@@ -74,12 +74,44 @@
         <h3 class="col-sm {{ object.get_heading }}">{{ object.freebies }}</h3>
     </div>
 {% endif %}
+{% if form.non_field_errors %}
+    <div class="row mb-2">
+        <div class="col-sm">
+            <div class="text-danger" style="font-size: 0.875rem;">{{ form.non_field_errors }}</div>
+        </div>
+    </div>
+{% endif %}
 <div class="row">
-    <div class="col-sm">{{ form.category }}</div>
-    <div class="col-sm d-none" id="example_wrap">{{ form.example }}</div>
-    <div class="col-sm d-none" id="value_wrap">{{ form.value }}</div>
-    <div class="col-sm d-none" id="note_wrap">{{ form.note }}</div>
-    <div class="col-sm d-none" id="pooled_wrap">Pooled? {{ form.pooled }}</div>
+    <div class="col-sm">
+        {{ form.category }}
+        {% if form.category.errors %}
+            <div class="text-danger" style="font-size: 0.875rem;">{{ form.category.errors }}</div>
+        {% endif %}
+    </div>
+    <div class="col-sm d-none" id="example_wrap">
+        {{ form.example }}
+        {% if form.example.errors %}
+            <div class="text-danger" style="font-size: 0.875rem;">{{ form.example.errors }}</div>
+        {% endif %}
+    </div>
+    <div class="col-sm d-none" id="value_wrap">
+        {{ form.value }}
+        {% if form.value.errors %}
+            <div class="text-danger" style="font-size: 0.875rem;">{{ form.value.errors }}</div>
+        {% endif %}
+    </div>
+    <div class="col-sm d-none" id="note_wrap">
+        {{ form.note }}
+        {% if form.note.errors %}
+            <div class="text-danger" style="font-size: 0.875rem;">{{ form.note.errors }}</div>
+        {% endif %}
+    </div>
+    <div class="col-sm d-none" id="pooled_wrap">
+        Pooled? {{ form.pooled }}
+        {% if form.pooled.errors %}
+            <div class="text-danger" style="font-size: 0.875rem;">{{ form.pooled.errors }}</div>
+        {% endif %}
+    </div>
 </div>
 {% for item in object.spent_freebies %}
     <div class="row">

--- a/items/templates/items/vampire/artifact/form.html
+++ b/items/templates/items/vampire/artifact/form.html
@@ -11,14 +11,23 @@
         <div class="col-md-6">
             <label for="{{ form.name.id_for_label }}" class="form-label">Name</label>
             {{ form.name }}
+            {% if form.name.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.name.errors }}</div>
+            {% endif %}
         </div>
         <div class="col-md-3">
             <label for="{{ form.power_level.id_for_label }}" class="form-label">Power Level</label>
             {{ form.power_level }}
+            {% if form.power_level.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.power_level.errors }}</div>
+            {% endif %}
         </div>
         <div class="col-md-3">
             <label for="{{ form.background_cost.id_for_label }}" class="form-label">Background Cost</label>
             {{ form.background_cost }}
+            {% if form.background_cost.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.background_cost.errors }}</div>
+            {% endif %}
         </div>
     </div>
 
@@ -26,6 +35,9 @@
         <div class="col-12">
             <label for="{{ form.description.id_for_label }}" class="form-label">Description</label>
             {{ form.description }}
+            {% if form.description.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.description.errors }}</div>
+            {% endif %}
         </div>
     </div>
 
@@ -37,6 +49,9 @@
                     Cursed
                 </label>
             </div>
+            {% if form.is_cursed.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.is_cursed.errors }}</div>
+            {% endif %}
         </div>
         <div class="col-md-4">
             <div class="form-check">
@@ -45,6 +60,9 @@
                     Unique Artifact
                 </label>
             </div>
+            {% if form.is_unique.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.is_unique.errors }}</div>
+            {% endif %}
         </div>
         <div class="col-md-4">
             <div class="form-check">
@@ -53,6 +71,9 @@
                     Requires Blood
                 </label>
             </div>
+            {% if form.requires_blood.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.requires_blood.errors }}</div>
+            {% endif %}
         </div>
     </div>
 
@@ -60,6 +81,9 @@
         <div class="col-12">
             <label for="{{ form.powers.id_for_label }}" class="form-label">Powers & Effects</label>
             {{ form.powers }}
+            {% if form.powers.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.powers.errors }}</div>
+            {% endif %}
         </div>
     </div>
 
@@ -67,6 +91,9 @@
         <div class="col-12">
             <label for="{{ form.history.id_for_label }}" class="form-label">History & Lore</label>
             {{ form.history }}
+            {% if form.history.errors %}
+                <div class="text-danger" style="font-size: 0.875rem;">{{ form.history.errors }}</div>
+            {% endif %}
         </div>
     </div>
 {% endblock contents %}

--- a/items/tests/views/vampire/test_artifact.py
+++ b/items/tests/views/vampire/test_artifact.py
@@ -1,0 +1,121 @@
+"""Tests for vampire artifact views."""
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from items.models.vampire import VampireArtifact
+
+
+class VampireArtifactCreateViewTest(TestCase):
+    """Test the VampireArtifact create view."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.create_url = reverse("items:vampire:create:artifact")
+
+    def test_create_view_requires_login(self):
+        """Unauthenticated users are denied or redirected."""
+        response = self.client.get(self.create_url)
+        # Either redirect (302) or unauthorized (401) is acceptable
+        self.assertIn(response.status_code, [302, 401])
+
+    def test_create_view_authenticated(self):
+        """Authenticated users can access the create view."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.create_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "items/vampire/artifact/form.html")
+
+    def test_create_valid_artifact(self):
+        """Valid form data creates an artifact."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.post(
+            self.create_url,
+            {
+                "name": "Test Artifact",
+                "description": "A test artifact",
+                "power_level": 3,
+                "background_cost": 2,
+                "is_cursed": False,
+                "is_unique": True,
+                "requires_blood": False,
+                "powers": "Test powers",
+                "history": "Test history",
+            },
+        )
+        self.assertEqual(VampireArtifact.objects.count(), 1)
+        artifact = VampireArtifact.objects.first()
+        self.assertEqual(artifact.name, "Test Artifact")
+        self.assertEqual(artifact.owner, self.user)
+
+    def test_create_empty_name_shows_error(self):
+        """Submitting empty name shows field error in template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.post(
+            self.create_url,
+            {
+                "name": "",  # Empty name should trigger error
+                "description": "A test artifact",
+                "power_level": 3,
+                "background_cost": 2,
+            },
+        )
+        # Form should not be valid
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(VampireArtifact.objects.count(), 0)
+
+        # Check the form has errors
+        form = response.context["form"]
+        self.assertTrue(form.errors)
+        self.assertIn("name", form.errors)
+
+        # Verify the error is rendered in the template
+        self.assertContains(response, "text-danger")
+        self.assertContains(response, "This field is required")
+
+
+class VampireArtifactUpdateViewTest(TestCase):
+    """Test the VampireArtifact update view."""
+
+    def setUp(self):
+        self.client = Client()
+        # Create a superuser to have full edit permissions
+        self.user = User.objects.create_superuser(
+            username="adminuser", email="admin@test.com", password="password"
+        )
+        self.artifact = VampireArtifact.objects.create(
+            name="Test Artifact",
+            owner=self.user,
+            power_level=3,
+            background_cost=2,
+        )
+        self.update_url = reverse(
+            "items:vampire:update:artifact", kwargs={"pk": self.artifact.pk}
+        )
+
+    def test_update_empty_name_shows_error(self):
+        """Submitting empty name on update shows field error in template."""
+        self.client.login(username="adminuser", password="password")
+        response = self.client.post(
+            self.update_url,
+            {
+                "name": "",  # Empty name should trigger error
+                "description": "Updated description",
+                "power_level": 3,
+                "background_cost": 2,
+            },
+        )
+        # Form should not be valid
+        self.assertEqual(response.status_code, 200)
+
+        # Check the form has errors
+        form = response.context["form"]
+        self.assertTrue(form.errors)
+        self.assertIn("name", form.errors)
+
+        # Verify the error is rendered in the template
+        self.assertContains(response, "text-danger")
+        self.assertContains(response, "This field is required")


### PR DESCRIPTION
## Summary
- Added field error display after each form field in VampireArtifact form template
- Added field error display and non-field errors in VampireFreebies form template
- Added comprehensive tests to verify error messages are rendered in templates

## Test plan
- [x] Verified VampireArtifact create view shows field errors when validation fails
- [x] Verified VampireArtifact update view shows field errors when validation fails
- [x] Verified VampireFreebies form template includes error display for all fields
- [x] All existing tests pass

Fixes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)