### PR TITLE
Implement Changeling location views (Holding, Trod, DreamRealm)

### DIFF
--- a/locations/forms/changeling/__init__.py
+++ b/locations/forms/changeling/__init__.py
@@ -4,4 +4,7 @@ from .creation import (
     FreeholdFeaturesForm,
     FreeholdPowersForm,
 )
+from .dream_realm import DreamRealmForm
 from .freehold import FreeholdForm
+from .holding import HoldingForm
+from .trod import TrodForm

--- a/locations/forms/changeling/dream_realm.py
+++ b/locations/forms/changeling/dream_realm.py
@@ -1,0 +1,71 @@
+from django import forms
+from locations.models.changeling import DreamRealm
+
+
+class DreamRealmForm(forms.ModelForm):
+    """Form for creating and editing Dream Realms"""
+
+    class Meta:
+        model = DreamRealm
+        fields = (
+            "name",
+            "description",
+            "depth",
+            "realm_type",
+            "stability",
+            "accessibility",
+            "appearance",
+            "laws_of_reality",
+            "inhabitants",
+            "ruler",
+            "emotional_tone",
+            "entry_requirements",
+            "exit_difficulty",
+            "mundane_connection",
+            "glamour_level",
+            "provides_glamour",
+            "treasures",
+            "time_flow",
+            "is_mutable",
+        )
+        widgets = {
+            "description": forms.Textarea(
+                attrs={"rows": 4, "placeholder": "Enter dream realm description"}
+            ),
+            "appearance": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "What this realm looks like - dream logic applies"}
+            ),
+            "laws_of_reality": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "How reality works here (gravity, time, causality)"}
+            ),
+            "inhabitants": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Who or what lives in this realm (chimera, dreamers)"}
+            ),
+            "entry_requirements": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "What's needed to enter (trod, ritual, state of mind)"}
+            ),
+            "mundane_connection": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "What in the Autumn World this realm connects to"}
+            ),
+            "treasures": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "Special items, knowledge, or powers found here"}
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set placeholders
+        self.fields["name"].widget.attrs.update({"placeholder": "Enter dream realm name"})
+        self.fields["ruler"].widget.attrs.update(
+            {"placeholder": "Who rules or controls this realm (if anyone)"}
+        )
+        self.fields["emotional_tone"].widget.attrs.update(
+            {"placeholder": "E.g., peaceful, chaotic, melancholic"}
+        )
+
+        # Set help text
+        self.fields["stability"].help_text = "0-5 dots. How stable/permanent this realm is"
+        self.fields["accessibility"].help_text = "0-5 dots. How easy it is to reach"
+        self.fields["exit_difficulty"].help_text = "0-10. How hard it is to leave"
+        self.fields["glamour_level"].help_text = "0-10. How much Glamour permeates this realm"

--- a/locations/forms/changeling/holding.py
+++ b/locations/forms/changeling/holding.py
@@ -1,0 +1,84 @@
+from django import forms
+from locations.models.changeling import Holding
+
+
+class HoldingForm(forms.ModelForm):
+    """Form for creating and editing Holdings"""
+
+    class Meta:
+        model = Holding
+        fields = (
+            "name",
+            "description",
+            "rank",
+            "court",
+            "ruler_name",
+            "ruler_title",
+            "territory_description",
+            "mundane_location",
+            "vassals",
+            "liege",
+            "freehold_count",
+            "major_freeholds",
+            "population",
+            "military_strength",
+            "wealth",
+            "stability",
+            "political_situation",
+            "notable_laws",
+            "rival_holdings",
+            "history",
+        )
+        widgets = {
+            "description": forms.Textarea(
+                attrs={"rows": 4, "placeholder": "Enter holding description"}
+            ),
+            "territory_description": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Geographic area this holding covers"}
+            ),
+            "mundane_location": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "Real-world location this holding encompasses"}
+            ),
+            "vassals": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Lesser nobles who owe fealty to this holding's ruler"}
+            ),
+            "major_freeholds": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Names and descriptions of major freeholds"}
+            ),
+            "political_situation": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Current political climate, tensions, alliances"}
+            ),
+            "notable_laws": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Important laws or customs specific to this holding"}
+            ),
+            "rival_holdings": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "Neighboring or rival holdings and their relations"}
+            ),
+            "history": forms.Textarea(
+                attrs={"rows": 4, "placeholder": "History of this holding, major events"}
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set placeholders
+        self.fields["name"].widget.attrs.update({"placeholder": "Enter holding name"})
+        self.fields["ruler_name"].widget.attrs.update(
+            {"placeholder": "Name of the noble who rules this holding"}
+        )
+        self.fields["ruler_title"].widget.attrs.update(
+            {"placeholder": "E.g., 'Baron of the Silver Mists'"}
+        )
+        self.fields["liege"].widget.attrs.update(
+            {"placeholder": "Higher noble this holding owes allegiance to"}
+        )
+        self.fields["population"].widget.attrs.update(
+            {"placeholder": "E.g., small, moderate, large"}
+        )
+
+        # Set help text
+        self.fields["military_strength"].help_text = "0-5 dots. Military/defensive capability"
+        self.fields["wealth"].help_text = "0-5 dots. Economic resources"
+        self.fields["stability"].help_text = "0-5 dots. Political stability (0=chaos, 5=very stable)"
+        self.fields["freehold_count"].help_text = "Number of freeholds within this holding (0-50)"

--- a/locations/forms/changeling/trod.py
+++ b/locations/forms/changeling/trod.py
@@ -1,0 +1,75 @@
+from django import forms
+from locations.models.changeling import Trod
+
+
+class TrodForm(forms.ModelForm):
+    """Form for creating and editing Trods"""
+
+    class Meta:
+        model = Trod
+        fields = (
+            "name",
+            "description",
+            "trod_type",
+            "origin_name",
+            "origin_description",
+            "destination_name",
+            "destination_description",
+            "strength",
+            "difficulty",
+            "access_requirements",
+            "guardians",
+            "travel_duration",
+            "is_two_way",
+            "is_stable",
+            "glamour_cost",
+            "accessibility_notes",
+            "journey_description",
+            "known_to",
+        )
+        widgets = {
+            "description": forms.Textarea(
+                attrs={"rows": 4, "placeholder": "Enter trod description"}
+            ),
+            "origin_description": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "Description of the origin point"}
+            ),
+            "destination_description": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "Description of the destination"}
+            ),
+            "access_requirements": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "What's needed to access this trod (key, ritual, knowledge)"}
+            ),
+            "guardians": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "Creatures or beings that guard this trod"}
+            ),
+            "accessibility_notes": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "When or how this trod can be accessed"}
+            ),
+            "journey_description": forms.Textarea(
+                attrs={"rows": 3, "placeholder": "What traveling this trod is like - sights, sounds, sensations"}
+            ),
+            "known_to": forms.Textarea(
+                attrs={"rows": 2, "placeholder": "Which changelings or groups know about this trod"}
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set placeholders
+        self.fields["name"].widget.attrs.update({"placeholder": "Enter trod name"})
+        self.fields["origin_name"].widget.attrs.update(
+            {"placeholder": "Name of where this trod starts"}
+        )
+        self.fields["destination_name"].widget.attrs.update(
+            {"placeholder": "Name of where this trod leads"}
+        )
+        self.fields["travel_duration"].widget.attrs.update(
+            {"placeholder": "E.g., instant, minutes, hours"}
+        )
+
+        # Set help text
+        self.fields["strength"].help_text = "0-5 dots. How strong/stable this trod is"
+        self.fields["difficulty"].help_text = "0-10. Difficulty to traverse (0=easy, 10=nearly impossible)"
+        self.fields["glamour_cost"].help_text = "0-10. Glamour required to activate/traverse"

--- a/locations/templates/locations/changeling/dream_realm/form.html
+++ b/locations/templates/locations/changeling/dream_realm/form.html
@@ -1,0 +1,32 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+    <div class="container mt-4">
+        <div class="tg-card header-card mb-4" data-gameline="ctd">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title ctd_heading">
+                    {% if object %}Edit{% else %}Create{% endif %} Dream Realm
+                </h1>
+            </div>
+        </div>
+
+        <div class="tg-card">
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post" id="dreamRealmForm">
+                    {% csrf_token %}
+                    {{ form|crispy }}
+
+                    <div class="mt-4">
+                        <button type="submit" class="btn btn-primary">
+                            {% if object %}Update{% else %}Create{% endif %} Dream Realm
+                        </button>
+                        <a href="{% if object %}{{ object.get_absolute_url }}{% else %}{% url 'locations:changeling:list:dream_realm' %}{% endif %}" class="btn btn-secondary">
+                            Cancel
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/changeling/dream_realm/list.html
+++ b/locations/templates/locations/changeling/dream_realm/list.html
@@ -1,0 +1,71 @@
+{% extends "core/base.html" %}
+{% load dots %}
+
+{% block content %}
+    <div class="container mt-4">
+        <div class="tg-card header-card mb-4" data-gameline="ctd">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title ctd_heading">Dream Realms</h1>
+            </div>
+        </div>
+
+        {% if object_list %}
+            <div class="row">
+                {% for realm in object_list %}
+                    <div class="col-md-6 mb-4">
+                        <div class="tg-card h-100">
+                            <div class="tg-card-body" style="padding: 20px;">
+                                <h5 class="tg-card-title">
+                                    <a href="{{ realm.get_absolute_url }}">{{ realm.name }}</a>
+                                </h5>
+                                <h6 class="tg-card-subtitle mb-2" style="color: var(--theme-text-secondary);">
+                                    {{ realm.get_realm_type_display }} - {{ realm.get_depth_display }}
+                                </h6>
+                                {% if realm.emotional_tone %}
+                                    <p class="mb-2" style="font-style: italic; color: var(--theme-text-secondary);">
+                                        {{ realm.emotional_tone }}
+                                    </p>
+                                {% endif %}
+                                {% if realm.description %}
+                                    <p class="mb-2">{{ realm.description|truncatewords:25 }}</p>
+                                {% endif %}
+                                <div style="margin-top: 12px;">
+                                    {% if realm.stability > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Stability <span class="dots colored-dots">{{ realm.stability|dots }}</span>
+                                        </span>
+                                    {% endif %}
+                                    {% if realm.accessibility > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Access <span class="dots colored-dots">{{ realm.accessibility|dots }}</span>
+                                        </span>
+                                    {% endif %}
+                                    {% if realm.glamour_level > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Glamour {{ realm.glamour_level }}
+                                        </span>
+                                    {% endif %}
+                                    {% if realm.provides_glamour %}
+                                        <span class="tg-badge badge-pill">
+                                            Harvestable
+                                        </span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="tg-card">
+                <div class="tg-card-body text-center" style="padding: 40px;">
+                    <p class="mb-0">No dream realms have been created yet.</p>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="text-center mt-4">
+            <a href="{% url 'locations:changeling:create:dream_realm' %}" class="btn btn-primary">Create New Dream Realm</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/changeling/holding/form.html
+++ b/locations/templates/locations/changeling/holding/form.html
@@ -1,0 +1,32 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+    <div class="container mt-4">
+        <div class="tg-card header-card mb-4" data-gameline="ctd">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title ctd_heading">
+                    {% if object %}Edit{% else %}Create{% endif %} Holding
+                </h1>
+            </div>
+        </div>
+
+        <div class="tg-card">
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post" id="holdingForm">
+                    {% csrf_token %}
+                    {{ form|crispy }}
+
+                    <div class="mt-4">
+                        <button type="submit" class="btn btn-primary">
+                            {% if object %}Update{% else %}Create{% endif %} Holding
+                        </button>
+                        <a href="{% if object %}{{ object.get_absolute_url }}{% else %}{% url 'locations:changeling:list:holding' %}{% endif %}" class="btn btn-secondary">
+                            Cancel
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/changeling/holding/list.html
+++ b/locations/templates/locations/changeling/holding/list.html
@@ -1,0 +1,66 @@
+{% extends "core/base.html" %}
+{% load dots %}
+
+{% block content %}
+    <div class="container mt-4">
+        <div class="tg-card header-card mb-4" data-gameline="ctd">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title ctd_heading">Holdings</h1>
+            </div>
+        </div>
+
+        {% if object_list %}
+            <div class="row">
+                {% for holding in object_list %}
+                    <div class="col-md-6 mb-4">
+                        <div class="tg-card h-100">
+                            <div class="tg-card-body" style="padding: 20px;">
+                                <h5 class="tg-card-title">
+                                    <a href="{{ holding.get_absolute_url }}">{{ holding.name }}</a>
+                                </h5>
+                                <h6 class="tg-card-subtitle mb-2" style="color: var(--theme-text-secondary);">
+                                    {{ holding.get_rank_display }} - {{ holding.get_court_display }}
+                                </h6>
+                                {% if holding.ruler_name %}
+                                    <p class="mb-2" style="font-style: italic; color: var(--theme-text-secondary);">
+                                        Ruled by {{ holding.ruler_name }}
+                                    </p>
+                                {% endif %}
+                                {% if holding.description %}
+                                    <p class="mb-2">{{ holding.description|truncatewords:25 }}</p>
+                                {% endif %}
+                                <div style="margin-top: 12px;">
+                                    {% if holding.military_strength > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Military <span class="dots colored-dots">{{ holding.military_strength|dots }}</span>
+                                        </span>
+                                    {% endif %}
+                                    {% if holding.wealth > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Wealth <span class="dots colored-dots">{{ holding.wealth|dots }}</span>
+                                        </span>
+                                    {% endif %}
+                                    {% if holding.stability > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Stability <span class="dots colored-dots">{{ holding.stability|dots }}</span>
+                                        </span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="tg-card">
+                <div class="tg-card-body text-center" style="padding: 40px;">
+                    <p class="mb-0">No holdings have been created yet.</p>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="text-center mt-4">
+            <a href="{% url 'locations:changeling:create:holding' %}" class="btn btn-primary">Create New Holding</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/changeling/trod/form.html
+++ b/locations/templates/locations/changeling/trod/form.html
@@ -1,0 +1,32 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+    <div class="container mt-4">
+        <div class="tg-card header-card mb-4" data-gameline="ctd">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title ctd_heading">
+                    {% if object %}Edit{% else %}Create{% endif %} Trod
+                </h1>
+            </div>
+        </div>
+
+        <div class="tg-card">
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post" id="trodForm">
+                    {% csrf_token %}
+                    {{ form|crispy }}
+
+                    <div class="mt-4">
+                        <button type="submit" class="btn btn-primary">
+                            {% if object %}Update{% else %}Create{% endif %} Trod
+                        </button>
+                        <a href="{% if object %}{{ object.get_absolute_url }}{% else %}{% url 'locations:changeling:list:trod' %}{% endif %}" class="btn btn-secondary">
+                            Cancel
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/templates/locations/changeling/trod/list.html
+++ b/locations/templates/locations/changeling/trod/list.html
@@ -1,0 +1,74 @@
+{% extends "core/base.html" %}
+{% load dots %}
+
+{% block content %}
+    <div class="container mt-4">
+        <div class="tg-card header-card mb-4" data-gameline="ctd">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title ctd_heading">Trods</h1>
+            </div>
+        </div>
+
+        {% if object_list %}
+            <div class="row">
+                {% for trod in object_list %}
+                    <div class="col-md-6 mb-4">
+                        <div class="tg-card h-100">
+                            <div class="tg-card-body" style="padding: 20px;">
+                                <h5 class="tg-card-title">
+                                    <a href="{{ trod.get_absolute_url }}">{{ trod.name }}</a>
+                                </h5>
+                                <h6 class="tg-card-subtitle mb-2" style="color: var(--theme-text-secondary);">
+                                    {{ trod.get_trod_type_display }}
+                                </h6>
+                                {% if trod.origin_name and trod.destination_name %}
+                                    <p class="mb-2" style="font-style: italic; color: var(--theme-text-secondary);">
+                                        {{ trod.origin_name }} &rarr; {{ trod.destination_name }}
+                                    </p>
+                                {% endif %}
+                                {% if trod.description %}
+                                    <p class="mb-2">{{ trod.description|truncatewords:25 }}</p>
+                                {% endif %}
+                                <div style="margin-top: 12px;">
+                                    {% if trod.strength > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Strength <span class="dots colored-dots">{{ trod.strength|dots }}</span>
+                                        </span>
+                                    {% endif %}
+                                    <span class="tg-badge badge-pill">
+                                        Difficulty {{ trod.difficulty }}
+                                    </span>
+                                    {% if trod.glamour_cost > 0 %}
+                                        <span class="tg-badge badge-pill">
+                                            Glamour {{ trod.glamour_cost }}
+                                        </span>
+                                    {% endif %}
+                                    {% if not trod.is_two_way %}
+                                        <span class="tg-badge badge-pill">
+                                            One-Way
+                                        </span>
+                                    {% endif %}
+                                    {% if not trod.is_stable %}
+                                        <span class="tg-badge badge-pill">
+                                            Unstable
+                                        </span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="tg-card">
+                <div class="tg-card-body text-center" style="padding: 40px;">
+                    <p class="mb-0">No trods have been created yet.</p>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="text-center mt-4">
+            <a href="{% url 'locations:changeling:create:trod' %}" class="btn btn-primary">Create New Trod</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/locations/tests/forms/changeling/test_dream_realm.py
+++ b/locations/tests/forms/changeling/test_dream_realm.py
@@ -1,0 +1,178 @@
+"""Tests for DreamRealm form."""
+
+from django.test import TestCase
+from locations.forms.changeling import DreamRealmForm
+from locations.models.changeling import DreamRealm
+
+
+class DreamRealmFormTest(TestCase):
+    """Tests for the DreamRealmForm."""
+
+    def test_form_has_correct_model(self):
+        """Test that form uses the DreamRealm model."""
+        form = DreamRealmForm()
+        self.assertEqual(form.Meta.model, DreamRealm)
+
+    def test_form_has_required_fields(self):
+        """Test that form includes the expected fields."""
+        form = DreamRealmForm()
+        expected_fields = [
+            "name",
+            "description",
+            "depth",
+            "realm_type",
+            "stability",
+            "accessibility",
+            "appearance",
+            "laws_of_reality",
+            "inhabitants",
+            "ruler",
+            "emotional_tone",
+            "entry_requirements",
+            "exit_difficulty",
+            "mundane_connection",
+            "glamour_level",
+            "provides_glamour",
+            "treasures",
+            "time_flow",
+            "is_mutable",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_form_valid_with_minimal_data(self):
+        """Test that form validates with minimal required data."""
+        data = {
+            "name": "Test Realm",
+            "depth": "near",
+            "realm_type": "collective",
+            "stability": 3,
+            "accessibility": 3,
+            "exit_difficulty": 3,
+            "glamour_level": 3,
+            "provides_glamour": True,
+            "time_flow": "normal",
+            "is_mutable": True,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_valid_with_full_data(self):
+        """Test that form validates with full data."""
+        data = {
+            "name": "The Crystal Gardens",
+            "description": "A realm of living crystal formations",
+            "depth": "far",
+            "realm_type": "mythic",
+            "stability": 4,
+            "accessibility": 2,
+            "appearance": "Towering crystal spires under a purple sky",
+            "laws_of_reality": "Gravity pulls toward the largest crystal",
+            "inhabitants": "Crystal chimera and light elementals",
+            "ruler": "The Crystal Queen",
+            "emotional_tone": "serene yet alien",
+            "entry_requirements": "Hold a crystal focus while dreaming",
+            "exit_difficulty": 5,
+            "mundane_connection": "Crystal caves in the mundane world",
+            "glamour_level": 7,
+            "provides_glamour": True,
+            "treasures": "Living crystal implements",
+            "time_flow": "slower",
+            "is_mutable": False,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_saves_correctly(self):
+        """Test that form saves a DreamRealm correctly."""
+        data = {
+            "name": "Nightmare Hollow",
+            "depth": "deep",
+            "realm_type": "nightmare",
+            "stability": 2,
+            "accessibility": 1,
+            "exit_difficulty": 8,
+            "glamour_level": 5,
+            "provides_glamour": False,
+            "time_flow": "variable",
+            "is_mutable": True,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertTrue(form.is_valid())
+        realm = form.save()
+        self.assertEqual(realm.name, "Nightmare Hollow")
+        self.assertEqual(realm.depth, "deep")
+        self.assertEqual(realm.realm_type, "nightmare")
+        self.assertFalse(realm.provides_glamour)
+
+    def test_form_invalid_stability_above_max(self):
+        """Test that form rejects stability above 5."""
+        data = {
+            "name": "Invalid Realm",
+            "depth": "near",
+            "realm_type": "collective",
+            "stability": 6,  # Invalid - max is 5
+            "accessibility": 3,
+            "exit_difficulty": 3,
+            "glamour_level": 3,
+            "provides_glamour": True,
+            "time_flow": "normal",
+            "is_mutable": True,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("stability", form.errors)
+
+    def test_form_invalid_accessibility_above_max(self):
+        """Test that form rejects accessibility above 5."""
+        data = {
+            "name": "Invalid Realm",
+            "depth": "near",
+            "realm_type": "collective",
+            "stability": 3,
+            "accessibility": 6,  # Invalid - max is 5
+            "exit_difficulty": 3,
+            "glamour_level": 3,
+            "provides_glamour": True,
+            "time_flow": "normal",
+            "is_mutable": True,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("accessibility", form.errors)
+
+    def test_form_invalid_exit_difficulty_above_max(self):
+        """Test that form rejects exit difficulty above 10."""
+        data = {
+            "name": "Invalid Realm",
+            "depth": "near",
+            "realm_type": "collective",
+            "stability": 3,
+            "accessibility": 3,
+            "exit_difficulty": 11,  # Invalid - max is 10
+            "glamour_level": 3,
+            "provides_glamour": True,
+            "time_flow": "normal",
+            "is_mutable": True,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("exit_difficulty", form.errors)
+
+    def test_form_invalid_glamour_level_above_max(self):
+        """Test that form rejects glamour level above 10."""
+        data = {
+            "name": "Invalid Realm",
+            "depth": "near",
+            "realm_type": "collective",
+            "stability": 3,
+            "accessibility": 3,
+            "exit_difficulty": 3,
+            "glamour_level": 11,  # Invalid - max is 10
+            "provides_glamour": True,
+            "time_flow": "normal",
+            "is_mutable": True,
+        }
+        form = DreamRealmForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("glamour_level", form.errors)

--- a/locations/tests/forms/changeling/test_holding.py
+++ b/locations/tests/forms/changeling/test_holding.py
@@ -1,0 +1,146 @@
+"""Tests for Holding form."""
+
+from django.test import TestCase
+from locations.forms.changeling import HoldingForm
+from locations.models.changeling import Holding
+
+
+class HoldingFormTest(TestCase):
+    """Tests for the HoldingForm."""
+
+    def test_form_has_correct_model(self):
+        """Test that form uses the Holding model."""
+        form = HoldingForm()
+        self.assertEqual(form.Meta.model, Holding)
+
+    def test_form_has_required_fields(self):
+        """Test that form includes the expected fields."""
+        form = HoldingForm()
+        expected_fields = [
+            "name",
+            "description",
+            "rank",
+            "court",
+            "ruler_name",
+            "ruler_title",
+            "territory_description",
+            "mundane_location",
+            "vassals",
+            "liege",
+            "freehold_count",
+            "major_freeholds",
+            "population",
+            "military_strength",
+            "wealth",
+            "stability",
+            "political_situation",
+            "notable_laws",
+            "rival_holdings",
+            "history",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_form_valid_with_minimal_data(self):
+        """Test that form validates with minimal required data."""
+        data = {
+            "name": "Test Holding",
+            "rank": "barony",
+            "court": "seelie",
+            "military_strength": 1,
+            "wealth": 1,
+            "stability": 3,
+            "freehold_count": 0,
+        }
+        form = HoldingForm(data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_valid_with_full_data(self):
+        """Test that form validates with full data."""
+        data = {
+            "name": "The Silver Duchy",
+            "description": "A beautiful duchy in the mountains",
+            "rank": "duchy",
+            "court": "seelie",
+            "ruler_name": "Duke Silvanus",
+            "ruler_title": "Duke of the Silver Peaks",
+            "territory_description": "The mountain region",
+            "mundane_location": "Rocky Mountains, Colorado",
+            "vassals": "Baron Ironwood, Baroness Starlight",
+            "liege": "King Oberon",
+            "freehold_count": 5,
+            "major_freeholds": "The Silver Court, The Mountain Lodge",
+            "population": "large",
+            "military_strength": 4,
+            "wealth": 3,
+            "stability": 4,
+            "political_situation": "Peaceful but watchful",
+            "notable_laws": "No cold iron within borders",
+            "rival_holdings": "The Unseelie Barony to the south",
+            "history": "Founded in 1452 during the Great Migration",
+        }
+        form = HoldingForm(data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_saves_correctly(self):
+        """Test that form saves a Holding correctly."""
+        data = {
+            "name": "Test Barony",
+            "rank": "barony",
+            "court": "unseelie",
+            "military_strength": 2,
+            "wealth": 1,
+            "stability": 2,
+            "freehold_count": 1,
+        }
+        form = HoldingForm(data=data)
+        self.assertTrue(form.is_valid())
+        holding = form.save()
+        self.assertEqual(holding.name, "Test Barony")
+        self.assertEqual(holding.rank, "barony")
+        self.assertEqual(holding.court, "unseelie")
+
+    def test_form_invalid_military_strength_above_max(self):
+        """Test that form rejects military strength above 5."""
+        data = {
+            "name": "Invalid Holding",
+            "rank": "barony",
+            "court": "seelie",
+            "military_strength": 6,  # Invalid - max is 5
+            "wealth": 1,
+            "stability": 3,
+            "freehold_count": 0,
+        }
+        form = HoldingForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("military_strength", form.errors)
+
+    def test_form_invalid_wealth_above_max(self):
+        """Test that form rejects wealth above 5."""
+        data = {
+            "name": "Invalid Holding",
+            "rank": "barony",
+            "court": "seelie",
+            "military_strength": 1,
+            "wealth": 6,  # Invalid - max is 5
+            "stability": 3,
+            "freehold_count": 0,
+        }
+        form = HoldingForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("wealth", form.errors)
+
+    def test_form_invalid_stability_above_max(self):
+        """Test that form rejects stability above 5."""
+        data = {
+            "name": "Invalid Holding",
+            "rank": "barony",
+            "court": "seelie",
+            "military_strength": 1,
+            "wealth": 1,
+            "stability": 6,  # Invalid - max is 5
+            "freehold_count": 0,
+        }
+        form = HoldingForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("stability", form.errors)

--- a/locations/tests/forms/changeling/test_trod.py
+++ b/locations/tests/forms/changeling/test_trod.py
@@ -1,0 +1,143 @@
+"""Tests for Trod form."""
+
+from django.test import TestCase
+from locations.forms.changeling import TrodForm
+from locations.models.changeling import Trod
+
+
+class TrodFormTest(TestCase):
+    """Tests for the TrodForm."""
+
+    def test_form_has_correct_model(self):
+        """Test that form uses the Trod model."""
+        form = TrodForm()
+        self.assertEqual(form.Meta.model, Trod)
+
+    def test_form_has_required_fields(self):
+        """Test that form includes the expected fields."""
+        form = TrodForm()
+        expected_fields = [
+            "name",
+            "description",
+            "trod_type",
+            "origin_name",
+            "origin_description",
+            "destination_name",
+            "destination_description",
+            "strength",
+            "difficulty",
+            "access_requirements",
+            "guardians",
+            "travel_duration",
+            "is_two_way",
+            "is_stable",
+            "glamour_cost",
+            "accessibility_notes",
+            "journey_description",
+            "known_to",
+        ]
+        for field in expected_fields:
+            self.assertIn(field, form.fields)
+
+    def test_form_valid_with_minimal_data(self):
+        """Test that form validates with minimal required data."""
+        data = {
+            "name": "Test Trod",
+            "trod_type": "silver_path",
+            "strength": 1,
+            "difficulty": 5,
+            "is_two_way": True,
+            "is_stable": True,
+            "glamour_cost": 0,
+        }
+        form = TrodForm(data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_valid_with_full_data(self):
+        """Test that form validates with full data."""
+        data = {
+            "name": "The Moonlit Path",
+            "description": "A shimmering path that appears under full moons",
+            "trod_type": "moonpath",
+            "origin_name": "The Old Oak",
+            "origin_description": "An ancient oak in the city park",
+            "destination_name": "The Silver Glade",
+            "destination_description": "A clearing in the Near Dreaming",
+            "strength": 3,
+            "difficulty": 4,
+            "access_requirements": "Must walk counterclockwise around the oak",
+            "guardians": "A pair of chimerical wolves",
+            "travel_duration": "5 minutes",
+            "is_two_way": True,
+            "is_stable": False,
+            "glamour_cost": 1,
+            "accessibility_notes": "Only during full moon nights",
+            "journey_description": "Silver light surrounds travelers",
+            "known_to": "Local Seelie court members",
+        }
+        form = TrodForm(data=data)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_form_saves_correctly(self):
+        """Test that form saves a Trod correctly."""
+        data = {
+            "name": "Test Path",
+            "trod_type": "rath",
+            "strength": 4,
+            "difficulty": 3,
+            "is_two_way": False,
+            "is_stable": True,
+            "glamour_cost": 2,
+        }
+        form = TrodForm(data=data)
+        self.assertTrue(form.is_valid())
+        trod = form.save()
+        self.assertEqual(trod.name, "Test Path")
+        self.assertEqual(trod.trod_type, "rath")
+        self.assertFalse(trod.is_two_way)
+        self.assertEqual(trod.glamour_cost, 2)
+
+    def test_form_invalid_strength_above_max(self):
+        """Test that form rejects strength above 5."""
+        data = {
+            "name": "Invalid Trod",
+            "trod_type": "silver_path",
+            "strength": 6,  # Invalid - max is 5
+            "difficulty": 5,
+            "is_two_way": True,
+            "is_stable": True,
+            "glamour_cost": 0,
+        }
+        form = TrodForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("strength", form.errors)
+
+    def test_form_invalid_difficulty_above_max(self):
+        """Test that form rejects difficulty above 10."""
+        data = {
+            "name": "Invalid Trod",
+            "trod_type": "silver_path",
+            "strength": 1,
+            "difficulty": 11,  # Invalid - max is 10
+            "is_two_way": True,
+            "is_stable": True,
+            "glamour_cost": 0,
+        }
+        form = TrodForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("difficulty", form.errors)
+
+    def test_form_invalid_glamour_cost_above_max(self):
+        """Test that form rejects glamour cost above 10."""
+        data = {
+            "name": "Invalid Trod",
+            "trod_type": "silver_path",
+            "strength": 1,
+            "difficulty": 5,
+            "is_two_way": True,
+            "is_stable": True,
+            "glamour_cost": 11,  # Invalid - max is 10
+        }
+        form = TrodForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("glamour_cost", form.errors)

--- a/locations/tests/views/changeling/test_dream_realm.py
+++ b/locations/tests/views/changeling/test_dream_realm.py
@@ -1,5 +1,172 @@
-"""Tests for dream_realm module."""
+"""Tests for DreamRealm views."""
 
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from locations.models.changeling import DreamRealm
 
-# TODO: Move relevant tests from existing test files here
+
+class DreamRealmListViewTest(TestCase):
+    """Tests for DreamRealmListView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("locations:changeling:list:dream_realm")
+
+    def test_list_view_returns_200(self):
+        """Test that the list view returns a 200 response."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_uses_correct_template(self):
+        """Test that list view uses the correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/changeling/dream_realm/list.html")
+
+    def test_list_view_shows_dream_realms(self):
+        """Test that the list view shows existing dream realms."""
+        realm = DreamRealm.objects.create(
+            name="Crystal Gardens",
+            depth="far",
+            realm_type="mythic",
+        )
+        response = self.client.get(self.url)
+        self.assertContains(response, "Crystal Gardens")
+
+    def test_list_view_shows_empty_message(self):
+        """Test that the list view shows empty message when no dream realms exist."""
+        response = self.client.get(self.url)
+        self.assertContains(response, "No dream realms have been created yet")
+
+    def test_list_view_has_create_link(self):
+        """Test that the list view has a link to create new dream realms."""
+        response = self.client.get(self.url)
+        self.assertContains(response, "Create New Dream Realm")
+        self.assertContains(response, reverse("locations:changeling:create:dream_realm"))
+
+
+class DreamRealmCreateViewTest(TestCase):
+    """Tests for DreamRealmCreateView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.url = reverse("locations:changeling:create:dream_realm")
+
+    def test_create_view_requires_login(self):
+        """Test that the create view requires authentication."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)  # LoginRequiredMixin returns 401
+
+    def test_create_view_returns_200_for_logged_in_user(self):
+        """Test that the create view returns 200 for authenticated users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_uses_correct_template(self):
+        """Test that create view uses the correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/changeling/dream_realm/form.html")
+
+    def test_create_dream_realm_success(self):
+        """Test successful creation of a dream realm."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Realm",
+            "description": "A test realm",
+            "depth": "near",
+            "realm_type": "collective",
+            "stability": 3,
+            "accessibility": 3,
+            "exit_difficulty": 3,
+            "glamour_level": 5,
+            "provides_glamour": True,
+            "time_flow": "normal",
+            "is_mutable": True,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(DreamRealm.objects.count(), 1)
+        realm = DreamRealm.objects.first()
+        self.assertEqual(realm.name, "New Realm")
+        # The redirect goes to the detail view, follow the redirect
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, realm.get_absolute_url())
+
+
+class DreamRealmDetailViewTest(TestCase):
+    """Tests for DreamRealmDetailView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.realm = DreamRealm.objects.create(
+            name="Test Realm",
+            depth="deep",
+            realm_type="nightmare",
+        )
+
+    def test_detail_view_returns_200(self):
+        """Test that the detail view returns 200 for staff users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.realm.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_shows_realm_info(self):
+        """Test that the detail view shows dream realm information."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.realm.get_absolute_url())
+        self.assertContains(response, "Test Realm")
+
+
+class DreamRealmUpdateViewTest(TestCase):
+    """Tests for DreamRealmUpdateView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.realm = DreamRealm.objects.create(
+            name="Test Realm",
+            depth="near",
+            realm_type="collective",
+        )
+
+    def test_update_view_returns_200_for_staff(self):
+        """Test that the update view returns 200 for staff users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.realm.get_update_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_uses_correct_template(self):
+        """Test that update view uses the correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.realm.get_update_url())
+        self.assertTemplateUsed(response, "locations/changeling/dream_realm/form.html")
+
+    def test_update_dream_realm_success(self):
+        """Test successful update of a dream realm."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "Updated Realm",
+            "description": "Updated description",
+            "depth": "far",
+            "realm_type": "mythic",
+            "stability": 4,
+            "accessibility": 2,
+            "exit_difficulty": 5,
+            "glamour_level": 7,
+            "provides_glamour": False,
+            "time_flow": "slower",
+            "is_mutable": False,
+        }
+        response = self.client.post(self.realm.get_update_url(), data)
+        self.realm.refresh_from_db()
+        self.assertEqual(self.realm.name, "Updated Realm")
+        self.assertEqual(self.realm.depth, "far")

--- a/locations/tests/views/changeling/test_holding.py
+++ b/locations/tests/views/changeling/test_holding.py
@@ -1,5 +1,166 @@
-"""Tests for holding module."""
+"""Tests for Holding views."""
 
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from locations.models.changeling import Holding
 
-# TODO: Move relevant tests from existing test files here
+
+class HoldingListViewTest(TestCase):
+    """Tests for HoldingListView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("locations:changeling:list:holding")
+
+    def test_list_view_returns_200(self):
+        """Test that the list view returns a 200 response."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_uses_correct_template(self):
+        """Test that list view uses the correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/changeling/holding/list.html")
+
+    def test_list_view_shows_holdings(self):
+        """Test that the list view shows existing holdings."""
+        holding = Holding.objects.create(
+            name="Test Barony",
+            rank="barony",
+            court="seelie",
+        )
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Barony")
+
+    def test_list_view_shows_empty_message(self):
+        """Test that the list view shows empty message when no holdings exist."""
+        response = self.client.get(self.url)
+        self.assertContains(response, "No holdings have been created yet")
+
+    def test_list_view_has_create_link(self):
+        """Test that the list view has a link to create new holdings."""
+        response = self.client.get(self.url)
+        self.assertContains(response, "Create New Holding")
+        self.assertContains(response, reverse("locations:changeling:create:holding"))
+
+
+class HoldingCreateViewTest(TestCase):
+    """Tests for HoldingCreateView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.url = reverse("locations:changeling:create:holding")
+
+    def test_create_view_requires_login(self):
+        """Test that the create view requires authentication."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)  # LoginRequiredMixin returns 401
+
+    def test_create_view_returns_200_for_logged_in_user(self):
+        """Test that the create view returns 200 for authenticated users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_uses_correct_template(self):
+        """Test that create view uses the correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/changeling/holding/form.html")
+
+    def test_create_holding_success(self):
+        """Test successful creation of a holding."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Barony",
+            "description": "A test barony",
+            "rank": "barony",
+            "court": "seelie",
+            "military_strength": 2,
+            "wealth": 2,
+            "stability": 3,
+            "freehold_count": 1,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(Holding.objects.count(), 1)
+        holding = Holding.objects.first()
+        self.assertEqual(holding.name, "New Barony")
+        # The redirect goes to the detail view, follow the redirect
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, holding.get_absolute_url())
+
+
+class HoldingDetailViewTest(TestCase):
+    """Tests for HoldingDetailView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.holding = Holding.objects.create(
+            name="Test Duchy",
+            rank="duchy",
+            court="unseelie",
+        )
+
+    def test_detail_view_returns_200(self):
+        """Test that the detail view returns 200 for staff users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.holding.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_shows_holding_info(self):
+        """Test that the detail view shows holding information."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.holding.get_absolute_url())
+        self.assertContains(response, "Test Duchy")
+
+
+class HoldingUpdateViewTest(TestCase):
+    """Tests for HoldingUpdateView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.holding = Holding.objects.create(
+            name="Test Barony",
+            rank="barony",
+            court="seelie",
+        )
+
+    def test_update_view_returns_200_for_staff(self):
+        """Test that the update view returns 200 for staff users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.holding.get_update_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_uses_correct_template(self):
+        """Test that update view uses the correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.holding.get_update_url())
+        self.assertTemplateUsed(response, "locations/changeling/holding/form.html")
+
+    def test_update_holding_success(self):
+        """Test successful update of a holding."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "Updated Barony",
+            "description": "Updated description",
+            "rank": "duchy",
+            "court": "unseelie",
+            "military_strength": 3,
+            "wealth": 3,
+            "stability": 4,
+            "freehold_count": 2,
+        }
+        response = self.client.post(self.holding.get_update_url(), data)
+        self.holding.refresh_from_db()
+        self.assertEqual(self.holding.name, "Updated Barony")
+        self.assertEqual(self.holding.rank, "duchy")

--- a/locations/tests/views/changeling/test_trod.py
+++ b/locations/tests/views/changeling/test_trod.py
@@ -1,5 +1,165 @@
-"""Tests for trod module."""
+"""Tests for Trod views."""
 
-from django.test import TestCase
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from locations.models.changeling import Trod
 
-# TODO: Move relevant tests from existing test files here
+
+class TrodListViewTest(TestCase):
+    """Tests for TrodListView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("locations:changeling:list:trod")
+
+    def test_list_view_returns_200(self):
+        """Test that the list view returns a 200 response."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_uses_correct_template(self):
+        """Test that list view uses the correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/changeling/trod/list.html")
+
+    def test_list_view_shows_trods(self):
+        """Test that the list view shows existing trods."""
+        trod = Trod.objects.create(
+            name="Silver Path",
+            trod_type="silver_path",
+        )
+        response = self.client.get(self.url)
+        self.assertContains(response, "Silver Path")
+
+    def test_list_view_shows_empty_message(self):
+        """Test that the list view shows empty message when no trods exist."""
+        response = self.client.get(self.url)
+        self.assertContains(response, "No trods have been created yet")
+
+    def test_list_view_has_create_link(self):
+        """Test that the list view has a link to create new trods."""
+        response = self.client.get(self.url)
+        self.assertContains(response, "Create New Trod")
+        self.assertContains(response, reverse("locations:changeling:create:trod"))
+
+
+class TrodCreateViewTest(TestCase):
+    """Tests for TrodCreateView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.url = reverse("locations:changeling:create:trod")
+
+    def test_create_view_requires_login(self):
+        """Test that the create view requires authentication."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)  # LoginRequiredMixin returns 401
+
+    def test_create_view_returns_200_for_logged_in_user(self):
+        """Test that the create view returns 200 for authenticated users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_uses_correct_template(self):
+        """Test that create view uses the correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/changeling/trod/form.html")
+
+    def test_create_trod_success(self):
+        """Test successful creation of a trod."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Trod",
+            "description": "A test trod",
+            "trod_type": "silver_path",
+            "origin_name": "The Oak",
+            "destination_name": "The Glade",
+            "strength": 3,
+            "difficulty": 4,
+            "is_two_way": True,
+            "is_stable": True,
+            "glamour_cost": 1,
+        }
+        response = self.client.post(self.url, data)
+        self.assertEqual(Trod.objects.count(), 1)
+        trod = Trod.objects.first()
+        self.assertEqual(trod.name, "New Trod")
+        # The redirect goes to the detail view, follow the redirect
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, trod.get_absolute_url())
+
+
+class TrodDetailViewTest(TestCase):
+    """Tests for TrodDetailView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.trod = Trod.objects.create(
+            name="Test Trod",
+            trod_type="rath",
+        )
+
+    def test_detail_view_returns_200(self):
+        """Test that the detail view returns 200 for staff users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.trod.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_shows_trod_info(self):
+        """Test that the detail view shows trod information."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.trod.get_absolute_url())
+        self.assertContains(response, "Test Trod")
+
+
+class TrodUpdateViewTest(TestCase):
+    """Tests for TrodUpdateView."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password", is_staff=True
+        )
+        self.trod = Trod.objects.create(
+            name="Test Trod",
+            trod_type="silver_path",
+        )
+
+    def test_update_view_returns_200_for_staff(self):
+        """Test that the update view returns 200 for staff users."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.trod.get_update_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_uses_correct_template(self):
+        """Test that update view uses the correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.trod.get_update_url())
+        self.assertTemplateUsed(response, "locations/changeling/trod/form.html")
+
+    def test_update_trod_success(self):
+        """Test successful update of a trod."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "Updated Trod",
+            "description": "Updated description",
+            "trod_type": "rath",
+            "strength": 4,
+            "difficulty": 5,
+            "is_two_way": False,
+            "is_stable": True,
+            "glamour_cost": 2,
+        }
+        response = self.client.post(self.trod.get_update_url(), data)
+        self.trod.refresh_from_db()
+        self.assertEqual(self.trod.name, "Updated Trod")
+        self.assertEqual(self.trod.trod_type, "rath")

--- a/locations/urls/changeling/create.py
+++ b/locations/urls/changeling/create.py
@@ -15,4 +15,19 @@ urls = [
         views.changeling.FreeholdCreateView.as_view(),
         name="freehold_direct",
     ),
+    path(
+        "holding/",
+        views.changeling.HoldingCreateView.as_view(),
+        name="holding",
+    ),
+    path(
+        "trod/",
+        views.changeling.TrodCreateView.as_view(),
+        name="trod",
+    ),
+    path(
+        "dream_realm/",
+        views.changeling.DreamRealmCreateView.as_view(),
+        name="dream_realm",
+    ),
 ]

--- a/locations/urls/changeling/index.py
+++ b/locations/urls/changeling/index.py
@@ -8,4 +8,19 @@ urls = [
         views.changeling.FreeholdListView.as_view(),
         name="freehold",
     ),
+    path(
+        "holding/",
+        views.changeling.HoldingListView.as_view(),
+        name="holding",
+    ),
+    path(
+        "trod/",
+        views.changeling.TrodListView.as_view(),
+        name="trod",
+    ),
+    path(
+        "dream_realm/",
+        views.changeling.DreamRealmListView.as_view(),
+        name="dream_realm",
+    ),
 ]

--- a/locations/urls/changeling/update.py
+++ b/locations/urls/changeling/update.py
@@ -15,4 +15,19 @@ urls = [
         views.changeling.FreeholdUpdateView.as_view(),
         name="freehold_direct",
     ),
+    path(
+        "holding/<int:pk>/",
+        views.changeling.HoldingUpdateView.as_view(),
+        name="holding",
+    ),
+    path(
+        "trod/<int:pk>/",
+        views.changeling.TrodUpdateView.as_view(),
+        name="trod",
+    ),
+    path(
+        "dream_realm/<int:pk>/",
+        views.changeling.DreamRealmUpdateView.as_view(),
+        name="dream_realm",
+    ),
 ]

--- a/locations/views/changeling/__init__.py
+++ b/locations/views/changeling/__init__.py
@@ -5,12 +5,17 @@ from .creation import (
     FreeholdFeaturesView,
     FreeholdPowersView,
 )
-from .dream_realm import DreamRealmDetailView, DreamRealmUpdateView
+from .dream_realm import (
+    DreamRealmCreateView,
+    DreamRealmDetailView,
+    DreamRealmListView,
+    DreamRealmUpdateView,
+)
 from .freehold import (
     FreeholdCreateView,
     FreeholdDetailView,
     FreeholdListView,
     FreeholdUpdateView,
 )
-from .holding import HoldingDetailView, HoldingUpdateView
-from .trod import TrodDetailView, TrodUpdateView
+from .holding import HoldingCreateView, HoldingDetailView, HoldingListView, HoldingUpdateView
+from .trod import TrodCreateView, TrodDetailView, TrodListView, TrodUpdateView

--- a/locations/views/changeling/dream_realm.py
+++ b/locations/views/changeling/dream_realm.py
@@ -1,5 +1,7 @@
 from core.mixins import EditPermissionMixin, ViewPermissionMixin
-from django.views.generic import DetailView, UpdateView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.forms.changeling.dream_realm import DreamRealmForm
 from locations.models.changeling import DreamRealm
 
 
@@ -10,16 +12,25 @@ class DreamRealmDetailView(ViewPermissionMixin, DetailView):
     template_name = "locations/changeling/dream_realm/detail.html"
 
 
+class DreamRealmListView(ListView):
+    """List view for all Dream Realms"""
+
+    model = DreamRealm
+    ordering = ["name"]
+    template_name = "locations/changeling/dream_realm/list.html"
+
+
+class DreamRealmCreateView(LoginRequiredMixin, CreateView):
+    """Create view for a new Dream Realm"""
+
+    model = DreamRealm
+    form_class = DreamRealmForm
+    template_name = "locations/changeling/dream_realm/form.html"
+
+
 class DreamRealmUpdateView(EditPermissionMixin, UpdateView):
     """Update view for an existing Dream Realm"""
 
     model = DreamRealm
-    fields = [
-        "name",
-        "description",
-        "chronicle",
-        "realm_type",
-        "stability",
-        "accessibility",
-    ]
+    form_class = DreamRealmForm
     template_name = "locations/changeling/dream_realm/form.html"

--- a/locations/views/changeling/holding.py
+++ b/locations/views/changeling/holding.py
@@ -1,5 +1,7 @@
 from core.mixins import EditPermissionMixin, ViewPermissionMixin
-from django.views.generic import DetailView, UpdateView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.forms.changeling.holding import HoldingForm
 from locations.models.changeling import Holding
 
 
@@ -10,15 +12,25 @@ class HoldingDetailView(ViewPermissionMixin, DetailView):
     template_name = "locations/changeling/holding/detail.html"
 
 
+class HoldingListView(ListView):
+    """List view for all Holdings"""
+
+    model = Holding
+    ordering = ["name"]
+    template_name = "locations/changeling/holding/list.html"
+
+
+class HoldingCreateView(LoginRequiredMixin, CreateView):
+    """Create view for a new Holding"""
+
+    model = Holding
+    form_class = HoldingForm
+    template_name = "locations/changeling/holding/form.html"
+
+
 class HoldingUpdateView(EditPermissionMixin, UpdateView):
     """Update view for an existing Holding"""
 
     model = Holding
-    fields = [
-        "name",
-        "description",
-        "chronicle",
-        "holding_type",
-        "glamour_per_week",
-    ]
+    form_class = HoldingForm
     template_name = "locations/changeling/holding/form.html"

--- a/locations/views/changeling/trod.py
+++ b/locations/views/changeling/trod.py
@@ -1,5 +1,7 @@
 from core.mixins import EditPermissionMixin, ViewPermissionMixin
-from django.views.generic import DetailView, UpdateView
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.forms.changeling.trod import TrodForm
 from locations.models.changeling import Trod
 
 
@@ -10,15 +12,25 @@ class TrodDetailView(ViewPermissionMixin, DetailView):
     template_name = "locations/changeling/trod/detail.html"
 
 
+class TrodListView(ListView):
+    """List view for all Trods"""
+
+    model = Trod
+    ordering = ["name"]
+    template_name = "locations/changeling/trod/list.html"
+
+
+class TrodCreateView(LoginRequiredMixin, CreateView):
+    """Create view for a new Trod"""
+
+    model = Trod
+    form_class = TrodForm
+    template_name = "locations/changeling/trod/form.html"
+
+
 class TrodUpdateView(EditPermissionMixin, UpdateView):
     """Update view for an existing Trod"""
 
     model = Trod
-    fields = [
-        "name",
-        "description",
-        "chronicle",
-        "trod_type",
-        "danger_level",
-    ]
+    form_class = TrodForm
     template_name = "locations/changeling/trod/form.html"


### PR DESCRIPTION
## Summary
- Adds missing list and create views for Holding, Trod, and DreamRealm Changeling location models
- Creates corresponding forms (HoldingForm, TrodForm, DreamRealmForm) with appropriate fields and validation
- Updates existing update views to use the new forms instead of inline field lists
- Adds URL patterns for all new endpoints
- Creates list and form templates following existing project patterns

Fixes #1084

## Changes
| Model | List View | Create View | Form | List Template | Form Template |
|-------|-----------|-------------|------|---------------|---------------|
| Holding | HoldingListView | HoldingCreateView | HoldingForm | list.html | form.html |
| Trod | TrodListView | TrodCreateView | TrodForm | list.html | form.html |
| DreamRealm | DreamRealmListView | DreamRealmCreateView | DreamRealmForm | list.html | form.html |

## Test plan
- [x] Run `python manage.py test locations.tests.views.changeling` - 67 tests pass
- [x] Run `python manage.py test locations.tests.forms.changeling` - All form tests pass
- [x] Run `python manage.py check` - No issues found
- [ ] Manual verification of list views showing location data
- [ ] Manual verification of create flow redirects to detail view
- [ ] Manual verification of update flow with new form

🤖 Generated with [Claude Code](https://claude.com/claude-code)