### PR TITLE
Implement missing views for Mage focus models (SpecializedPractice, CorruptedPractice)

### DIFF
--- a/characters/models/mage/focus.py
+++ b/characters/models/mage/focus.py
@@ -89,6 +89,9 @@ class SpecializedPractice(Practice):
         verbose_name = "Specialized Practice"
         verbose_name_plural = "Specialized Practices"
 
+    def get_absolute_url(self):
+        return reverse("characters:mage:specialized_practice", args=[str(self.id)])
+
     def get_update_url(self):
         return reverse("characters:mage:update:specialized_practice", kwargs={"pk": self.pk})
 
@@ -120,6 +123,9 @@ class CorruptedPractice(Practice):
     class Meta:
         verbose_name = "Corrupted Practice"
         verbose_name_plural = "Corrupted Practices"
+
+    def get_absolute_url(self):
+        return reverse("characters:mage:corrupted_practice", args=[str(self.id)])
 
     def get_update_url(self):
         return reverse("characters:mage:update:corrupted_practice", kwargs={"pk": self.pk})

--- a/characters/templates/characters/mage/corrupted_practice/list.html
+++ b/characters/templates/characters/mage/corrupted_practice/list.html
@@ -1,0 +1,17 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Corrupted Practices
+{% endblock title %}
+{% block content %}
+    {% load field %}
+    <div class="centertext container">
+        <div class="row border">
+            <h3 class="col-sm border">Corrupted Practices</h3>
+        </div>
+        {% for obj in object_list %}
+            <div class="row border">
+                <a class="col-sm border" href="{{ obj.get_absolute_url }}">{{ obj.name }}</a>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/characters/templates/characters/mage/specialized_practice/list.html
+++ b/characters/templates/characters/mage/specialized_practice/list.html
@@ -1,0 +1,17 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Specialized Practices
+{% endblock title %}
+{% block content %}
+    {% load field %}
+    <div class="centertext container">
+        <div class="row border">
+            <h3 class="col-sm border">Specialized Practices</h3>
+        </div>
+        {% for obj in object_list %}
+            <div class="row border">
+                <a class="col-sm border" href="{{ obj.get_absolute_url }}">{{ obj.name }}</a>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock content %}

--- a/characters/tests/models/mage/test_focus.py
+++ b/characters/tests/models/mage/test_focus.py
@@ -508,6 +508,120 @@ class TestParadigmUpdateView(TestCase):
         self.assertEqual(self.paradigm.name, "Test Paradigm 2")
 
 
+class TestInstrumentListView(TestCase):
+    def setUp(self):
+        self.instrument = Instrument.objects.create(name="Test Instrument")
+        self.url = "/characters/mage/list/instruments/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/instrument/list.html")
+
+    def test_list_view_contains_instrument(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Instrument")
+
+
+class TestPracticeListView(TestCase):
+    def setUp(self):
+        self.practice = Practice.objects.create(name="Test Practice")
+        self.url = "/characters/mage/list/practices/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/practice/list.html")
+
+    def test_list_view_contains_practice(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Practice")
+
+
+class TestSpecializedPracticeListView(TestCase):
+    def setUp(self):
+        self.practice = Practice.objects.create(name="Parent Practice")
+        self.specialized_practice = SpecializedPractice.objects.create(
+            name="Test Specialized Practice", parent_practice=self.practice
+        )
+        self.url = "/characters/mage/list/specialized_practices/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/specialized_practice/list.html")
+
+    def test_list_view_contains_specialized_practice(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Specialized Practice")
+
+
+class TestCorruptedPracticeListView(TestCase):
+    def setUp(self):
+        self.practice = Practice.objects.create(name="Parent Practice")
+        self.corrupted_practice = CorruptedPractice.objects.create(
+            name="Test Corrupted Practice", parent_practice=self.practice
+        )
+        self.url = "/characters/mage/list/corrupted_practices/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/corrupted_practice/list.html")
+
+    def test_list_view_contains_corrupted_practice(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Corrupted Practice")
+
+
+class TestTenetListView(TestCase):
+    def setUp(self):
+        self.tenet = Tenet.objects.create(name="Test Tenet")
+        self.url = "/characters/mage/list/tenet/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/tenet/list.html")
+
+    def test_list_view_contains_tenet(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Tenet")
+
+
+class TestParadigmListView(TestCase):
+    def setUp(self):
+        self.paradigm = Paradigm.objects.create(name="Test Paradigm")
+        self.url = "/characters/mage/list/paradigms/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/paradigm/list.html")
+
+    def test_list_view_contains_paradigm(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Paradigm")
+
+
 class TestGenericCharacterDetailViews(TestCase):
     def setUp(self) -> None:
         self.practice = Practice.objects.create(name="Practice")

--- a/characters/urls/mage/detail.py
+++ b/characters/urls/mage/detail.py
@@ -44,6 +44,16 @@ urls = [
         name="practice",
     ),
     path(
+        "specialized_practices/<pk>/",
+        views.mage.SpecializedPracticeDetailView.as_view(),
+        name="specialized_practice",
+    ),
+    path(
+        "corrupted_practices/<pk>/",
+        views.mage.CorruptedPracticeDetailView.as_view(),
+        name="corrupted_practice",
+    ),
+    path(
         "tenet/<pk>/",
         views.mage.TenetDetailView.as_view(),
         name="tenet",

--- a/characters/urls/mage/index.py
+++ b/characters/urls/mage/index.py
@@ -29,6 +29,16 @@ urls = [
         name="practice",
     ),
     path(
+        "specialized_practices/",
+        views.mage.SpecializedPracticeListView.as_view(),
+        name="specialized_practice",
+    ),
+    path(
+        "corrupted_practices/",
+        views.mage.CorruptedPracticeListView.as_view(),
+        name="corrupted_practice",
+    ),
+    path(
         "tenet/",
         views.mage.TenetListView.as_view(),
         name="tenet",

--- a/characters/views/mage/__init__.py
+++ b/characters/views/mage/__init__.py
@@ -22,6 +22,7 @@ from .fellowship import (
 from .focus import (
     CorruptedPracticeCreateView,
     CorruptedPracticeDetailView,
+    CorruptedPracticeListView,
     CorruptedPracticeUpdateView,
     GenericPracticeDetailView,
     InstrumentCreateView,
@@ -38,6 +39,7 @@ from .focus import (
     PracticeUpdateView,
     SpecializedPracticeCreateView,
     SpecializedPracticeDetailView,
+    SpecializedPracticeListView,
     SpecializedPracticeUpdateView,
     TenetCreateView,
     TenetDetailView,

--- a/characters/views/mage/focus.py
+++ b/characters/views/mage/focus.py
@@ -158,6 +158,12 @@ class CorruptedPracticeUpdateView(MessageMixin, UpdateView):
     error_message = "There was an error updating the Corrupted Practice."
 
 
+class CorruptedPracticeListView(ListView):
+    model = CorruptedPractice
+    ordering = ["name"]
+    template_name = "characters/mage/corrupted_practice/list.html"
+
+
 class SpecializedPracticeDetailView(PracticeDetailView):
     model = SpecializedPractice
     template_name = "characters/mage/specialized_practice/detail.html"
@@ -195,6 +201,12 @@ class SpecializedPracticeUpdateView(MessageMixin, UpdateView):
     template_name = "characters/mage/specialized_practice/form.html"
     success_message = "Specialized Practice updated successfully."
     error_message = "There was an error updating the Specialized Practice."
+
+
+class SpecializedPracticeListView(ListView):
+    model = SpecializedPractice
+    ordering = ["name"]
+    template_name = "characters/mage/specialized_practice/list.html"
 
 
 class TenetDetailView(DetailView):


### PR DESCRIPTION
## Summary
- Add `get_absolute_url()` methods to `SpecializedPractice` and `CorruptedPractice` models so they no longer inherit the parent `Practice`'s URL (which caused incorrect detail view routing)
- Add list views and URL patterns for `SpecializedPractice` and `CorruptedPractice`
- Add list templates for both models
- Add comprehensive tests for all list views

## Test plan
- [x] Run `python manage.py test characters.tests.models.mage.test_focus` - all 84 tests pass
- [x] Verify URL generation for SpecializedPractice and CorruptedPractice models
- [x] Verify list views accessible at `/characters/mage/list/specialized_practices/` and `/characters/mage/list/corrupted_practices/`
- [x] Verify detail views accessible at `/characters/mage/specialized_practices/<pk>/` and `/characters/mage/corrupted_practices/<pk>/`

Fixes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)