### PR TITLE
Add missing CRUD views for game models (#1085)

### DIFF
--- a/game/templates/game/chronicle/form.html
+++ b/game/templates/game/chronicle/form.html
@@ -1,0 +1,58 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update {{ object.name }}
+    {% else %}
+        Create Chronicle
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update {{ object.name }}
+                    {% else %}
+                        Create Chronicle
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {{ field }}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{{ object.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:chronicles' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/freebie_spending_record/detail.html
+++ b/game/templates/game/freebie_spending_record/detail.html
@@ -1,0 +1,82 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Freebie Spending Record - {{ object.character.name }}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wod">
+            <div class="tg-card-header text-center">
+                <h1 class="tg-card-title wod_heading">Freebie Spending Record</h1>
+                <div style="font-size: 0.875rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                    {{ object.character.name }} - {{ object.trait_name }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Record Details -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Record Details</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Character</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);"><a href="{{ object.character.get_absolute_url }}">{{ object.character.name }}</a></div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Player</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.character.owner.username }}</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Trait Name</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.trait_name }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Trait Type</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.trait_type }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Value</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.trait_value }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Freebie Cost</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.cost }}</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Created</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.created_at|date:"M d, Y H:i" }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="text-center mb-4">
+            {% if is_owner %}
+                <a href="{% url 'game:freebie_spending_record:update' object.pk %}" class="btn btn-secondary">Edit</a>
+            {% endif %}
+            <a href="{% url 'game:freebie_spending_record:list' %}" class="btn btn-secondary">Back to List</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/freebie_spending_record/form.html
+++ b/game/templates/game/freebie_spending_record/form.html
@@ -1,0 +1,58 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update Freebie Spending Record
+    {% else %}
+        Create Freebie Spending Record
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update Freebie Spending Record
+                    {% else %}
+                        Create Freebie Spending Record for {{ character.name }}
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {{ field }}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{% url 'game:freebie_spending_record:detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:freebie_spending_record:list' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/freebie_spending_record/list.html
+++ b/game/templates/game/freebie_spending_record/list.html
@@ -1,0 +1,79 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Freebie Spending Records
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">Freebie Spending Records</h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                {% if object_list %}
+                    <div class="tg-table-responsive">
+                        <table class="tg-table">
+                            <thead>
+                                <tr>
+                                    <th>Character</th>
+                                    {% if is_st %}
+                                        <th>Player</th>
+                                    {% endif %}
+                                    <th>Trait</th>
+                                    <th>Type</th>
+                                    <th>Value</th>
+                                    <th>Cost</th>
+                                    <th>Created</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for record in object_list %}
+                                    <tr>
+                                        <td><a href="{{ record.character.get_absolute_url }}">{{ record.character.name }}</a></td>
+                                        {% if is_st %}
+                                            <td>{{ record.character.owner.username }}</td>
+                                        {% endif %}
+                                        <td>{{ record.trait_name }}</td>
+                                        <td>{{ record.trait_type }}</td>
+                                        <td>{{ record.trait_value }}</td>
+                                        <td>{{ record.cost }} freebies</td>
+                                        <td>{{ record.created_at|date:"M d, Y" }}</td>
+                                        <td><a href="{% url 'game:freebie_spending_record:detail' record.pk %}" class="btn btn-sm btn-primary">View</a></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {% if is_paginated %}
+                        <nav aria-label="Page navigation" class="mt-4">
+                            <ul class="pagination justify-content-center">
+                                {% if page_obj.has_previous %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page=1">First</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                    </li>
+                                {% endif %}
+                                <li class="page-item active">
+                                    <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                                </li>
+                                {% if page_obj.has_next %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </nav>
+                    {% endif %}
+                {% else %}
+                    <p class="text-center text-muted">No freebie spending records found.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/scene/form.html
+++ b/game/templates/game/scene/form.html
@@ -1,0 +1,67 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update Scene
+    {% else %}
+        Create Scene
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update Scene
+                    {% else %}
+                        Create Scene{% if chronicle %} for {{ chronicle.name }}{% endif %}
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {% if field.field.widget.input_type == "checkbox" %}
+                                    <div class="form-check">
+                                        {{ field }}
+                                        <label class="form-check-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                    </div>
+                                {% else %}
+                                    {{ field }}
+                                {% endif %}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{{ object.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+                            {% elif chronicle %}
+                                <a href="{{ chronicle.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:scenes' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/story_xp_request/form.html
+++ b/game/templates/game/story_xp_request/form.html
@@ -1,0 +1,65 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update Story XP Request
+    {% else %}
+        Create Story XP Request
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update Story XP Request
+                    {% else %}
+                        Create Story XP Request for {{ character.name }}
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {% if field.field.widget.input_type == "checkbox" %}
+                                    <div class="form-check">
+                                        {{ field }}
+                                        <label class="form-check-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+                                    </div>
+                                {% else %}
+                                    {{ field }}
+                                {% endif %}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{% url 'game:story_xp_request:detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:story_xp_request:list' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/xp_spending_request/detail.html
+++ b/game/templates/game/xp_spending_request/detail.html
@@ -1,0 +1,126 @@
+{% extends "core/base.html" %}
+{% block title %}
+    XP Spending Request - {{ object.character.name }}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="wod">
+            <div class="tg-card-header text-center">
+                <h1 class="tg-card-title wod_heading">XP Spending Request</h1>
+                <div style="font-size: 0.875rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                    {{ object.character.name }} - {{ object.trait_name }}
+                </div>
+            </div>
+        </div>
+
+        <!-- Request Details -->
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h5 class="tg-card-title wod_heading">Request Details</h5>
+            </div>
+            <div class="tg-card-body" style="padding: 20px;">
+                <div class="row mb-3">
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Character</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);"><a href="{{ object.character.get_absolute_url }}">{{ object.character.name }}</a></div>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Player</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.character.owner.username }}</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Trait Name</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.trait_name }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Trait Type</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.trait_type }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">New Value</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.trait_value }}</div>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">XP Cost</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.cost }}</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mb-3">
+                    <div class="col-md-4">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Status</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">
+                                {% if object.approved == "Pending" %}
+                                    <span class="tg-badge badge-sub">Pending</span>
+                                {% elif object.approved == "Approved" %}
+                                    <span class="tg-badge badge-app">Approved</span>
+                                {% else %}
+                                    <span class="tg-badge badge-dec">Denied</span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-4">
+                        <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                            <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Created</div>
+                            <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.created_at|date:"M d, Y H:i" }}</div>
+                        </div>
+                    </div>
+                    {% if object.approved_at %}
+                        <div class="col-md-4">
+                            <div style="padding: 12px; border-radius: 6px; background-color: rgba(0,0,0,0.02);">
+                                <div style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; color: var(--theme-text-secondary); margin-bottom: 4px;">Processed</div>
+                                <div style="font-weight: 700; color: var(--theme-text-primary);">{{ object.approved_at|date:"M d, Y H:i" }} by {{ object.approved_by.username }}</div>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        {% if is_st and object.approved == "Pending" %}
+            <!-- Approval Form -->
+            <div class="tg-card mb-4">
+                <div class="tg-card-header text-center">
+                    <h5 class="tg-card-title wod_heading">Process Request</h5>
+                </div>
+                <div class="tg-card-body" style="padding: 20px;">
+                    <form method="post" action="{% url 'game:xp_spending_request:approve' object.pk %}">
+                        {% csrf_token %}
+                        <div class="row mb-3">
+                            <div class="col-md-4 offset-md-4">
+                                {{ approval_form.approved }}
+                            </div>
+                        </div>
+                        <div class="text-center">
+                            <button type="submit" class="btn btn-primary">Submit Decision</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="text-center mb-4">
+            {% if is_owner and object.approved == "Pending" %}
+                <a href="{% url 'game:xp_spending_request:update' object.pk %}" class="btn btn-secondary">Edit</a>
+            {% endif %}
+            <a href="{% url 'game:xp_spending_request:list' %}" class="btn btn-secondary">Back to List</a>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/xp_spending_request/form.html
+++ b/game/templates/game/xp_spending_request/form.html
@@ -1,0 +1,58 @@
+{% extends "core/base.html" %}
+{% block title %}
+    {% if object.pk %}
+        Update XP Spending Request
+    {% else %}
+        Create XP Spending Request
+    {% endif %}
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">
+                    {% if object.pk %}
+                        Update XP Spending Request
+                    {% else %}
+                        Create XP Spending Request for {{ character.name }}
+                    {% endif %}
+                </h3>
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                <form method="post">
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row mb-3">
+                            <div class="col-md-4">
+                                <label class="form-label" style="font-weight: 600; color: var(--theme-text-secondary);">{{ field.label }}</label>
+                                {% if field.help_text %}
+                                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary);">{{ field.help_text }}</div>
+                                {% endif %}
+                            </div>
+                            <div class="col-md-8">
+                                {{ field }}
+                            </div>
+                        </div>
+                        {% if field.errors %}
+                            <div class="row mb-3">
+                                <div class="col-md-8 offset-md-4">
+                                    <div class="text-danger" style="font-size: 0.875rem;">{{ field.errors }}</div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                    <div class="row">
+                        <div class="col-md-8 offset-md-4">
+                            <button type="submit" class="btn btn-primary">Save</button>
+                            {% if object.pk %}
+                                <a href="{% url 'game:xp_spending_request:detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+                            {% else %}
+                                <a href="{% url 'game:xp_spending_request:list' %}" class="btn btn-secondary">Cancel</a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/templates/game/xp_spending_request/list.html
+++ b/game/templates/game/xp_spending_request/list.html
@@ -1,0 +1,94 @@
+{% extends "core/base.html" %}
+{% block title %}
+    XP Spending Requests
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card mb-4">
+            <div class="tg-card-header text-center">
+                <h3 class="tg-card-title wod_heading">XP Spending Requests</h3>
+                {% if is_st and pending_count %}
+                    <div style="font-size: 0.875rem; color: var(--theme-text-secondary); margin-top: 8px;">
+                        {{ pending_count }} pending request{{ pending_count|pluralize }}
+                    </div>
+                {% endif %}
+            </div>
+            <div class="tg-card-body" style="padding: 24px;">
+                {% if object_list %}
+                    <div class="tg-table-responsive">
+                        <table class="tg-table">
+                            <thead>
+                                <tr>
+                                    <th>Character</th>
+                                    {% if is_st %}
+                                        <th>Player</th>
+                                    {% endif %}
+                                    <th>Trait</th>
+                                    <th>Type</th>
+                                    <th>Value</th>
+                                    <th>Cost</th>
+                                    <th>Status</th>
+                                    <th>Created</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for request in object_list %}
+                                    <tr>
+                                        <td><a href="{{ request.character.get_absolute_url }}">{{ request.character.name }}</a></td>
+                                        {% if is_st %}
+                                            <td>{{ request.character.owner.username }}</td>
+                                        {% endif %}
+                                        <td>{{ request.trait_name }}</td>
+                                        <td>{{ request.trait_type }}</td>
+                                        <td>{{ request.trait_value }}</td>
+                                        <td>{{ request.cost }} XP</td>
+                                        <td>
+                                            {% if request.approved == "Pending" %}
+                                                <span class="tg-badge badge-sub">Pending</span>
+                                            {% elif request.approved == "Approved" %}
+                                                <span class="tg-badge badge-app">Approved</span>
+                                            {% else %}
+                                                <span class="tg-badge badge-dec">Denied</span>
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ request.created_at|date:"M d, Y" }}</td>
+                                        <td><a href="{% url 'game:xp_spending_request:detail' request.pk %}" class="btn btn-sm btn-primary">View</a></td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {% if is_paginated %}
+                        <nav aria-label="Page navigation" class="mt-4">
+                            <ul class="pagination justify-content-center">
+                                {% if page_obj.has_previous %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page=1">First</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                                    </li>
+                                {% endif %}
+                                <li class="page-item active">
+                                    <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+                                </li>
+                                {% if page_obj.has_next %}
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                                    </li>
+                                    <li class="page-item">
+                                        <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last</a>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </nav>
+                    {% endif %}
+                {% else %}
+                    <p class="text-center text-muted">No XP spending requests found.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/game/urls.py
+++ b/game/urls.py
@@ -37,6 +37,12 @@ weekly_xp_request_urls = [
 story_xp_request_urls = [
     path("list/", views.StoryXPRequestListView.as_view(), name="list"),
     path("<pk>/", views.StoryXPRequestDetailView.as_view(), name="detail"),
+    path(
+        "create/<character_pk>/",
+        views.StoryXPRequestCreateView.as_view(),
+        name="create",
+    ),
+    path("<pk>/update/", views.StoryXPRequestUpdateView.as_view(), name="update"),
 ]
 
 setting_element_urls = [
@@ -44,6 +50,44 @@ setting_element_urls = [
     path("<pk>/", views.SettingElementDetailView.as_view(), name="detail"),
     path("create/", views.SettingElementCreateView.as_view(), name="create"),
     path("<pk>/update/", views.SettingElementUpdateView.as_view(), name="update"),
+]
+
+xp_spending_request_urls = [
+    path("list/", views.XPSpendingRequestListView.as_view(), name="list"),
+    path("<pk>/", views.XPSpendingRequestDetailView.as_view(), name="detail"),
+    path(
+        "create/<character_pk>/",
+        views.XPSpendingRequestCreateView.as_view(),
+        name="create",
+    ),
+    path("<pk>/update/", views.XPSpendingRequestUpdateView.as_view(), name="update"),
+    path("<pk>/approve/", views.XPSpendingRequestApproveView.as_view(), name="approve"),
+]
+
+freebie_spending_record_urls = [
+    path("list/", views.FreebieSpendingRecordListView.as_view(), name="list"),
+    path("<pk>/", views.FreebieSpendingRecordDetailView.as_view(), name="detail"),
+    path(
+        "create/<character_pk>/",
+        views.FreebieSpendingRecordCreateView.as_view(),
+        name="create",
+    ),
+    path("<pk>/update/", views.FreebieSpendingRecordUpdateView.as_view(), name="update"),
+]
+
+chronicle_urls = [
+    path("create/", views.ChronicleCreateView.as_view(), name="create"),
+    path("<pk>/update/", views.ChronicleUpdateView.as_view(), name="update"),
+]
+
+scene_urls = [
+    path("create/", views.SceneCreateView.as_view(), name="create"),
+    path(
+        "create/<chronicle_pk>/",
+        views.SceneCreateView.as_view(),
+        name="create_for_chronicle",
+    ),
+    path("<pk>/update/", views.SceneUpdateView.as_view(), name="update"),
 ]
 
 urlpatterns = [
@@ -70,4 +114,11 @@ urlpatterns = [
     path("weekly-xp-request/", include((weekly_xp_request_urls, "weekly_xp_request"))),
     path("story-xp-request/", include((story_xp_request_urls, "story_xp_request"))),
     path("setting-element/", include((setting_element_urls, "setting_element"))),
+    path("xp-spending-request/", include((xp_spending_request_urls, "xp_spending_request"))),
+    path(
+        "freebie-spending-record/",
+        include((freebie_spending_record_urls, "freebie_spending_record")),
+    ),
+    path("chronicle-manage/", include((chronicle_urls, "chronicle_manage"))),
+    path("scene-manage/", include((scene_urls, "scene_manage"))),
 ]


### PR DESCRIPTION
## Summary
- Add full CRUD views, forms, and templates for XPSpendingRequest with ST approval workflow
- Add full CRUD views for FreebieSpendingRecord (character creation freebie tracking)
- Add create/update views for StoryXPRequest (ST-only)
- Add create/update views for Chronicle and Scene management (ST-only)

## Changes
- **Forms**: Added 8 new form classes (XPSpendingRequestForm, XPSpendingRequestApprovalForm, FreebieSpendingRecordForm, StoryXPRequestForm, ChronicleForm, SceneForm)
- **Views**: Added 18 new view classes for list, detail, create, update, and approve operations
- **URLs**: Added 4 new namespaced URL patterns (xp_spending_request, freebie_spending_record, chronicle_manage, scene_manage)
- **Templates**: Added 10 new templates following TG design system patterns

## Test plan
- [x] All 36 new tests pass
- [x] XP spending requests can be created, listed, viewed, updated, and approved
- [x] Freebie spending records can be created, listed, viewed, and updated
- [x] Story XP requests can be created and updated by STs
- [x] Chronicles and scenes can be created and updated by STs
- [x] Permission checks work correctly (owners can access their content, STs have elevated access)

Fixes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)