### PR TITLE
Fix unsafe .objects.get() calls - return 404 instead of 500

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -62,7 +62,7 @@ class ProfileView(LoginRequiredMixin, DetailView):
             WeeklyXPRequestForm(
                 character=c,
                 week=w,
-                instance=WeeklyXPRequest.objects.get(character=c, week=w),
+                instance=get_object_or_404(WeeklyXPRequest, character=c, week=w),
             )
             for c, w in self.object.get_unfulfilled_weekly_xp_requests_to_approve()
         ]

--- a/characters/tests/views/core/test_human.py
+++ b/characters/tests/views/core/test_human.py
@@ -1,5 +1,101 @@
-"""Tests for human module."""
+"""Tests for human views module."""
 
-from django.test import TestCase
+from characters.models.core.human import Human
+from characters.models.core.merit_flaw_block import MeritFlaw
+from core.models import Number
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+from game.models import ObjectType
 
-# TODO: Move relevant tests from existing test files here
+
+class TestHumanDetailView(TestCase):
+    """Test HumanDetailView permissions and 404 handling."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="password"
+        )
+        self.human = Human.objects.create(
+            name="Test Human",
+            owner=self.owner,
+            status="App",
+        )
+
+    def test_detail_view_returns_404_for_invalid_pk(self):
+        """Test that detail view returns 404 for non-existent character."""
+        self.client.login(username="owner", password="password")
+        response = self.client.get(
+            reverse("characters:character", kwargs={"pk": 99999})
+        )
+        self.assertEqual(response.status_code, 404)
+
+
+class TestLoadValuesView(TestCase):
+    """Test load_values AJAX view 404 handling."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.chartype, _ = ObjectType.objects.get_or_create(
+            name="human", defaults={"type": "char", "gameline": "wod"}
+        )
+        self.mf = MeritFlaw.objects.create(name="Test Merit")
+        self.mf.allowed_types.add(self.chartype)
+        # Add ratings via Number model
+        num1, _ = Number.objects.get_or_create(value=1)
+        num2, _ = Number.objects.get_or_create(value=2)
+        self.mf.ratings.add(num1, num2)
+
+        self.human = Human.objects.create(
+            name="Test Human",
+            owner=self.user,
+        )
+
+    def test_load_values_returns_404_for_invalid_meritflaw(self):
+        """Test that load_values returns 404 for non-existent merit/flaw."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:ajax:load_values"),
+            {"example": 99999},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_load_values_returns_404_for_invalid_character(self):
+        """Test that load_values returns 404 for non-existent character."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:ajax:load_values"),
+            {"example": self.mf.pk, "object": 99999},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_load_values_returns_200_for_valid_meritflaw(self):
+        """Test that load_values returns 200 for valid merit/flaw."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:ajax:load_values"),
+            {"example": self.mf.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+class TestHumanChargenView(TestCase):
+    """Test HumanChargenView 404 handling."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="password"
+        )
+
+    def test_chargen_view_returns_404_for_invalid_pk(self):
+        """Test that chargen view returns 404 for non-existent character."""
+        self.client.login(username="owner", password="password")
+        response = self.client.get(
+            reverse("characters:update:human", kwargs={"pk": 99999})
+        )
+        self.assertEqual(response.status_code, 404)

--- a/characters/tests/views/mage/test_mage.py
+++ b/characters/tests/views/mage/test_mage.py
@@ -399,3 +399,40 @@ class TestMageRoteView(TestCase):
         url = reverse("characters:mage:update:mage", kwargs={"pk": self.mage.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+
+class TestMageView404Handling(TestCase):
+    """Test 404 error handling for mage views with invalid IDs."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="password"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.user)
+
+    def test_mage_detail_returns_404_for_invalid_pk(self):
+        """Test that mage detail returns 404 for non-existent character."""
+        self.client.login(username="testuser", password="password")
+        # Uses the generic character detail view which maps to specific views
+        response = self.client.get(
+            reverse("characters:character", kwargs={"pk": 99999})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_mage_update_returns_404_for_invalid_pk(self):
+        """Test that mage update returns 404 for non-existent character."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:mage:update:mage", kwargs={"pk": 99999})
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_mage_full_update_returns_404_for_invalid_pk(self):
+        """Test that mage full update returns 404 for non-existent character."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(
+            reverse("characters:mage:update:mage_full", kwargs={"pk": 99999})
+        )
+        self.assertEqual(response.status_code, 404)

--- a/characters/views/core/human.py
+++ b/characters/views/core/human.py
@@ -277,7 +277,7 @@ def load_examples(request):
 
 @login_required
 def load_values(request):
-    mf = MeritFlaw.objects.get(pk=request.GET.get("example"))
+    mf = get_object_or_404(MeritFlaw, pk=request.GET.get("example"))
     character_id = request.GET.get("object")
     is_xp = request.GET.get("xp", "false").lower() == "true"
 
@@ -286,9 +286,9 @@ def load_values(request):
 
     # Filter ratings based on character's available freebies/XP and flaw limit
     if character_id:
-        from characters.models import Human
+        from characters.models.core import Human
 
-        character = Human.objects.get(pk=character_id)
+        character = get_object_or_404(Human, pk=character_id)
         current_rating = character.mf_rating(mf)
 
         affordable_ratings = []
@@ -329,7 +329,7 @@ class HumanFreebieFormPopulationView(View):
         from core.ajax import dropdown_options_response
 
         category_choice = request.GET.get("category")
-        self.character = self.primary_class.objects.get(pk=request.GET.get("object"))
+        self.character = get_object_or_404(self.primary_class, pk=request.GET.get("object"))
         examples = []
         if category_choice in self.category_method_map().keys():
             examples = self.category_method_map()[category_choice]()
@@ -474,7 +474,8 @@ class HumanLanguagesView(SpendFreebiesPermissionMixin, FormView):
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         human_pk = self.kwargs.get("pk")
-        num_languages = Human.objects.get(pk=human_pk).num_languages()
+        human = get_object_or_404(Human, pk=human_pk)
+        num_languages = human.num_languages()
         kwargs.update({"pk": human_pk, "num_languages": int(num_languages)})
         return kwargs
 
@@ -508,7 +509,7 @@ class HumanSpecialtiesView(SpendFreebiesPermissionMixin, FormView):
     def get_object(self):
         """Return the Human object for permission checking."""
         if not hasattr(self, "object") or self.object is None:
-            self.object = Human.objects.get(id=self.kwargs["pk"])
+            self.object = get_object_or_404(Human, id=self.kwargs["pk"])
         return self.object
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:

--- a/characters/views/mage/companion.py
+++ b/characters/views/mage/companion.py
@@ -217,9 +217,9 @@ class CompanionExtrasView(SpecialUserMixin, UpdateView):
         elif self.object.companion_type in ["familiar"]:
             if self.object.npc == False:
                 self.object.freebies = 25
-            thaumivore = MeritFlaw.objects.get(name="Thaumivore")
-            bond_sharing = Advantage.objects.get(name="Bond-Sharing")
-            paradox_nullification = Advantage.objects.get(name="Paradox Nullification")
+            thaumivore = get_object_or_404(MeritFlaw, name="Thaumivore")
+            bond_sharing = get_object_or_404(Advantage, name="Bond-Sharing")
+            paradox_nullification = get_object_or_404(Advantage, name="Paradox Nullification")
             self.object.add_mf(thaumivore, -5)
             self.object.spent_freebies.append(
                 self.object.freebie_spend_record(thaumivore.name, "meritflaw", -5, cost=-5)
@@ -234,7 +234,7 @@ class CompanionExtrasView(SpecialUserMixin, UpdateView):
                 self.object.freebie_spend_record(paradox_nullification.name, "advantage", 2, cost=2)
             )
 
-            self.object.add_charm(SpiritCharm.objects.get(name="Airt Sense"))
+            self.object.add_charm(get_object_or_404(SpiritCharm, name="Airt Sense"))
 
             self.object.freebies -= 1
 

--- a/characters/views/mage/mage.py
+++ b/characters/views/mage/mage.py
@@ -634,13 +634,13 @@ class MageDetailView(HumanDetailView):
             try:
                 with transaction.atomic():
                     if trait_type == "attribute":
-                        att = Attribute.objects.get(name=trait_name)
+                        att = get_object_or_404(Attribute, name=trait_name)
                         self.object.approve_xp_spend(
                             request_id, att.property_name, value, request.user
                         )
                         messages.success(request, f"Approved {att.name} increase to {value}")
                     elif trait_type == "ability":
-                        abb = Ability.objects.get(name=trait_name)
+                        abb = get_object_or_404(Ability, name=trait_name)
                         self.object.approve_xp_spend(
                             request_id, abb.property_name, value, request.user
                         )
@@ -672,7 +672,7 @@ class MageDetailView(HumanDetailView):
                             bg_name = trait_name.strip()
                             note = ""
                         BackgroundRating.objects.create(
-                            bg=Background.objects.get(name=bg_name),
+                            bg=get_object_or_404(Background, name=bg_name),
                             rating=1,
                             char=self.object,
                             note=note,
@@ -686,7 +686,7 @@ class MageDetailView(HumanDetailView):
                         self.object.approve_xp_spend(request_id, "willpower", value, request.user)
                         messages.success(request, f"Approved Willpower increase to {value}")
                     elif trait_type == "meritflaw":
-                        mf = MeritFlaw.objects.get(name=trait_name)
+                        mf = get_object_or_404(MeritFlaw, name=trait_name)
                         self.object.add_mf(mf, value)
                         xp_request.approved = "Approved"
                         xp_request.approved_by = request.user
@@ -694,7 +694,7 @@ class MageDetailView(HumanDetailView):
                         xp_request.save()
                         messages.success(request, f"Approved merit/flaw {trait_name}")
                     elif trait_type == "sphere":
-                        s = Sphere.objects.get(name=trait_name)
+                        s = get_object_or_404(Sphere, name=trait_name)
                         setattr(self.object, s.property_name, value)
                         self.object.save()
                         xp_request.approved = "Approved"
@@ -706,7 +706,7 @@ class MageDetailView(HumanDetailView):
                         self.object.approve_xp_spend(request_id, "arete", value, request.user)
                         messages.success(request, f"Approved Arete increase to {value}")
                     elif trait_type == "tenet":
-                        t = Tenet.objects.get(name=trait_name)
+                        t = get_object_or_404(Tenet, name=trait_name)
                         self.object.other_tenets.add(t)
                         xp_request.approved = "Approved"
                         xp_request.approved_by = request.user
@@ -716,7 +716,7 @@ class MageDetailView(HumanDetailView):
                     elif trait_type == "remove tenet" or trait_type == "remove-tenet":
                         # Remove "Remove " prefix if present
                         tenet_name = trait_name.replace("Remove ", "")
-                        tenet = Tenet.objects.get(name=tenet_name)
+                        tenet = get_object_or_404(Tenet, name=tenet_name)
                         if tenet in self.object.other_tenets.all():
                             self.object.other_tenets.remove(tenet)
                         else:
@@ -738,7 +738,7 @@ class MageDetailView(HumanDetailView):
                         xp_request.save()
                         messages.success(request, f"Approved removal of tenet {tenet_name}")
                     elif trait_type == "practice":
-                        practice = Practice.objects.get(name=trait_name)
+                        practice = get_object_or_404(Practice, name=trait_name)
                         self.object.add_practice(practice)
                         xp_request.approved = "Approved"
                         xp_request.approved_by = request.user
@@ -1460,7 +1460,7 @@ class MageChantryView(GenericBackgroundView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs["character"] = self.primary_object_class.objects.get(pk=self.kwargs["pk"])
+        kwargs["character"] = get_object_or_404(self.primary_object_class, pk=self.kwargs["pk"])
         return kwargs
 
     def get_form(self, form_class=None):

--- a/characters/views/mage/sorcerer.py
+++ b/characters/views/mage/sorcerer.py
@@ -875,7 +875,7 @@ class SorcererArtifactView(EditPermissionMixin, FormView):
 
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["object"] = Human.objects.get(id=self.kwargs["pk"])
+        context["object"] = get_object_or_404(Human, id=self.kwargs["pk"])
         context["current_artifact"] = (
             context["object"]
             .backgrounds.filter(bg__property_name="artifact", complete=False)


### PR DESCRIPTION
## Summary
- Replaced all unsafe `.objects.get()` calls with `get_object_or_404()` in views
- Views now return proper 404 responses instead of 500 errors when objects don't exist
- Added tests to verify 404 behavior for invalid IDs

## Affected Files
- `characters/views/core/human.py` - Fixed `load_values()`, `HumanFreebieFormPopulationView`, `HumanLanguagesView`, `HumanSpecialtiesView`
- `characters/views/mage/mage.py` - Fixed XP approval handlers and `MageChantryView`
- `characters/views/mage/companion.py` - Fixed familiar data lookups in `CompanionExtrasView`
- `characters/views/mage/sorcerer.py` - Fixed `SorcererArtifactCreateView`
- `accounts/views.py` - Fixed `WeeklyXPRequest` lookup in `ProfileView`

## Test plan
- [x] Added new tests in `characters/tests/views/core/test_human.py` for 404 handling
- [x] Added new tests in `characters/tests/views/mage/test_mage.py` for 404 handling
- [x] Ran existing tests for affected apps - all pass (212 tests)
- [ ] Manual testing: Access views with invalid IDs to verify 404 responses

Closes #1052

🤖 Generated with [Claude Code](https://claude.com/claude-code)