### PR TITLE
Implement Sphere (Mage) views and templates

### DIFF
--- a/characters/models/mage/sphere.py
+++ b/characters/models/mage/sphere.py
@@ -1,5 +1,25 @@
 from characters.models.core.statistic import Statistic
+from django.urls import reverse
 
 
 class Sphere(Statistic):
     type = "sphere"
+    gameline = "mta"
+
+    class Meta:
+        verbose_name = "Sphere"
+        verbose_name_plural = "Spheres"
+        ordering = ["name"]
+
+    def get_absolute_url(self):
+        return reverse("characters:mage:sphere", kwargs={"pk": self.pk})
+
+    def get_update_url(self):
+        return reverse("characters:mage:update:sphere", kwargs={"pk": self.pk})
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("characters:mage:create:sphere")
+
+    def get_heading(self):
+        return "mta_heading"

--- a/characters/templates/characters/mage/sphere/detail.html
+++ b/characters/templates/characters/mage/sphere/detail.html
@@ -1,0 +1,14 @@
+{% extends "core/object.html" %}
+{% block contents %}
+<div class="tg-card mb-4">
+    <div class="tg-card-header">
+        <h5 class="tg-card-title mta_heading">Sphere Details</h5>
+    </div>
+    <div class="tg-card-body">
+        <div class="row mb-2">
+            <div class="col-md-4"><strong>Property Name:</strong></div>
+            <div class="col-md-8">{{ object.property_name }}</div>
+        </div>
+    </div>
+</div>
+{% endblock contents %}

--- a/characters/templates/characters/mage/sphere/form.html
+++ b/characters/templates/characters/mage/sphere/form.html
@@ -1,0 +1,14 @@
+{% extends "core/form.html" %}
+{% block creation_title %}
+    {% if object %}Edit Sphere{% else %}Create Sphere{% endif %}
+{% endblock creation_title %}
+{% block contents %}
+    <div class="row">
+        <div class="col-sm">Name</div>
+        <div class="col-sm">{{ form.name }}</div>
+    </div>
+    <div class="row">
+        <div class="col-sm">Property Name</div>
+        <div class="col-sm">{{ form.property_name }}</div>
+    </div>
+{% endblock contents %}

--- a/characters/templates/characters/mage/sphere/list.html
+++ b/characters/templates/characters/mage/sphere/list.html
@@ -1,0 +1,38 @@
+{% extends "core/base.html" %}
+{% block title %}
+    Spheres
+{% endblock title %}
+{% block content %}
+    <div class="container">
+        <div class="tg-card header-card mb-4" data-gameline="mta">
+            <div class="tg-card-header">
+                <h1 class="tg-card-title mta_heading">Spheres</h1>
+            </div>
+        </div>
+
+        <div class="tg-card">
+            <div class="tg-card-body">
+                <table class="tg-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Property Name</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for obj in object_list %}
+                            <tr>
+                                <td><a href="{{ obj.get_absolute_url }}">{{ obj.name }}</a></td>
+                                <td>{{ obj.property_name }}</td>
+                            </tr>
+                        {% empty %}
+                            <tr>
+                                <td colspan="2" class="text-center">No spheres found.</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/characters/tests/views/mage/test_sphere.py
+++ b/characters/tests/views/mage/test_sphere.py
@@ -1,0 +1,128 @@
+"""Tests for Sphere views."""
+
+from characters.models.mage import Sphere
+from django.test import TestCase
+
+
+class TestSphereModel(TestCase):
+    def setUp(self):
+        self.sphere = Sphere.objects.create(
+            name="Forces",
+            property_name="forces",
+        )
+
+    def test_str(self):
+        self.assertEqual(str(self.sphere), "Forces")
+
+    def test_get_absolute_url(self):
+        url = self.sphere.get_absolute_url()
+        self.assertIn(f"/characters/mage/sphere/{self.sphere.pk}/", url)
+
+    def test_get_update_url(self):
+        expected_url = f"/characters/mage/update/sphere/{self.sphere.pk}/"
+        self.assertEqual(self.sphere.get_update_url(), expected_url)
+
+    def test_get_creation_url(self):
+        expected_url = "/characters/mage/create/sphere/"
+        self.assertEqual(Sphere.get_creation_url(), expected_url)
+
+    def test_get_heading(self):
+        self.assertEqual(self.sphere.get_heading(), "mta_heading")
+
+
+class TestSphereDetailView(TestCase):
+    def setUp(self):
+        self.sphere = Sphere.objects.create(
+            name="Forces",
+            property_name="forces",
+        )
+        self.url = self.sphere.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/sphere/detail.html")
+
+    def test_detail_view_context(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.context["object"], self.sphere)
+
+
+class TestSphereCreateView(TestCase):
+    def setUp(self):
+        self.valid_data = {
+            "name": "Entropy",
+            "property_name": "entropy",
+        }
+        self.url = Sphere.get_creation_url()
+
+    def test_create_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/sphere/form.html")
+
+    def test_create_view_successful_post(self):
+        response = self.client.post(self.url, data=self.valid_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Sphere.objects.count(), 1)
+        self.assertEqual(Sphere.objects.first().name, "Entropy")
+
+
+class TestSphereUpdateView(TestCase):
+    def setUp(self):
+        self.sphere = Sphere.objects.create(
+            name="Forces",
+            property_name="forces",
+        )
+        self.valid_data = {
+            "name": "Forces Updated",
+            "property_name": "forces",
+        }
+        self.url = self.sphere.get_update_url()
+
+    def test_update_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/sphere/form.html")
+
+    def test_update_view_successful_post(self):
+        response = self.client.post(self.url, data=self.valid_data)
+        self.assertEqual(response.status_code, 302)
+        self.sphere.refresh_from_db()
+        self.assertEqual(self.sphere.name, "Forces Updated")
+
+
+class TestSphereListView(TestCase):
+    def setUp(self):
+        self.sphere1 = Sphere.objects.create(name="Correspondence", property_name="correspondence")
+        self.sphere2 = Sphere.objects.create(name="Entropy", property_name="entropy")
+        self.sphere3 = Sphere.objects.create(name="Forces", property_name="forces")
+        self.url = "/characters/mage/list/spheres/"
+
+    def test_list_view_status_code(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mage/sphere/list.html")
+
+    def test_list_view_context(self):
+        response = self.client.get(self.url)
+        self.assertEqual(len(response.context["object_list"]), 3)
+
+    def test_list_view_ordering(self):
+        response = self.client.get(self.url)
+        spheres = list(response.context["object_list"])
+        self.assertEqual(spheres[0].name, "Correspondence")
+        self.assertEqual(spheres[1].name, "Entropy")
+        self.assertEqual(spheres[2].name, "Forces")

--- a/characters/urls/mage/create.py
+++ b/characters/urls/mage/create.py
@@ -93,4 +93,9 @@ urls = [
         views.mage.CabalCreateView.as_view(),
         name="cabal",
     ),
+    path(
+        "sphere/",
+        views.mage.SphereCreateView.as_view(),
+        name="sphere",
+    ),
 ]

--- a/characters/urls/mage/detail.py
+++ b/characters/urls/mage/detail.py
@@ -62,4 +62,5 @@ urls = [
     path("paths/<pk>/", views.mage.PathDetailView.as_view(), name="path"),
     path("rituals/<pk>/", views.mage.RitualDetailView.as_view(), name="ritual"),
     path("advantages/<pk>/", views.mage.AdvantageDetailView.as_view(), name="advantage"),
+    path("sphere/<pk>/", views.mage.SphereDetailView.as_view(), name="sphere"),
 ]

--- a/characters/urls/mage/index.py
+++ b/characters/urls/mage/index.py
@@ -45,4 +45,5 @@ urls = [
     ),
     path("rotes/", views.mage.RoteListView.as_view(), name="rote"),
     path("cabal/", views.mage.CabalListView.as_view(), name="cabal"),
+    path("spheres/", views.mage.SphereListView.as_view(), name="sphere"),
 ]

--- a/characters/urls/mage/update.py
+++ b/characters/urls/mage/update.py
@@ -93,4 +93,9 @@ urls = [
         views.mage.CabalUpdateView.as_view(),
         name="cabal",
     ),
+    path(
+        "sphere/<pk>/",
+        views.mage.SphereUpdateView.as_view(),
+        name="sphere",
+    ),
 ]

--- a/characters/views/mage/__init__.py
+++ b/characters/views/mage/__init__.py
@@ -77,3 +77,9 @@ from .sorcerer import (
     SorcererDetailView,
     SorcererUpdateView,
 )
+from .sphere import (
+    SphereCreateView,
+    SphereDetailView,
+    SphereListView,
+    SphereUpdateView,
+)

--- a/characters/views/mage/sphere.py
+++ b/characters/views/mage/sphere.py
@@ -1,0 +1,30 @@
+from characters.models.mage import Sphere
+from core.mixins import MessageMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+
+
+class SphereDetailView(DetailView):
+    model = Sphere
+    template_name = "characters/mage/sphere/detail.html"
+
+
+class SphereCreateView(MessageMixin, CreateView):
+    model = Sphere
+    fields = ["name", "property_name"]
+    template_name = "characters/mage/sphere/form.html"
+    success_message = "Sphere created successfully."
+    error_message = "There was an error creating the Sphere."
+
+
+class SphereUpdateView(MessageMixin, UpdateView):
+    model = Sphere
+    fields = ["name", "property_name"]
+    template_name = "characters/mage/sphere/form.html"
+    success_message = "Sphere updated successfully."
+    error_message = "There was an error updating the Sphere."
+
+
+class SphereListView(ListView):
+    model = Sphere
+    ordering = ["name"]
+    template_name = "characters/mage/sphere/list.html"


### PR DESCRIPTION
## Summary

- Implement complete CRUD views for the Sphere reference model
- Add templates (list, detail, form) with proper tg-card styling
- Add comprehensive test coverage (18 tests)

## Changes

- **Model**: Updated `Sphere` with `get_absolute_url()`, `get_update_url()`, `get_creation_url()`, `get_heading()`, and Meta class
- **Views**: Created `SphereListView`, `SphereDetailView`, `SphereCreateView`, `SphereUpdateView`
- **Templates**: Added `list.html`, `detail.html`, `form.html` in `characters/templates/characters/mage/sphere/`
- **URLs**: Registered patterns in list/detail/create/update URL files
- **Tests**: Added 18 tests covering model methods and all CRUD views

## Test plan

- [x] Run `python manage.py test characters.tests.views.mage.test_sphere` - 18 tests pass
- [x] Run `python manage.py test characters.tests.views.mage` - all 77 tests pass
- [x] Run `python manage.py test characters.tests.models.mage` - all 178 tests pass

Fixes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)