### PR TITLE
Add comprehensive test coverage for item models

### DIFF
--- a/items/tests/models/changeling/test_dross.py
+++ b/items/tests/models/changeling/test_dross.py
@@ -1,5 +1,208 @@
-"""Tests for dross module."""
-
+"""Tests for Dross model."""
 from django.test import TestCase
+from items.models.changeling.dross import Dross
 
-# TODO: Move relevant tests from existing test files here
+
+class TestDross(TestCase):
+    """Test Dross model methods."""
+
+    def setUp(self):
+        self.dross = Dross.objects.create(
+            name="Test Dross",
+            quality="fine",
+            glamour_value=5,
+            physical_form="crystal",
+        )
+
+    def test_str_with_name(self):
+        """Test __str__ returns name with glamour value."""
+        expected = f"{self.dross.name} ({self.dross.glamour_value} Glamour)"
+        self.assertEqual(str(self.dross), expected)
+
+    def test_str_without_name(self):
+        """Test __str__ without name shows quality."""
+        dross = Dross.objects.create(quality="common", glamour_value=3)
+        # Need to clear the name to test fallback
+        Dross.objects.filter(pk=dross.pk).update(name="")
+        dross.refresh_from_db()
+        self.assertIn("Glamour", str(dross))
+
+    def test_get_quality_multiplier(self):
+        """Test get_quality_multiplier returns correct values."""
+        quality_multipliers = {
+            "ephemeral": 0.5,
+            "common": 1.0,
+            "fine": 2.0,
+            "exquisite": 4.0,
+            "legendary": 10.0,
+        }
+        for quality, expected in quality_multipliers.items():
+            dross = Dross.objects.create(name=f"{quality} dross", quality=quality)
+            self.assertEqual(dross.get_quality_multiplier(), expected)
+
+
+class TestDrossDefaults(TestCase):
+    """Test Dross default values."""
+
+    def test_quality_default(self):
+        """Test quality defaults to common."""
+        dross = Dross.objects.create(name="Default Quality")
+        self.assertEqual(dross.quality, "common")
+
+    def test_glamour_value_default(self):
+        """Test glamour_value defaults to 2."""
+        dross = Dross.objects.create(name="Default Glamour")
+        self.assertEqual(dross.glamour_value, 2)
+
+    def test_physical_form_default(self):
+        """Test physical_form defaults to crystal."""
+        dross = Dross.objects.create(name="Default Form")
+        self.assertEqual(dross.physical_form, "crystal")
+
+    def test_source_default(self):
+        """Test source defaults to natural."""
+        dross = Dross.objects.create(name="Default Source")
+        self.assertEqual(dross.source, "natural")
+
+    def test_is_stable_default(self):
+        """Test is_stable defaults to True."""
+        dross = Dross.objects.create(name="Default Stable")
+        self.assertTrue(dross.is_stable)
+
+    def test_is_consumable_default(self):
+        """Test is_consumable defaults to True."""
+        dross = Dross.objects.create(name="Default Consumable")
+        self.assertTrue(dross.is_consumable)
+
+
+class TestDrossQuality(TestCase):
+    """Test quality choices."""
+
+    def test_quality_choices(self):
+        """Test quality can be set to valid choices."""
+        valid_qualities = ["ephemeral", "common", "fine", "exquisite", "legendary"]
+        for quality in valid_qualities:
+            dross = Dross.objects.create(name=f"{quality} dross", quality=quality)
+            self.assertEqual(dross.quality, quality)
+
+
+class TestDrossPhysicalForm(TestCase):
+    """Test physical form choices."""
+
+    def test_physical_form_choices(self):
+        """Test physical_form can be set to valid choices."""
+        valid_forms = ["crystal", "liquid", "vapor", "object", "other"]
+        for form in valid_forms:
+            dross = Dross.objects.create(name=f"{form} dross", physical_form=form)
+            self.assertEqual(dross.physical_form, form)
+
+
+class TestDrossSource(TestCase):
+    """Test source choices."""
+
+    def test_source_choices(self):
+        """Test source can be set to valid choices."""
+        valid_sources = ["balefire", "dream", "art", "natural", "refined", "unknown"]
+        for source in valid_sources:
+            dross = Dross.objects.create(name=f"{source} dross", source=source)
+            self.assertEqual(dross.source, source)
+
+
+class TestDrossUrls(TestCase):
+    """Test URL methods for Dross."""
+
+    def setUp(self):
+        self.dross = Dross.objects.create(name="URL Test Dross")
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url generates correct URL."""
+        url = self.dross.get_absolute_url()
+        self.assertIn(str(self.dross.id), url)
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.dross.get_update_url()
+        self.assertIn(str(self.dross.id), url)
+        self.assertIn("dross", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Dross.get_creation_url()
+        self.assertIn("dross", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.dross.get_heading(), "ctd_heading")
+
+
+class TestDrossDetailView(TestCase):
+    """Test Dross detail view."""
+
+    def setUp(self):
+        self.dross = Dross.objects.create(name="Test Dross")
+        self.url = self.dross.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/changeling/dross/detail.html")
+
+
+class TestDrossCreateView(TestCase):
+    """Test Dross create view."""
+
+    def setUp(self):
+        self.url = Dross.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/changeling/dross/form.html")
+
+
+class TestDrossUpdateView(TestCase):
+    """Test Dross update view."""
+
+    def setUp(self):
+        self.dross = Dross.objects.create(name="Test Dross", description="Test")
+        self.url = self.dross.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/changeling/dross/form.html")
+
+
+class TestDrossOptionalFields(TestCase):
+    """Test optional text fields."""
+
+    def test_color_can_be_set(self):
+        """Test color can be set."""
+        dross = Dross.objects.create(name="Colored Dross", color="Iridescent blue")
+        self.assertEqual(dross.color, "Iridescent blue")
+
+    def test_resonance_can_be_set(self):
+        """Test resonance can be set."""
+        dross = Dross.objects.create(name="Resonant Dross", resonance="Joy")
+        self.assertEqual(dross.resonance, "Joy")
+
+    def test_restricted_to_can_be_set(self):
+        """Test restricted_to can be set."""
+        dross = Dross.objects.create(name="Restricted Dross", restricted_to="Sluagh only")
+        self.assertEqual(dross.restricted_to, "Sluagh only")

--- a/items/tests/models/changeling/test_treasure.py
+++ b/items/tests/models/changeling/test_treasure.py
@@ -1,5 +1,174 @@
-"""Tests for treasure module."""
-
+"""Tests for Treasure model."""
 from django.test import TestCase
+from items.models.changeling.treasure import Treasure
 
-# TODO: Move relevant tests from existing test files here
+
+class TestTreasure(TestCase):
+    """Test Treasure model methods."""
+
+    def setUp(self):
+        self.treasure = Treasure.objects.create(
+            name="Test Treasure",
+            rating=3,
+            treasure_type="talisman",
+        )
+
+    def test_str_with_name_and_rating(self):
+        """Test __str__ returns name with star rating."""
+        expected = f"{self.treasure.name} (★★★)"
+        self.assertEqual(str(self.treasure), expected)
+
+    def test_str_rating_1(self):
+        """Test __str__ with rating 1."""
+        treasure = Treasure.objects.create(name="One Star", rating=1)
+        self.assertEqual(str(treasure), "One Star (★)")
+
+    def test_str_rating_5(self):
+        """Test __str__ with rating 5."""
+        treasure = Treasure.objects.create(name="Five Star", rating=5)
+        self.assertEqual(str(treasure), "Five Star (★★★★★)")
+
+
+class TestTreasureDefaults(TestCase):
+    """Test Treasure default values."""
+
+    def test_rating_default(self):
+        """Test rating defaults to 1."""
+        treasure = Treasure.objects.create(name="Default Rating")
+        self.assertEqual(treasure.rating, 1)
+
+    def test_treasure_type_default(self):
+        """Test treasure_type defaults to empty string."""
+        treasure = Treasure.objects.create(name="Default Type")
+        self.assertEqual(treasure.treasure_type, "")
+
+    def test_permanence_default(self):
+        """Test permanence defaults to True."""
+        treasure = Treasure.objects.create(name="Default Permanence")
+        self.assertTrue(treasure.permanence)
+
+    def test_glamour_storage_default(self):
+        """Test glamour_storage defaults to 0."""
+        treasure = Treasure.objects.create(name="Default Glamour")
+        self.assertEqual(treasure.glamour_storage, 0)
+
+
+class TestTreasureType(TestCase):
+    """Test treasure type choices."""
+
+    def test_treasure_type_choices(self):
+        """Test treasure_type can be set to valid choices."""
+        valid_types = ["weapon", "armor", "talisman", "wonder", "other"]
+        for ttype in valid_types:
+            treasure = Treasure.objects.create(name=f"{ttype} treasure", treasure_type=ttype)
+            self.assertEqual(treasure.treasure_type, ttype)
+
+
+class TestTreasureUrls(TestCase):
+    """Test URL methods for Treasure."""
+
+    def setUp(self):
+        self.treasure = Treasure.objects.create(name="URL Test Treasure")
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.treasure.get_update_url()
+        self.assertIn(str(self.treasure.id), url)
+        self.assertIn("treasure", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Treasure.get_creation_url()
+        self.assertIn("treasure", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.treasure.get_heading(), "ctd_heading")
+
+
+class TestTreasureDetailView(TestCase):
+    """Test Treasure detail view."""
+
+    def setUp(self):
+        self.treasure = Treasure.objects.create(name="Test Treasure")
+        self.url = self.treasure.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/changeling/treasure/detail.html")
+
+
+class TestTreasureCreateView(TestCase):
+    """Test Treasure create view."""
+
+    def setUp(self):
+        self.url = Treasure.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/changeling/treasure/form.html")
+
+
+class TestTreasureUpdateView(TestCase):
+    """Test Treasure update view."""
+
+    def setUp(self):
+        self.treasure = Treasure.objects.create(name="Test Treasure", description="Test")
+        self.url = self.treasure.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/changeling/treasure/form.html")
+
+
+class TestTreasureEffects(TestCase):
+    """Test effects JSONField."""
+
+    def test_effects_default(self):
+        """Test effects defaults to empty list."""
+        treasure = Treasure.objects.create(name="Default Effects")
+        self.assertEqual(treasure.effects, [])
+
+    def test_effects_can_be_set(self):
+        """Test effects can be set to a list."""
+        effects_list = ["Flight", "Invisibility", "Telekinesis"]
+        treasure = Treasure.objects.create(name="With Effects", effects=effects_list)
+        self.assertEqual(treasure.effects, effects_list)
+
+
+class TestTreasureGlamour(TestCase):
+    """Test glamour-related properties."""
+
+    def test_glamour_storage_can_be_set(self):
+        """Test glamour_storage can be set."""
+        treasure = Treasure.objects.create(name="Glamour Storage", glamour_storage=25)
+        self.assertEqual(treasure.glamour_storage, 25)
+
+    def test_glamour_affinity_default(self):
+        """Test glamour_affinity defaults to empty string."""
+        treasure = Treasure.objects.create(name="Default Affinity")
+        self.assertEqual(treasure.glamour_affinity, "")
+
+    def test_glamour_affinity_can_be_set(self):
+        """Test glamour_affinity can be set."""
+        treasure = Treasure.objects.create(name="With Affinity", glamour_affinity="Joy")
+        self.assertEqual(treasure.glamour_affinity, "Joy")

--- a/items/tests/models/demon/test_relic.py
+++ b/items/tests/models/demon/test_relic.py
@@ -1,5 +1,188 @@
-"""Tests for relic module."""
-
+"""Tests for Demon Relic model."""
 from django.test import TestCase
+from items.models.demon.relic import Relic
 
-# TODO: Move relevant tests from existing test files here
+
+class TestRelic(TestCase):
+    """Test Relic model methods."""
+
+    def setUp(self):
+        self.relic = Relic.objects.create(
+            name="Test Relic",
+            relic_type="enhanced",
+            complexity=3,
+        )
+
+    def test_str(self):
+        """Test __str__ returns name with type display."""
+        expected = f"{self.relic.name} ({self.relic.get_relic_type_display()})"
+        self.assertEqual(str(self.relic), expected)
+
+    def test_set_complexity_valid(self):
+        """Test set_complexity with valid values."""
+        for complexity in range(1, 11):
+            result = self.relic.set_complexity(complexity)
+            self.assertTrue(result)
+            self.relic.refresh_from_db()
+            self.assertEqual(self.relic.complexity, complexity)
+
+    def test_set_complexity_invalid_low(self):
+        """Test set_complexity rejects values below 1."""
+        original = self.relic.complexity
+        result = self.relic.set_complexity(0)
+        self.assertFalse(result)
+        self.relic.refresh_from_db()
+        self.assertEqual(self.relic.complexity, original)
+
+    def test_set_complexity_invalid_high(self):
+        """Test set_complexity rejects values above 10."""
+        original = self.relic.complexity
+        result = self.relic.set_complexity(11)
+        self.assertFalse(result)
+        self.relic.refresh_from_db()
+        self.assertEqual(self.relic.complexity, original)
+
+    def test_has_complexity_true(self):
+        """Test has_complexity returns True when complexity > 0."""
+        self.assertTrue(self.relic.has_complexity())
+
+    def test_has_complexity_false(self):
+        """Test has_complexity returns False when complexity is 0."""
+        relic = Relic.objects.create(name="No Complexity", complexity=0)
+        self.assertFalse(relic.has_complexity())
+
+    def test_set_difficulty_valid(self):
+        """Test set_difficulty with valid values."""
+        result = self.relic.set_difficulty(8)
+        self.assertTrue(result)
+        self.relic.refresh_from_db()
+        self.assertEqual(self.relic.difficulty, 8)
+
+    def test_set_difficulty_invalid(self):
+        """Test set_difficulty rejects values below 2."""
+        original = self.relic.difficulty
+        result = self.relic.set_difficulty(1)
+        self.assertFalse(result)
+        self.relic.refresh_from_db()
+        self.assertEqual(self.relic.difficulty, original)
+
+
+class TestRelicDefaults(TestCase):
+    """Test Relic default values."""
+
+    def test_relic_type_default(self):
+        """Test relic_type defaults to enhanced."""
+        relic = Relic.objects.create(name="Default Type")
+        self.assertEqual(relic.relic_type, "enhanced")
+
+    def test_complexity_default(self):
+        """Test complexity defaults to 1."""
+        relic = Relic.objects.create(name="Default Complexity")
+        self.assertEqual(relic.complexity, 1)
+
+    def test_difficulty_default(self):
+        """Test difficulty defaults to 6."""
+        relic = Relic.objects.create(name="Default Difficulty")
+        self.assertEqual(relic.difficulty, 6)
+
+    def test_is_permanent_default(self):
+        """Test is_permanent defaults to False."""
+        relic = Relic.objects.create(name="Default Permanent")
+        self.assertFalse(relic.is_permanent)
+
+    def test_dice_pool_default(self):
+        """Test dice_pool defaults to 0."""
+        relic = Relic.objects.create(name="Default Dice Pool")
+        self.assertEqual(relic.dice_pool, 0)
+
+
+class TestRelicType(TestCase):
+    """Test relic type choices."""
+
+    def test_relic_type_choices(self):
+        """Test relic_type can be set to valid choices."""
+        valid_types = ["enhanced", "enchanted", "house_specific", "demonic", "ancient"]
+        for rtype in valid_types:
+            relic = Relic.objects.create(name=f"{rtype} relic", relic_type=rtype)
+            self.assertEqual(relic.relic_type, rtype)
+
+
+class TestRelicUrls(TestCase):
+    """Test URL methods for Relic."""
+
+    def setUp(self):
+        self.relic = Relic.objects.create(name="URL Test Relic")
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url generates correct URL."""
+        url = self.relic.get_absolute_url()
+        self.assertIn(str(self.relic.pk), url)
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.relic.get_update_url()
+        self.assertIn(str(self.relic.id), url)
+        self.assertIn("relic", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Relic.get_creation_url()
+        self.assertIn("relic", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.relic.get_heading(), "dtf_heading")
+
+
+class TestRelicDetailView(TestCase):
+    """Test Relic detail view."""
+
+    def setUp(self):
+        self.relic = Relic.objects.create(name="Test Relic")
+        self.url = self.relic.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/demon/relic/detail.html")
+
+
+class TestRelicCreateView(TestCase):
+    """Test Relic create view."""
+
+    def setUp(self):
+        self.url = Relic.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/demon/relic/form.html")
+
+
+class TestRelicUpdateView(TestCase):
+    """Test Relic update view."""
+
+    def setUp(self):
+        self.relic = Relic.objects.create(name="Test Relic", description="Test")
+        self.url = self.relic.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/demon/relic/form.html")

--- a/items/tests/models/mage/test_periapt.py
+++ b/items/tests/models/mage/test_periapt.py
@@ -1,5 +1,223 @@
-"""Tests for periapt module."""
-
+"""Tests for Periapt model."""
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
+from items.models.mage.periapt import Periapt
 
-# TODO: Move relevant tests from existing test files here
+
+class TestPeriapt(TestCase):
+    """Test Periapt model methods."""
+
+    def setUp(self):
+        self.periapt = Periapt.objects.create(
+            name="Test Periapt",
+            max_charges=5,
+            current_charges=3,
+        )
+
+    def test_set_power(self):
+        """Test setting a power on a periapt."""
+        from characters.models.mage.effect import Effect
+
+        effect = Effect.objects.create(name="Test Effect")
+        self.assertFalse(self.periapt.has_power())
+        self.assertTrue(self.periapt.set_power(effect))
+        self.assertEqual(self.periapt.power, effect)
+
+    def test_has_power(self):
+        """Test checking if periapt has a power."""
+        from characters.models.mage.effect import Effect
+
+        self.assertFalse(self.periapt.has_power())
+        effect = Effect.objects.create(name="Test Effect")
+        self.periapt.power = effect
+        self.periapt.save()
+        self.assertTrue(self.periapt.has_power())
+
+    def test_use_charge_success(self):
+        """Test using a charge successfully."""
+        initial_charges = self.periapt.current_charges
+        result = self.periapt.use_charge()
+        self.assertTrue(result)
+        self.periapt.refresh_from_db()
+        self.assertEqual(self.periapt.current_charges, initial_charges - 1)
+
+    def test_use_charge_when_empty(self):
+        """Test using a charge when periapt is empty."""
+        self.periapt.current_charges = 0
+        self.periapt.save()
+        result = self.periapt.use_charge()
+        self.assertFalse(result)
+        self.periapt.refresh_from_db()
+        self.assertEqual(self.periapt.current_charges, 0)
+
+    def test_recharge_normal(self):
+        """Test recharging the periapt."""
+        self.periapt.current_charges = 2
+        self.periapt.save()
+        result = self.periapt.recharge(2)
+        self.assertTrue(result)
+        self.periapt.refresh_from_db()
+        self.assertEqual(self.periapt.current_charges, 4)
+
+    def test_recharge_capped_at_max(self):
+        """Test recharging doesn't exceed max_charges."""
+        self.periapt.current_charges = 4
+        self.periapt.save()
+        result = self.periapt.recharge(5)
+        self.assertTrue(result)
+        self.periapt.refresh_from_db()
+        self.assertEqual(self.periapt.current_charges, self.periapt.max_charges)
+
+    def test_is_depleted_true(self):
+        """Test is_depleted returns True when charges are 0."""
+        self.periapt.current_charges = 0
+        self.periapt.save()
+        self.assertTrue(self.periapt.is_depleted())
+
+    def test_is_depleted_false(self):
+        """Test is_depleted returns False when charges remain."""
+        self.assertFalse(self.periapt.is_depleted())
+
+    def test_charges_remaining(self):
+        """Test charges_remaining returns current charges."""
+        self.assertEqual(self.periapt.charges_remaining(), 3)
+
+
+class TestPeriaptUrls(TestCase):
+    """Test URL methods for Periapt."""
+
+    def setUp(self):
+        self.periapt = Periapt.objects.create(name="URL Test Periapt")
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.periapt.get_update_url()
+        self.assertIn(str(self.periapt.id), url)
+        self.assertIn("periapt", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Periapt.get_creation_url()
+        self.assertIn("periapt", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.periapt.get_heading(), "mta_heading")
+
+
+class TestPeriaptDetailView(TestCase):
+    """Test Periapt detail view."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.periapt = Periapt.objects.create(
+            name="Test Periapt",
+            owner=self.user,
+            status="App",
+        )
+        self.url = self.periapt.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200 for logged in user."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mage/periapt/detail.html")
+
+
+class TestPeriaptCreateView(TestCase):
+    """Test Periapt create view."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.url = Periapt.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mage/periapt/form.html")
+
+
+class TestPeriaptUpdateView(TestCase):
+    """Test Periapt update view."""
+
+    def setUp(self):
+        self.st = User.objects.create_user(username="st_user", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.periapt = Periapt.objects.create(
+            name="Test Periapt",
+            description="Test description",
+            owner=self.st,
+            chronicle=self.chronicle,
+            status="App",
+        )
+        self.url = self.periapt.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200 for ST."""
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mage/periapt/form.html")
+
+
+class TestPeriaptConsumable(TestCase):
+    """Test consumable behavior for Periapt."""
+
+    def test_is_consumable_default_true(self):
+        """Test is_consumable defaults to True."""
+        periapt = Periapt.objects.create(name="Consumable Periapt")
+        self.assertTrue(periapt.is_consumable)
+
+    def test_is_consumable_can_be_false(self):
+        """Test is_consumable can be set to False."""
+        periapt = Periapt.objects.create(name="Permanent Periapt", is_consumable=False)
+        self.assertFalse(periapt.is_consumable)
+
+
+class TestPeriaptChargeManagement(TestCase):
+    """Test charge management edge cases."""
+
+    def test_use_all_charges(self):
+        """Test using all charges sequentially."""
+        periapt = Periapt.objects.create(name="Test", max_charges=3, current_charges=3)
+        self.assertTrue(periapt.use_charge())
+        self.assertTrue(periapt.use_charge())
+        self.assertTrue(periapt.use_charge())
+        self.assertFalse(periapt.use_charge())
+        periapt.refresh_from_db()
+        self.assertEqual(periapt.current_charges, 0)
+
+    def test_recharge_from_empty(self):
+        """Test recharging from empty state."""
+        periapt = Periapt.objects.create(name="Test", max_charges=5, current_charges=0)
+        periapt.recharge(3)
+        periapt.refresh_from_db()
+        self.assertEqual(periapt.current_charges, 3)
+
+    def test_recharge_default_amount(self):
+        """Test recharge with default amount of 1."""
+        periapt = Periapt.objects.create(name="Test", max_charges=5, current_charges=2)
+        periapt.recharge()
+        periapt.refresh_from_db()
+        self.assertEqual(periapt.current_charges, 3)

--- a/items/tests/models/mummy/test_relic.py
+++ b/items/tests/models/mummy/test_relic.py
@@ -1,5 +1,202 @@
-"""Tests for relic module."""
-
+"""Tests for MummyRelic model."""
 from django.test import TestCase
+from items.models.mummy.relic import MummyRelic, RelicResonanceRating
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMummyRelic(TestCase):
+    """Test MummyRelic model methods."""
+
+    def setUp(self):
+        self.relic = MummyRelic.objects.create(
+            name="Test Relic",
+            rank=3,
+            relic_type="jewelry",
+            ba_cost=2,
+        )
+
+    def test_save_auto_sets_background_cost(self):
+        """Test save() auto-sets background_cost to rank if not set."""
+        relic = MummyRelic.objects.create(name="Background Test", rank=4)
+        self.assertEqual(relic.background_cost, 4)
+
+
+class TestMummyRelicType(TestCase):
+    """Test relic type choices."""
+
+    def test_relic_type_default(self):
+        """Test default relic_type is jewelry."""
+        relic = MummyRelic.objects.create(name="Default Type")
+        self.assertEqual(relic.relic_type, "jewelry")
+
+    def test_relic_type_choices(self):
+        """Test relic_type can be set to valid choices."""
+        valid_types = ["weapon", "jewelry", "scroll", "canopic", "statue", "crown", "tool", "clothing", "other"]
+        for rtype in valid_types:
+            relic = MummyRelic.objects.create(name=f"{rtype} relic", relic_type=rtype)
+            self.assertEqual(relic.relic_type, rtype)
+
+
+class TestMummyRelicEra(TestCase):
+    """Test era choices."""
+
+    def test_era_default(self):
+        """Test default era is old_kingdom."""
+        relic = MummyRelic.objects.create(name="Default Era")
+        self.assertEqual(relic.era, "old_kingdom")
+
+    def test_era_choices(self):
+        """Test era can be set to valid choices."""
+        valid_eras = ["predynastic", "old_kingdom", "middle_kingdom", "new_kingdom", "late_period", "ptolemaic", "unknown"]
+        for era in valid_eras:
+            relic = MummyRelic.objects.create(name=f"{era} relic", era=era)
+            self.assertEqual(relic.era, era)
+
+
+class TestMummyRelicProperties(TestCase):
+    """Test relic boolean properties."""
+
+    def test_is_cursed_default(self):
+        """Test is_cursed defaults to False."""
+        relic = MummyRelic.objects.create(name="Not Cursed")
+        self.assertFalse(relic.is_cursed)
+
+    def test_is_unique_default(self):
+        """Test is_unique defaults to False."""
+        relic = MummyRelic.objects.create(name="Not Unique")
+        self.assertFalse(relic.is_unique)
+
+    def test_is_sentient_default(self):
+        """Test is_sentient defaults to False."""
+        relic = MummyRelic.objects.create(name="Not Sentient")
+        self.assertFalse(relic.is_sentient)
+
+    def test_requires_ritual_default(self):
+        """Test requires_ritual defaults to False."""
+        relic = MummyRelic.objects.create(name="No Ritual")
+        self.assertFalse(relic.requires_ritual)
+
+
+class TestMummyRelicUrls(TestCase):
+    """Test URL methods for MummyRelic."""
+
+    def setUp(self):
+        self.relic = MummyRelic.objects.create(name="URL Test Relic")
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url generates correct URL."""
+        url = self.relic.get_absolute_url()
+        self.assertIn(str(self.relic.id), url)
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.relic.get_update_url()
+        self.assertIn(str(self.relic.pk), url)
+        self.assertIn("relic", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = MummyRelic.get_creation_url()
+        self.assertIn("relic", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.relic.get_heading(), "mtr_heading")
+
+
+class TestMummyRelicDetailView(TestCase):
+    """Test MummyRelic detail view."""
+
+    def setUp(self):
+        self.relic = MummyRelic.objects.create(name="Test Relic")
+        self.url = self.relic.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/relic/detail.html")
+
+
+class TestMummyRelicCreateView(TestCase):
+    """Test MummyRelic create view."""
+
+    def setUp(self):
+        self.url = MummyRelic.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/relic/form.html")
+
+
+class TestMummyRelicUpdateView(TestCase):
+    """Test MummyRelic update view."""
+
+    def setUp(self):
+        self.relic = MummyRelic.objects.create(name="Test Relic", description="Test")
+        self.url = self.relic.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/relic/form.html")
+
+
+class TestMummyRelicCosts(TestCase):
+    """Test Ba and Sekhem cost properties."""
+
+    def test_ba_cost_default(self):
+        """Test ba_cost defaults to 0."""
+        relic = MummyRelic.objects.create(name="No BA Cost")
+        self.assertEqual(relic.ba_cost, 0)
+
+    def test_requires_sekhem_default(self):
+        """Test requires_sekhem defaults to 0."""
+        relic = MummyRelic.objects.create(name="No Sekhem Requirement")
+        self.assertEqual(relic.requires_sekhem, 0)
+
+
+class TestRelicResonanceRating(TestCase):
+    """Test RelicResonanceRating through model."""
+
+    def test_relic_resonance_rating_creation(self):
+        """Test creating a RelicResonanceRating."""
+        from characters.models.mage.resonance import Resonance
+
+        relic = MummyRelic.objects.create(name="Resonance Test Relic")
+        resonance = Resonance.objects.create(name="Test Resonance")
+        rating = RelicResonanceRating.objects.create(
+            relic=relic,
+            resonance=resonance,
+            rating=3,
+        )
+        self.assertEqual(rating.relic, relic)
+        self.assertEqual(rating.resonance, resonance)
+        self.assertEqual(rating.rating, 3)
+
+    def test_relic_resonance_unique_together(self):
+        """Test unique_together constraint on relic+resonance."""
+        from characters.models.mage.resonance import Resonance
+        from django.db import IntegrityError
+
+        relic = MummyRelic.objects.create(name="Unique Test Relic")
+        resonance = Resonance.objects.create(name="Unique Resonance")
+        RelicResonanceRating.objects.create(relic=relic, resonance=resonance, rating=2)
+
+        with self.assertRaises(IntegrityError):
+            RelicResonanceRating.objects.create(relic=relic, resonance=resonance, rating=3)

--- a/items/tests/models/mummy/test_ushabti.py
+++ b/items/tests/models/mummy/test_ushabti.py
@@ -1,5 +1,209 @@
-"""Tests for ushabti module."""
-
+"""Tests for Ushabti model."""
 from django.test import TestCase
+from items.models.mummy.ushabti import Ushabti
 
-# TODO: Move relevant tests from existing test files here
+
+class TestUshabti(TestCase):
+    """Test Ushabti model methods."""
+
+    def setUp(self):
+        self.ushabti = Ushabti.objects.create(
+            name="Test Ushabti",
+            rank=3,
+            purpose="guardian",
+            physical_rating=3,
+            mental_rating=2,
+        )
+
+    def test_save_auto_sets_ba_to_animate(self):
+        """Test save() auto-sets ba_to_animate to rank."""
+        ushabti = Ushabti.objects.create(name="Auto BA Test", rank=4)
+        self.assertEqual(ushabti.ba_to_animate, 4)
+
+    def test_save_auto_sets_ba_per_day(self):
+        """Test save() auto-sets ba_per_day to rank."""
+        ushabti = Ushabti.objects.create(name="Auto BA Per Day Test", rank=5)
+        self.assertEqual(ushabti.ba_per_day, 5)
+
+
+class TestUshabtiDeactivate(TestCase):
+    """Test deactivate method."""
+
+    def test_deactivate(self):
+        """Test deactivate sets is_currently_animated to False."""
+        ushabti = Ushabti.objects.create(name="Deactivate Test", is_currently_animated=True)
+        ushabti.deactivate()
+        ushabti.refresh_from_db()
+        self.assertFalse(ushabti.is_currently_animated)
+
+    def test_deactivate_when_already_inactive(self):
+        """Test deactivate when already inactive."""
+        ushabti = Ushabti.objects.create(name="Already Inactive", is_currently_animated=False)
+        ushabti.deactivate()
+        ushabti.refresh_from_db()
+        self.assertFalse(ushabti.is_currently_animated)
+
+
+class TestUshabtiPurpose(TestCase):
+    """Test purpose choices."""
+
+    def test_purpose_default(self):
+        """Test default purpose is servant."""
+        ushabti = Ushabti.objects.create(name="Default Purpose")
+        self.assertEqual(ushabti.purpose, "servant")
+
+    def test_purpose_choices(self):
+        """Test purpose can be set to valid choices."""
+        valid_purposes = ["guardian", "servant", "laborer", "spy", "messenger", "craftsman", "scribe"]
+        for purpose in valid_purposes:
+            ushabti = Ushabti.objects.create(name=f"{purpose} ushabti", purpose=purpose)
+            self.assertEqual(ushabti.purpose, purpose)
+
+
+class TestUshabtiMaterial(TestCase):
+    """Test material choices."""
+
+    def test_material_default(self):
+        """Test default material is clay."""
+        ushabti = Ushabti.objects.create(name="Default Material")
+        self.assertEqual(ushabti.material, "clay")
+
+    def test_material_choices(self):
+        """Test material can be set to valid choices."""
+        valid_materials = ["clay", "wood", "stone", "gold", "bone", "wax"]
+        for material in valid_materials:
+            ushabti = Ushabti.objects.create(name=f"{material} ushabti", material=material)
+            self.assertEqual(ushabti.material, material)
+
+
+class TestUshabtiProperties(TestCase):
+    """Test Ushabti boolean properties."""
+
+    def test_is_currently_animated_default(self):
+        """Test is_currently_animated defaults to False."""
+        ushabti = Ushabti.objects.create(name="Not Animated")
+        self.assertFalse(ushabti.is_currently_animated)
+
+    def test_obeys_only_creator_default(self):
+        """Test obeys_only_creator defaults to True."""
+        ushabti = Ushabti.objects.create(name="Obeys Creator")
+        self.assertTrue(ushabti.obeys_only_creator)
+
+
+class TestUshabtiUrls(TestCase):
+    """Test URL methods for Ushabti."""
+
+    def setUp(self):
+        self.ushabti = Ushabti.objects.create(name="URL Test Ushabti")
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url generates correct URL."""
+        url = self.ushabti.get_absolute_url()
+        self.assertIn(str(self.ushabti.id), url)
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.ushabti.get_update_url()
+        self.assertIn(str(self.ushabti.pk), url)
+        self.assertIn("ushabti", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Ushabti.get_creation_url()
+        self.assertIn("ushabti", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.ushabti.get_heading(), "mtr_heading")
+
+
+class TestUshabtiDetailView(TestCase):
+    """Test Ushabti detail view."""
+
+    def setUp(self):
+        self.ushabti = Ushabti.objects.create(name="Test Ushabti")
+        self.url = self.ushabti.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/ushabti/detail.html")
+
+
+class TestUshabtiCreateView(TestCase):
+    """Test Ushabti create view."""
+
+    def setUp(self):
+        self.url = Ushabti.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/ushabti/form.html")
+
+
+class TestUshabtiUpdateView(TestCase):
+    """Test Ushabti update view."""
+
+    def setUp(self):
+        self.ushabti = Ushabti.objects.create(name="Test Ushabti", description="Test")
+        self.url = self.ushabti.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/ushabti/form.html")
+
+
+class TestUshabtiRatings(TestCase):
+    """Test physical and mental ratings."""
+
+    def test_physical_rating_default(self):
+        """Test physical_rating defaults to 1."""
+        ushabti = Ushabti.objects.create(name="Physical Default")
+        self.assertEqual(ushabti.physical_rating, 1)
+
+    def test_mental_rating_default(self):
+        """Test mental_rating defaults to 1."""
+        ushabti = Ushabti.objects.create(name="Mental Default")
+        self.assertEqual(ushabti.mental_rating, 1)
+
+    def test_ratings_can_be_set(self):
+        """Test ratings can be set to valid values."""
+        ushabti = Ushabti.objects.create(
+            name="Custom Ratings",
+            physical_rating=4,
+            mental_rating=3,
+        )
+        self.assertEqual(ushabti.physical_rating, 4)
+        self.assertEqual(ushabti.mental_rating, 3)
+
+
+class TestUshabtiAnimationProperties(TestCase):
+    """Test animation-related properties."""
+
+    def test_animation_duration_default(self):
+        """Test animation_duration_hours defaults to 24."""
+        ushabti = Ushabti.objects.create(name="Duration Default")
+        self.assertEqual(ushabti.animation_duration_hours, 24)
+
+    def test_size_description_default(self):
+        """Test size_description has default value."""
+        ushabti = Ushabti.objects.create(name="Size Default")
+        self.assertEqual(ushabti.size_description, "Small statuette")

--- a/items/tests/models/mummy/test_vessel.py
+++ b/items/tests/models/mummy/test_vessel.py
@@ -1,5 +1,259 @@
-"""Tests for vessel module."""
-
+"""Tests for Vessel model."""
 from django.test import TestCase
+from items.models.mummy.vessel import Vessel
 
-# TODO: Move relevant tests from existing test files here
+
+class TestVessel(TestCase):
+    """Test Vessel model methods."""
+
+    def setUp(self):
+        self.vessel = Vessel.objects.create(
+            name="Test Vessel",
+            rank=3,
+            current_ba=20,
+            transfer_rate=2,
+            efficiency=90,
+        )
+
+    def test_save_auto_calculates_max_ba(self):
+        """Test save() auto-calculates max_ba from rank."""
+        vessel = Vessel.objects.create(name="Rank Test", rank=5)
+        self.assertEqual(vessel.max_ba, 50)  # rank * 10
+
+    def test_save_auto_sets_background_cost(self):
+        """Test save() auto-sets background_cost to rank."""
+        vessel = Vessel.objects.create(name="Background Test", rank=4)
+        self.assertEqual(vessel.background_cost, 4)
+
+    def test_save_clamps_current_ba_to_max(self):
+        """Test save() ensures current_ba doesn't exceed max_ba."""
+        vessel = Vessel.objects.create(name="Clamp Test", rank=2, current_ba=100)
+        self.assertEqual(vessel.current_ba, 20)  # max_ba = rank * 10 = 20
+
+
+class TestVesselStoreBa(TestCase):
+    """Test store_ba method."""
+
+    def test_store_ba_basic(self):
+        """Test storing Ba in vessel."""
+        vessel = Vessel.objects.create(name="Test", rank=3, current_ba=10, transfer_rate=5, efficiency=100)
+        stored = vessel.store_ba(3)
+        self.assertEqual(stored, 3)
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 13)
+
+    def test_store_ba_limited_by_transfer_rate(self):
+        """Test store_ba is limited by transfer_rate."""
+        vessel = Vessel.objects.create(name="Test", rank=5, current_ba=0, transfer_rate=2, efficiency=100)
+        stored = vessel.store_ba(10)
+        self.assertEqual(stored, 2)  # Limited by transfer_rate
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 2)
+
+    def test_store_ba_limited_by_space(self):
+        """Test store_ba is limited by available space."""
+        vessel = Vessel.objects.create(name="Test", rank=2, current_ba=18, transfer_rate=5, efficiency=100)
+        # max_ba = 20, current = 18, space = 2
+        stored = vessel.store_ba(5)
+        self.assertEqual(stored, 2)
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 20)
+
+    def test_store_ba_applies_efficiency(self):
+        """Test store_ba applies efficiency percentage."""
+        vessel = Vessel.objects.create(name="Test", rank=5, current_ba=0, transfer_rate=10, efficiency=50)
+        stored = vessel.store_ba(10)
+        self.assertEqual(stored, 5)  # 50% efficiency
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 5)
+
+
+class TestVesselWithdrawBa(TestCase):
+    """Test withdraw_ba method."""
+
+    def test_withdraw_ba_basic(self):
+        """Test withdrawing Ba from vessel."""
+        vessel = Vessel.objects.create(name="Test", rank=5, current_ba=30, transfer_rate=5)
+        withdrawn = vessel.withdraw_ba(3)
+        self.assertEqual(withdrawn, 3)
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 27)
+
+    def test_withdraw_ba_limited_by_transfer_rate(self):
+        """Test withdraw_ba is limited by transfer_rate."""
+        vessel = Vessel.objects.create(name="Test", rank=5, current_ba=30, transfer_rate=2)
+        withdrawn = vessel.withdraw_ba(10)
+        self.assertEqual(withdrawn, 2)  # Limited by transfer_rate
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 28)
+
+    def test_withdraw_ba_limited_by_current(self):
+        """Test withdraw_ba is limited by current Ba."""
+        vessel = Vessel.objects.create(name="Test", rank=5, current_ba=1, transfer_rate=10)
+        withdrawn = vessel.withdraw_ba(5)
+        self.assertEqual(withdrawn, 1)  # Limited by current_ba
+        vessel.refresh_from_db()
+        self.assertEqual(vessel.current_ba, 0)
+
+
+class TestVesselStatus(TestCase):
+    """Test vessel status methods."""
+
+    def test_is_full_true(self):
+        """Test is_full returns True when at max."""
+        vessel = Vessel.objects.create(name="Test", rank=2, current_ba=20)
+        self.assertTrue(vessel.is_full())
+
+    def test_is_full_false(self):
+        """Test is_full returns False when not at max."""
+        vessel = Vessel.objects.create(name="Test", rank=2, current_ba=10)
+        self.assertFalse(vessel.is_full())
+
+    def test_is_empty_true(self):
+        """Test is_empty returns True when Ba is 0."""
+        vessel = Vessel.objects.create(name="Test", rank=2, current_ba=0)
+        self.assertTrue(vessel.is_empty())
+
+    def test_is_empty_false(self):
+        """Test is_empty returns False when Ba remains."""
+        vessel = Vessel.objects.create(name="Test", rank=2, current_ba=5)
+        self.assertFalse(vessel.is_empty())
+
+
+class TestVesselCanUse(TestCase):
+    """Test can_use method."""
+
+    def test_can_use_not_attuned(self):
+        """Test any mummy can use non-attuned vessel."""
+        vessel = Vessel.objects.create(name="Test", rank=2, is_attuned=False)
+        # Mock mummy object
+        class MockMummy:
+            pass
+        self.assertTrue(vessel.can_use(MockMummy()))
+
+    def test_can_use_attuned_to_correct_mummy(self):
+        """Test attuned vessel can be used by attuned mummy."""
+        vessel = Vessel.objects.create(name="Test", rank=2, is_attuned=True, attuned_to=None)
+        class MockMummy:
+            pass
+        mock = MockMummy()
+        vessel.attuned_to = None  # Would be a real Mummy FK in practice
+        # Since attuned_to is None and is_attuned is True, can_use checks attuned_to != mummy
+        # This will fail because None != mock
+        self.assertFalse(vessel.can_use(mock))
+
+
+class TestVesselTypes(TestCase):
+    """Test vessel type choices."""
+
+    def test_vessel_type_default(self):
+        """Test default vessel type is canopic."""
+        vessel = Vessel.objects.create(name="Default Type")
+        self.assertEqual(vessel.vessel_type, "canopic")
+
+    def test_vessel_type_choices(self):
+        """Test vessel type can be set to valid choices."""
+        valid_types = ["canopic", "scarab", "ankh", "crystal", "urn", "statue", "cartouche", "other"]
+        for vtype in valid_types:
+            vessel = Vessel.objects.create(name=f"{vtype} vessel", vessel_type=vtype)
+            self.assertEqual(vessel.vessel_type, vtype)
+
+
+class TestVesselUrls(TestCase):
+    """Test URL methods for Vessel."""
+
+    def setUp(self):
+        self.vessel = Vessel.objects.create(name="URL Test Vessel")
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url generates correct URL."""
+        url = self.vessel.get_absolute_url()
+        self.assertIn(str(self.vessel.id), url)
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.vessel.get_update_url()
+        self.assertIn(str(self.vessel.pk), url)
+        self.assertIn("vessel", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Vessel.get_creation_url()
+        self.assertIn("vessel", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.vessel.get_heading(), "mtr_heading")
+
+
+class TestVesselDetailView(TestCase):
+    """Test Vessel detail view."""
+
+    def setUp(self):
+        self.vessel = Vessel.objects.create(name="Test Vessel")
+        self.url = self.vessel.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/vessel/detail.html")
+
+
+class TestVesselCreateView(TestCase):
+    """Test Vessel create view."""
+
+    def setUp(self):
+        self.url = Vessel.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/vessel/form.html")
+
+
+class TestVesselUpdateView(TestCase):
+    """Test Vessel update view."""
+
+    def setUp(self):
+        self.vessel = Vessel.objects.create(name="Test Vessel", description="Test")
+        self.url = self.vessel.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/mummy/vessel/form.html")
+
+
+class TestVesselProperties(TestCase):
+    """Test vessel boolean properties."""
+
+    def test_is_portable_default(self):
+        """Test is_portable defaults to True."""
+        vessel = Vessel.objects.create(name="Portable")
+        self.assertTrue(vessel.is_portable)
+
+    def test_requires_ritual_default(self):
+        """Test requires_ritual defaults to False."""
+        vessel = Vessel.objects.create(name="No Ritual")
+        self.assertFalse(vessel.requires_ritual)
+
+    def test_is_attuned_default(self):
+        """Test is_attuned defaults to False."""
+        vessel = Vessel.objects.create(name="Not Attuned")
+        self.assertFalse(vessel.is_attuned)

--- a/items/tests/models/vampire/test_bloodstone.py
+++ b/items/tests/models/vampire/test_bloodstone.py
@@ -1,5 +1,198 @@
-"""Tests for bloodstone module."""
-
+"""Tests for Bloodstone model."""
 from django.test import TestCase
+from items.models.vampire.bloodstone import Bloodstone
 
-# TODO: Move relevant tests from existing test files here
+
+class TestBloodstone(TestCase):
+    """Test Bloodstone model methods."""
+
+    def setUp(self):
+        self.bloodstone = Bloodstone.objects.create(
+            name="Test Bloodstone",
+            blood_stored=5,
+            max_blood=10,
+        )
+
+    def test_add_blood_success(self):
+        """Test adding blood within capacity."""
+        result = self.bloodstone.add_blood(3)
+        self.assertTrue(result)
+        self.assertEqual(self.bloodstone.blood_stored, 8)
+
+    def test_add_blood_to_max(self):
+        """Test adding blood up to max capacity."""
+        result = self.bloodstone.add_blood(5)
+        self.assertTrue(result)
+        self.assertEqual(self.bloodstone.blood_stored, 10)
+
+    def test_add_blood_exceeds_max(self):
+        """Test adding blood that exceeds max returns False."""
+        result = self.bloodstone.add_blood(10)
+        self.assertFalse(result)
+        self.assertEqual(self.bloodstone.blood_stored, 5)  # Unchanged
+
+    def test_add_blood_when_inactive(self):
+        """Test adding blood when bloodstone is inactive returns False."""
+        self.bloodstone.is_active = False
+        self.bloodstone.save()
+        result = self.bloodstone.add_blood(2)
+        self.assertFalse(result)
+        self.assertEqual(self.bloodstone.blood_stored, 5)
+
+    def test_remove_blood_success(self):
+        """Test removing blood successfully."""
+        result = self.bloodstone.remove_blood(3)
+        self.assertTrue(result)
+        self.assertEqual(self.bloodstone.blood_stored, 2)
+
+    def test_remove_blood_all(self):
+        """Test removing all blood."""
+        result = self.bloodstone.remove_blood(5)
+        self.assertTrue(result)
+        self.assertEqual(self.bloodstone.blood_stored, 0)
+
+    def test_remove_blood_exceeds_stored(self):
+        """Test removing more blood than stored returns False."""
+        result = self.bloodstone.remove_blood(10)
+        self.assertFalse(result)
+        self.assertEqual(self.bloodstone.blood_stored, 5)  # Unchanged
+
+    def test_remove_blood_when_inactive(self):
+        """Test removing blood when bloodstone is inactive returns False."""
+        self.bloodstone.is_active = False
+        self.bloodstone.save()
+        result = self.bloodstone.remove_blood(2)
+        self.assertFalse(result)
+        self.assertEqual(self.bloodstone.blood_stored, 5)
+
+
+class TestBloodstoneDefaults(TestCase):
+    """Test Bloodstone default values."""
+
+    def test_blood_stored_default(self):
+        """Test blood_stored defaults to 0."""
+        bloodstone = Bloodstone.objects.create(name="Default Blood")
+        self.assertEqual(bloodstone.blood_stored, 0)
+
+    def test_max_blood_default(self):
+        """Test max_blood defaults to 10."""
+        bloodstone = Bloodstone.objects.create(name="Default Max")
+        self.assertEqual(bloodstone.max_blood, 10)
+
+    def test_is_active_default(self):
+        """Test is_active defaults to True."""
+        bloodstone = Bloodstone.objects.create(name="Default Active")
+        self.assertTrue(bloodstone.is_active)
+
+    def test_created_by_generation_default(self):
+        """Test created_by_generation defaults to 13."""
+        bloodstone = Bloodstone.objects.create(name="Default Gen")
+        self.assertEqual(bloodstone.created_by_generation, 13)
+
+
+class TestBloodstoneUrls(TestCase):
+    """Test URL methods for Bloodstone."""
+
+    def setUp(self):
+        self.bloodstone = Bloodstone.objects.create(name="URL Test Bloodstone")
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.bloodstone.get_update_url()
+        self.assertIn(str(self.bloodstone.id), url)
+        self.assertIn("bloodstone", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Bloodstone.get_creation_url()
+        self.assertIn("bloodstone", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.bloodstone.get_heading(), "vtm_heading")
+
+
+class TestBloodstoneDetailView(TestCase):
+    """Test Bloodstone detail view."""
+
+    def setUp(self):
+        self.bloodstone = Bloodstone.objects.create(name="Test Bloodstone")
+        self.url = self.bloodstone.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/vampire/bloodstone/detail.html")
+
+
+class TestBloodstoneCreateView(TestCase):
+    """Test Bloodstone create view."""
+
+    def setUp(self):
+        self.url = Bloodstone.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/vampire/bloodstone/form.html")
+
+
+class TestBloodstoneUpdateView(TestCase):
+    """Test Bloodstone update view."""
+
+    def setUp(self):
+        self.bloodstone = Bloodstone.objects.create(name="Test Bloodstone", description="Test")
+        self.url = self.bloodstone.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/vampire/bloodstone/form.html")
+
+
+class TestBloodstoneEdgeCases(TestCase):
+    """Test edge cases for Bloodstone."""
+
+    def test_add_blood_zero(self):
+        """Test adding zero blood."""
+        bloodstone = Bloodstone.objects.create(name="Zero Add", blood_stored=5)
+        result = bloodstone.add_blood(0)
+        self.assertTrue(result)
+        self.assertEqual(bloodstone.blood_stored, 5)
+
+    def test_remove_blood_zero(self):
+        """Test removing zero blood."""
+        bloodstone = Bloodstone.objects.create(name="Zero Remove", blood_stored=5)
+        result = bloodstone.remove_blood(0)
+        self.assertTrue(result)
+        self.assertEqual(bloodstone.blood_stored, 5)
+
+    def test_add_blood_exactly_to_max(self):
+        """Test adding blood to exactly reach max."""
+        bloodstone = Bloodstone.objects.create(name="Exact Max", blood_stored=8, max_blood=10)
+        result = bloodstone.add_blood(2)
+        self.assertTrue(result)
+        self.assertEqual(bloodstone.blood_stored, 10)
+
+    def test_remove_all_blood(self):
+        """Test removing exactly all stored blood."""
+        bloodstone = Bloodstone.objects.create(name="Remove All", blood_stored=5)
+        result = bloodstone.remove_blood(5)
+        self.assertTrue(result)
+        self.assertEqual(bloodstone.blood_stored, 0)

--- a/items/tests/models/werewolf/test_talen.py
+++ b/items/tests/models/werewolf/test_talen.py
@@ -1,5 +1,162 @@
-"""Tests for talen module."""
-
+"""Tests for Talen model."""
 from django.test import TestCase
+from items.models.werewolf.talen import Talen
 
-# TODO: Move relevant tests from existing test files here
+
+class TestTalen(TestCase):
+    """Test Talen model methods."""
+
+    def setUp(self):
+        self.talen = Talen.objects.create(
+            name="Test Talen",
+            rank=2,
+            gnosis=3,
+            spirit="Fire Spirit",
+        )
+
+    def test_save_sets_background_cost_to_rank(self):
+        """Test save() sets background_cost equal to rank."""
+        talen = Talen.objects.create(name="Rank Test", rank=4)
+        self.assertEqual(talen.background_cost, 4)
+
+    def test_save_updates_background_cost_on_rank_change(self):
+        """Test background_cost updates when rank changes."""
+        self.talen.rank = 5
+        self.talen.save()
+        self.talen.refresh_from_db()
+        self.assertEqual(self.talen.background_cost, 5)
+
+
+class TestTalenDefaults(TestCase):
+    """Test Talen default values."""
+
+    def test_gnosis_default(self):
+        """Test gnosis defaults to 0."""
+        talen = Talen.objects.create(name="Default Gnosis")
+        self.assertEqual(talen.gnosis, 0)
+
+    def test_spirit_default(self):
+        """Test spirit defaults to empty string."""
+        talen = Talen.objects.create(name="Default Spirit")
+        self.assertEqual(talen.spirit, "")
+
+
+class TestTalenUrls(TestCase):
+    """Test URL methods for Talen."""
+
+    def setUp(self):
+        self.talen = Talen.objects.create(name="URL Test Talen")
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.talen.get_update_url()
+        self.assertIn(str(self.talen.id), url)
+        self.assertIn("talen", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = Talen.get_creation_url()
+        self.assertIn("talen", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.talen.get_heading(), "wta_heading")
+
+
+class TestTalenDetailView(TestCase):
+    """Test Talen detail view."""
+
+    def setUp(self):
+        self.talen = Talen.objects.create(name="Test Talen")
+        self.url = self.talen.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/werewolf/talen/detail.html")
+
+
+class TestTalenCreateView(TestCase):
+    """Test Talen create view."""
+
+    def setUp(self):
+        self.valid_data = {
+            "name": "Test Talen",
+            "rank": 2,
+            "background_cost": 2,
+            "quintessence_max": 2,
+            "description": "Test",
+            "gnosis": 2,
+            "spirit": "Test Spirit",
+        }
+        self.url = Talen.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/werewolf/talen/form.html")
+
+    def test_create_view_successful_post(self):
+        """Test create view POST creates talen."""
+        response = self.client.post(self.url, data=self.valid_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Talen.objects.count(), 1)
+
+
+class TestTalenUpdateView(TestCase):
+    """Test Talen update view."""
+
+    def setUp(self):
+        self.talen = Talen.objects.create(name="Test Talen", description="Test")
+        self.valid_data = {
+            "name": "Updated Talen",
+            "rank": 3,
+            "background_cost": 3,
+            "quintessence_max": 3,
+            "description": "Updated",
+            "gnosis": 3,
+            "spirit": "Updated Spirit",
+        }
+        self.url = self.talen.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/werewolf/talen/form.html")
+
+    def test_update_view_successful_post(self):
+        """Test update view POST updates talen."""
+        response = self.client.post(self.url, data=self.valid_data)
+        self.assertEqual(response.status_code, 302)
+        self.talen.refresh_from_db()
+        self.assertEqual(self.talen.name, "Updated Talen")
+
+
+class TestTalenInheritance(TestCase):
+    """Test Talen inherits from Wonder correctly."""
+
+    def test_talen_type(self):
+        """Test Talen has correct type."""
+        talen = Talen.objects.create(name="Type Test")
+        self.assertEqual(talen.type, "talen")
+
+    def test_talen_gameline(self):
+        """Test Talen has correct gameline."""
+        talen = Talen.objects.create(name="Gameline Test")
+        self.assertEqual(talen.gameline, "wta")

--- a/items/tests/models/wraith/test_artifact.py
+++ b/items/tests/models/wraith/test_artifact.py
@@ -1,5 +1,177 @@
-"""Tests for artifact module."""
-
+"""Tests for WraithArtifact model."""
 from django.test import TestCase
+from items.models.wraith.artifact import WraithArtifact
 
-# TODO: Move relevant tests from existing test files here
+
+class TestWraithArtifact(TestCase):
+    """Test WraithArtifact model methods."""
+
+    def setUp(self):
+        self.artifact = WraithArtifact.objects.create(
+            name="Test Wraith Artifact",
+            level=3,
+            artifact_type="soulforged",
+            material="soulsteel",
+        )
+
+    def test_save_sets_background_cost_to_level(self):
+        """Test save() sets background_cost equal to level."""
+        artifact = WraithArtifact.objects.create(name="Level Test", level=4)
+        self.assertEqual(artifact.background_cost, 4)
+
+    def test_set_level(self):
+        """Test set_level sets level and background_cost."""
+        result = self.artifact.set_level(5)
+        self.assertTrue(result)
+        self.assertEqual(self.artifact.level, 5)
+        self.assertEqual(self.artifact.background_cost, 5)
+
+    def test_has_level_true(self):
+        """Test has_level returns True when level > 0."""
+        self.assertTrue(self.artifact.has_level())
+
+    def test_has_level_false(self):
+        """Test has_level returns False when level is 0."""
+        artifact = WraithArtifact.objects.create(name="No Level", level=0)
+        self.assertFalse(artifact.has_level())
+
+
+class TestWraithArtifactDefaults(TestCase):
+    """Test WraithArtifact default values."""
+
+    def test_level_default(self):
+        """Test level defaults to 1."""
+        artifact = WraithArtifact.objects.create(name="Default Level")
+        self.assertEqual(artifact.level, 1)
+
+    def test_artifact_type_default(self):
+        """Test artifact_type defaults to soulforged."""
+        artifact = WraithArtifact.objects.create(name="Default Type")
+        self.assertEqual(artifact.artifact_type, "soulforged")
+
+    def test_material_default(self):
+        """Test material defaults to soulsteel."""
+        artifact = WraithArtifact.objects.create(name="Default Material")
+        self.assertEqual(artifact.material, "soulsteel")
+
+    def test_corpus_default(self):
+        """Test corpus defaults to 0."""
+        artifact = WraithArtifact.objects.create(name="Default Corpus")
+        self.assertEqual(artifact.corpus, 0)
+
+    def test_pathos_cost_default(self):
+        """Test pathos_cost defaults to 0."""
+        artifact = WraithArtifact.objects.create(name="Default Pathos")
+        self.assertEqual(artifact.pathos_cost, 0)
+
+
+class TestWraithArtifactType(TestCase):
+    """Test artifact type choices."""
+
+    def test_artifact_type_choices(self):
+        """Test artifact_type can be set to valid choices."""
+        valid_types = ["soulforged", "skin", "spectre", "other"]
+        for atype in valid_types:
+            artifact = WraithArtifact.objects.create(name=f"{atype} artifact", artifact_type=atype)
+            self.assertEqual(artifact.artifact_type, atype)
+
+
+class TestWraithArtifactMaterial(TestCase):
+    """Test material choices."""
+
+    def test_material_choices(self):
+        """Test material can be set to valid choices."""
+        valid_materials = ["soulsteel", "stygian_steel", "necropolis_steel", "ash_iron", "labyrinthine_adamas"]
+        for material in valid_materials:
+            artifact = WraithArtifact.objects.create(name=f"{material} artifact", material=material)
+            self.assertEqual(artifact.material, material)
+
+
+class TestWraithArtifactUrls(TestCase):
+    """Test URL methods for WraithArtifact."""
+
+    def setUp(self):
+        self.artifact = WraithArtifact.objects.create(name="URL Test Artifact")
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.artifact.get_update_url()
+        self.assertIn(str(self.artifact.id), url)
+        self.assertIn("artifact", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = WraithArtifact.get_creation_url()
+        self.assertIn("artifact", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.artifact.get_heading(), "wto_heading")
+
+
+class TestWraithArtifactDetailView(TestCase):
+    """Test WraithArtifact detail view."""
+
+    def setUp(self):
+        self.artifact = WraithArtifact.objects.create(name="Test Artifact")
+        self.url = self.artifact.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/wraith/artifact/detail.html")
+
+
+class TestWraithArtifactCreateView(TestCase):
+    """Test WraithArtifact create view."""
+
+    def setUp(self):
+        self.url = WraithArtifact.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/wraith/artifact/form.html")
+
+
+class TestWraithArtifactUpdateView(TestCase):
+    """Test WraithArtifact update view."""
+
+    def setUp(self):
+        self.artifact = WraithArtifact.objects.create(name="Test Artifact", description="Test")
+        self.url = self.artifact.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/wraith/artifact/form.html")
+
+
+class TestWraithArtifactProperties(TestCase):
+    """Test WraithArtifact specific properties."""
+
+    def test_type_is_artifact(self):
+        """Test type is 'artifact'."""
+        artifact = WraithArtifact.objects.create(name="Type Test")
+        self.assertEqual(artifact.type, "artifact")
+
+    def test_gameline_is_wto(self):
+        """Test gameline is 'wto'."""
+        artifact = WraithArtifact.objects.create(name="Gameline Test")
+        self.assertEqual(artifact.gameline, "wto")

--- a/items/tests/models/wraith/test_relic.py
+++ b/items/tests/models/wraith/test_relic.py
@@ -1,5 +1,155 @@
-"""Tests for relic module."""
-
+"""Tests for WraithRelic model."""
 from django.test import TestCase
+from items.models.wraith.relic import WraithRelic
 
-# TODO: Move relevant tests from existing test files here
+
+class TestWraithRelic(TestCase):
+    """Test WraithRelic model methods."""
+
+    def setUp(self):
+        self.relic = WraithRelic.objects.create(
+            name="Test Wraith Relic",
+            level=3,
+            rarity="uncommon",
+        )
+
+    def test_save_sets_background_cost_to_level(self):
+        """Test save() sets background_cost equal to level."""
+        relic = WraithRelic.objects.create(name="Level Test", level=4)
+        self.assertEqual(relic.background_cost, 4)
+
+    def test_set_level(self):
+        """Test set_level sets level and background_cost."""
+        result = self.relic.set_level(5)
+        self.assertTrue(result)
+        self.assertEqual(self.relic.level, 5)
+        self.assertEqual(self.relic.background_cost, 5)
+
+    def test_has_level_true(self):
+        """Test has_level returns True when level > 0."""
+        self.assertTrue(self.relic.has_level())
+
+    def test_has_level_false(self):
+        """Test has_level returns False when level is 0."""
+        relic = WraithRelic.objects.create(name="No Level", level=0)
+        self.assertFalse(relic.has_level())
+
+
+class TestWraithRelicDefaults(TestCase):
+    """Test WraithRelic default values."""
+
+    def test_level_default(self):
+        """Test level defaults to 1."""
+        relic = WraithRelic.objects.create(name="Default Level")
+        self.assertEqual(relic.level, 1)
+
+    def test_rarity_default(self):
+        """Test rarity defaults to common."""
+        relic = WraithRelic.objects.create(name="Default Rarity")
+        self.assertEqual(relic.rarity, "common")
+
+    def test_pathos_cost_default(self):
+        """Test pathos_cost defaults to 0."""
+        relic = WraithRelic.objects.create(name="Default Pathos")
+        self.assertEqual(relic.pathos_cost, 0)
+
+
+class TestWraithRelicRarity(TestCase):
+    """Test rarity choices."""
+
+    def test_rarity_choices(self):
+        """Test rarity can be set to valid choices."""
+        valid_rarities = ["common", "uncommon", "rare", "very_rare", "legendary"]
+        for rarity in valid_rarities:
+            relic = WraithRelic.objects.create(name=f"{rarity} relic", rarity=rarity)
+            self.assertEqual(relic.rarity, rarity)
+
+
+class TestWraithRelicUrls(TestCase):
+    """Test URL methods for WraithRelic."""
+
+    def setUp(self):
+        self.relic = WraithRelic.objects.create(name="URL Test Relic")
+
+    def test_get_update_url(self):
+        """Test get_update_url generates correct URL."""
+        url = self.relic.get_update_url()
+        self.assertIn(str(self.relic.id), url)
+        self.assertIn("relic", url)
+
+    def test_get_creation_url(self):
+        """Test get_creation_url generates correct URL."""
+        url = WraithRelic.get_creation_url()
+        self.assertIn("relic", url)
+        self.assertIn("create", url)
+
+    def test_get_heading(self):
+        """Test get_heading returns correct heading class."""
+        self.assertEqual(self.relic.get_heading(), "wto_heading")
+
+
+class TestWraithRelicDetailView(TestCase):
+    """Test WraithRelic detail view."""
+
+    def setUp(self):
+        self.relic = WraithRelic.objects.create(name="Test Relic")
+        self.url = self.relic.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/wraith/relic/detail.html")
+
+
+class TestWraithRelicCreateView(TestCase):
+    """Test WraithRelic create view."""
+
+    def setUp(self):
+        self.url = WraithRelic.get_creation_url()
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/wraith/relic/form.html")
+
+
+class TestWraithRelicUpdateView(TestCase):
+    """Test WraithRelic update view."""
+
+    def setUp(self):
+        self.relic = WraithRelic.objects.create(name="Test Relic", description="Test")
+        self.url = self.relic.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "items/wraith/relic/form.html")
+
+
+class TestWraithRelicProperties(TestCase):
+    """Test WraithRelic specific properties."""
+
+    def test_type_is_relic(self):
+        """Test type is 'relic'."""
+        relic = WraithRelic.objects.create(name="Type Test")
+        self.assertEqual(relic.type, "relic")
+
+    def test_gameline_is_wto(self):
+        """Test gameline is 'wto'."""
+        relic = WraithRelic.objects.create(name="Gameline Test")
+        self.assertEqual(relic.gameline, "wto")


### PR DESCRIPTION
Fixes #1234
Increase test coverage for items & equipment from 41-94% to 95%+

Added tests for:
- Mage: Periapt (charge management, power setting, URLs, views)
- Mummy: Vessel (Ba storage/withdrawal, attunement, URLs, views)
- Mummy: Ushabti (animation, purpose/material choices, URLs, views)
- Mummy: MummyRelic (type/era choices, properties, resonance, URLs, views)
- Vampire: Bloodstone (blood add/remove, active status, URLs, views)
- Changeling: Treasure (rating display, effects, glamour, URLs, views)
- Changeling: Dross (quality multiplier, forms, sources, URLs, views)
- Demon: Relic (complexity/difficulty setting, type choices, URLs, views)
- Werewolf: Talen (save behavior, inheritance, URLs, views)
- Wraith: WraithRelic (level setting, rarity choices, URLs, views)
- Wraith: WraithArtifact (level setting, type/material choices, URLs, views)