### PR TITLE
Add comprehensive tests for Hunter and Mummy character views

### DIFF
--- a/characters/tests/models/hunter/test_hunter.py
+++ b/characters/tests/models/hunter/test_hunter.py
@@ -267,6 +267,57 @@ class TestHunter(TestCase):
         """Test Hunter has correct freebie step."""
         self.assertEqual(Hunter.freebie_step, 7)
 
+    def test_spend_xp_on_edge(self):
+        """Test XP spending on edges."""
+        # Set an edge value
+        self.hunter.discern = 2
+        self.hunter.save()
+
+        # Spend XP on edge should return correct result
+        result = self.hunter.spend_xp("discern")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["cost"], 9)  # (2+1) * 3 = 9
+        self.assertEqual(result["trait"], "discern")
+
+    def test_spend_xp_on_all_edge_types(self):
+        """Test XP spending works for all edge types."""
+        # Test conviction edges
+        conviction_edges = [
+            "discern", "burden", "balance", "expose",
+            "investigate", "witness", "prosecute",
+        ]
+        for edge in conviction_edges:
+            setattr(self.hunter, edge, 1)
+            self.hunter.save()
+            result = self.hunter.spend_xp(edge)
+            self.assertTrue(result["success"], f"Failed for edge: {edge}")
+            self.assertEqual(result["cost"], 6, f"Wrong cost for edge: {edge}")  # (1+1) * 3
+
+        # Test vision edges
+        vision_edges = [
+            "illuminate", "ward", "cleave", "hide",
+            "blaze", "radiate", "vengeance",
+        ]
+        for edge in vision_edges:
+            setattr(self.hunter, edge, 2)
+            self.hunter.save()
+            result = self.hunter.spend_xp(edge)
+            self.assertTrue(result["success"], f"Failed for edge: {edge}")
+            self.assertEqual(result["cost"], 9, f"Wrong cost for edge: {edge}")  # (2+1) * 3
+
+        # Test zeal edges
+        zeal_edges = [
+            "demand", "confront", "donate", "becalm",
+            "respire", "rejuvenate", "redeem",
+        ]
+        for edge in zeal_edges:
+            setattr(self.hunter, edge, 0)
+            self.hunter.save()
+            result = self.hunter.spend_xp(edge)
+            self.assertTrue(result["success"], f"Failed for edge: {edge}")
+            self.assertEqual(result["cost"], 3, f"Wrong cost for edge: {edge}")  # (0+1) * 3
+
 
 class TestHtRHuman(TestCase):
     """Tests for the HtRHuman model (mortal with Hunter abilities)."""

--- a/characters/tests/views/hunter/test_htrhuman.py
+++ b/characters/tests/views/hunter/test_htrhuman.py
@@ -1,5 +1,133 @@
-"""Tests for htrhuman module."""
+"""Tests for HtRHuman views."""
 
+from characters.forms.core.limited_edit import LimitedHtRHumanEditForm
+from characters.models.hunter import HtRHuman
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestHtRHumanDetailView(TestCase):
+    """Test the HtRHuman detail view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.human = HtRHuman.objects.create(name="Test Human", owner=self.player)
+        self.url = self.human.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Owner can view their own character."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Detail view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/htrhuman/detail.html")
+
+
+class TestHtRHumanCreateView(TestCase):
+    """Test the HtRHuman create view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.url = reverse("characters:hunter:create:htrhuman")
+
+    def test_create_view_status_code(self):
+        """Logged in user can access create view."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Create view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/htrhuman/form.html")
+
+    def test_create_view_url_resolves(self):
+        """Create view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/hunter/create/htrhuman/")
+
+
+class TestHtRHumanUpdateView(TestCase):
+    """Test the HtRHuman update view with permission checks."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.other_user = User.objects.create_user(username="other", password="password")
+        self.st = User.objects.create_user(username="st", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.human = HtRHuman.objects.create(
+            name="Test Human", owner=self.owner, chronicle=self.chronicle
+        )
+        self.url = reverse("characters:hunter:update:htrhuman", args=[self.human.id])
+
+    def test_st_can_access_update_view(self):
+        """ST should be able to access update view with full form."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("name", response.context["form"].fields)
+
+    def test_owner_gets_limited_form(self):
+        """Owner should get limited form when character is approved."""
+        self.human.status = "App"  # Approved status
+        self.human.save()
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        # Limited form should be used
+        self.assertIsInstance(response.context["form"], LimitedHtRHumanEditForm)
+
+    def test_other_user_cannot_access(self):
+        """Non-owner/non-ST should not be able to access update view."""
+        self.client.login(username="other", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_update_view_template(self):
+        """Update view uses correct template."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/htrhuman/form.html")
+
+
+class TestHtRHumanListView(TestCase):
+    """Test the HtRHuman list view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.url = reverse("characters:hunter:list:htrhuman")
+
+    def test_list_url_resolves(self):
+        """List view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/hunter/list/htrhuman/")
+
+    def test_list_view_status_code(self):
+        """List view is accessible."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """List view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/htrhuman/list.html")
+
+    def test_list_view_queryset_ordering(self):
+        """List view orders by name and includes related objects."""
+        HtRHuman.objects.create(name="Zebra Human", owner=self.player)
+        HtRHuman.objects.create(name="Alpha Human", owner=self.player)
+
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        humans = list(response.context["humans"])
+        self.assertEqual(humans[0].name, "Alpha Human")
+        self.assertEqual(humans[1].name, "Zebra Human")

--- a/characters/tests/views/hunter/test_hunter.py
+++ b/characters/tests/views/hunter/test_hunter.py
@@ -1,5 +1,157 @@
-"""Tests for hunter module."""
+"""Tests for Hunter views."""
 
+from characters.forms.core.limited_edit import LimitedHunterEditForm
+from characters.models.hunter import Hunter
+from characters.models.hunter.creed import Creed
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestHunterDetailView(TestCase):
+    """Test the Hunter detail view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.creed = Creed.objects.create(name="Avenger", primary_virtue="zeal")
+        self.hunter = Hunter.objects.create(
+            name="Test Hunter",
+            owner=self.player,
+            creed=self.creed,
+            discern=2,
+            illuminate=1,
+        )
+        self.url = self.hunter.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Owner can view their own character."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Detail view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/hunter/detail.html")
+
+    def test_detail_view_edges_context(self):
+        """Detail view includes edges in context."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        self.assertIn("edges", response.context)
+        edges = response.context["edges"]
+        self.assertEqual(edges["conviction"]["discern"], 2)
+        self.assertEqual(edges["vision"]["illuminate"], 1)
+        self.assertEqual(edges["zeal"], {})  # No zeal edges set
+
+
+class TestHunterCreateView(TestCase):
+    """Test the Hunter create view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.url = reverse("characters:hunter:create:hunter")
+
+    def test_create_view_status_code(self):
+        """Logged in user can access create view."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Create view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/hunter/form.html")
+
+    def test_create_view_url_resolves(self):
+        """Create view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/hunter/create/hunter/")
+
+
+class TestHunterUpdateView(TestCase):
+    """Test the Hunter update view with permission checks."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.other_user = User.objects.create_user(username="other", password="password")
+        self.st = User.objects.create_user(username="st", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.hunter = Hunter.objects.create(
+            name="Test Hunter", owner=self.owner, chronicle=self.chronicle
+        )
+        self.url = reverse("characters:hunter:update:hunter", args=[self.hunter.id])
+
+    def test_st_can_access_update_view(self):
+        """ST should be able to access update view with full form."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("name", response.context["form"].fields)
+
+    def test_owner_gets_limited_form(self):
+        """Owner should get limited form when character is approved."""
+        self.hunter.status = "App"  # Approved status
+        self.hunter.save()
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        # Limited form should be used
+        self.assertIsInstance(response.context["form"], LimitedHunterEditForm)
+
+    def test_other_user_cannot_access(self):
+        """Non-owner/non-ST should not be able to access update view."""
+        self.client.login(username="other", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_update_view_template(self):
+        """Update view uses correct template."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/hunter/form.html")
+
+
+class TestHunterListView(TestCase):
+    """Test the Hunter list view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.creed = Creed.objects.create(name="Judge", primary_virtue="conviction")
+        self.url = reverse("characters:hunter:list:hunter")
+
+    def test_list_url_resolves(self):
+        """List view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/hunter/list/hunter/")
+
+    def test_list_view_status_code(self):
+        """List view is accessible."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """List view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/hunter/hunter/list.html")
+
+    def test_list_view_queryset_ordering(self):
+        """List view orders by name and includes related objects."""
+        Hunter.objects.create(
+            name="Zebra Hunter", owner=self.player, creed=self.creed
+        )
+        Hunter.objects.create(
+            name="Alpha Hunter", owner=self.player, creed=self.creed
+        )
+
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        hunters = list(response.context["hunters"])
+        self.assertEqual(hunters[0].name, "Alpha Hunter")
+        self.assertEqual(hunters[1].name, "Zebra Hunter")

--- a/characters/tests/views/mummy/test_dynasty.py
+++ b/characters/tests/views/mummy/test_dynasty.py
@@ -1,5 +1,117 @@
-"""Tests for dynasty module."""
+"""Tests for Dynasty views."""
 
+from characters.models.mummy.dynasty import Dynasty
 from django.test import TestCase
+from django.urls import reverse
 
-# TODO: Move relevant tests from existing test files here
+
+class TestDynastyDetailView(TestCase):
+    """Test the Dynasty detail view."""
+
+    def setUp(self):
+        self.dynasty = Dynasty.objects.create(
+            name="Test Dynasty",
+            era="Middle Kingdom",
+            description="A test dynasty",
+        )
+        self.url = self.dynasty.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Dynasty detail view is publicly accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/dynasty/detail.html")
+
+
+class TestDynastyCreateView(TestCase):
+    """Test the Dynasty create view."""
+
+    def setUp(self):
+        self.url = reverse("characters:mummy:create:dynasty")
+
+    def test_create_view_status_code(self):
+        """Create view is accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/dynasty/form.html")
+
+    def test_create_view_url_resolves(self):
+        """Create view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/create/dynasty/")
+
+    def test_create_view_success_url(self):
+        """Create view redirects to dynasty detail after successful creation."""
+        response = self.client.post(
+            self.url,
+            data={
+                "name": "New Dynasty",
+                "era": "New Kingdom",
+                "description": "A newly created dynasty",
+                "favored_hekau": "alchemy",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        dynasty = Dynasty.objects.get(name="New Dynasty")
+        self.assertEqual(response.redirect_chain[-1][0], dynasty.get_absolute_url())
+
+
+class TestDynastyUpdateView(TestCase):
+    """Test the Dynasty update view."""
+
+    def setUp(self):
+        self.dynasty = Dynasty.objects.create(
+            name="Test Dynasty",
+            era="Middle Kingdom",
+        )
+        self.url = reverse("characters:mummy:update:dynasty", args=[self.dynasty.id])
+
+    def test_update_view_status_code(self):
+        """Update view is accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/dynasty/form.html")
+
+
+class TestDynastyListView(TestCase):
+    """Test the Dynasty list view."""
+
+    def setUp(self):
+        self.url = reverse("characters:mummy:list:dynasty")
+
+    def test_list_url_resolves(self):
+        """List view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/list/dynasty/")
+
+    def test_list_view_status_code(self):
+        """List view is accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """List view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/dynasty/list.html")
+
+    def test_list_view_queryset_ordering(self):
+        """List view orders by name."""
+        Dynasty.objects.create(name="Zebra Dynasty")
+        Dynasty.objects.create(name="Alpha Dynasty")
+
+        response = self.client.get(self.url)
+
+        dynasties = list(response.context["dynasty_list"])
+        self.assertEqual(dynasties[0].name, "Alpha Dynasty")
+        self.assertEqual(dynasties[1].name, "Zebra Dynasty")

--- a/characters/tests/views/mummy/test_mtr_human.py
+++ b/characters/tests/views/mummy/test_mtr_human.py
@@ -1,5 +1,139 @@
-"""Tests for mtr_human module."""
+"""Tests for MtRHuman views."""
 
+from characters.forms.core.limited_edit import LimitedMtRHumanEditForm
+from characters.models.mummy.mtr_human import MtRHuman
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMtRHumanDetailView(TestCase):
+    """Test the MtRHuman detail view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.human = MtRHuman.objects.create(name="Test Human", owner=self.player)
+        self.url = self.human.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Owner can view their own character."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Detail view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mtrhuman/detail.html")
+
+
+class TestMtRHumanCreateView(TestCase):
+    """Test the MtRHuman create view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.url = reverse("characters:mummy:create:mtrhuman")
+
+    def test_create_view_status_code(self):
+        """Logged in user can access create view."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Create view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mtrhuman/form.html")
+
+    def test_create_view_form_has_user(self):
+        """Create view passes user to form."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.context["form"].user, self.player)
+
+    def test_create_view_url_resolves(self):
+        """Create view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/create/mtrhuman/")
+
+
+class TestMtRHumanUpdateView(TestCase):
+    """Test the MtRHuman update view with permission checks."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.other_user = User.objects.create_user(username="other", password="password")
+        self.st = User.objects.create_user(username="st", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.human = MtRHuman.objects.create(
+            name="Test Human", owner=self.owner, chronicle=self.chronicle
+        )
+        self.url = reverse("characters:mummy:update:mtrhuman", args=[self.human.id])
+
+    def test_st_can_access_update_view(self):
+        """ST should be able to access update view with full form."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("name", response.context["form"].fields)
+
+    def test_owner_gets_limited_form(self):
+        """Owner should get limited form when character is approved."""
+        self.human.status = "App"  # Approved status
+        self.human.save()
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        # Limited form should be used
+        self.assertIsInstance(response.context["form"], LimitedMtRHumanEditForm)
+
+    def test_other_user_cannot_access(self):
+        """Non-owner/non-ST should not be able to access update view."""
+        self.client.login(username="other", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_update_view_template(self):
+        """Update view uses correct template."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mtrhuman/form.html")
+
+
+class TestMtRHumanListView(TestCase):
+    """Test the MtRHuman list view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.url = reverse("characters:mummy:list:mtrhuman")
+
+    def test_list_url_resolves(self):
+        """List view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/list/mtrhuman/")
+
+    def test_list_view_status_code(self):
+        """List view is accessible."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """List view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mtrhuman/list.html")
+
+    def test_list_view_queryset_ordering(self):
+        """List view orders by name and includes related objects."""
+        MtRHuman.objects.create(name="Zebra Human", owner=self.player)
+        MtRHuman.objects.create(name="Alpha Human", owner=self.player)
+
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        humans = list(response.context["humans"])
+        self.assertEqual(humans[0].name, "Alpha Human")
+        self.assertEqual(humans[1].name, "Zebra Human")

--- a/characters/tests/views/mummy/test_mummy.py
+++ b/characters/tests/views/mummy/test_mummy.py
@@ -1,5 +1,184 @@
-"""Tests for mummy module."""
+"""Tests for Mummy views."""
 
+from characters.forms.core.limited_edit import LimitedMummyEditForm
+from characters.models.mummy.dynasty import Dynasty
+from characters.models.mummy.mummy import Mummy
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
+from game.models import Chronicle
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMummyDetailView(TestCase):
+    """Test the Mummy detail view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.dynasty = Dynasty.objects.create(
+            name="Test Dynasty", era="Middle Kingdom"
+        )
+        self.mummy = Mummy.objects.create(
+            name="Test Mummy",
+            owner=self.player,
+            dynasty=self.dynasty,
+            alchemy=3,
+            necromancy=2,
+        )
+        self.url = self.mummy.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Owner can view their own character."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Detail view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mummy/detail.html")
+
+    def test_detail_view_hekau_context(self):
+        """Detail view includes hekau in context."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        self.assertIn("hekau", response.context)
+        hekau = response.context["hekau"]
+        self.assertEqual(hekau["Alchemy"], 3)
+        self.assertEqual(hekau["Necromancy"], 2)
+        self.assertNotIn("Celestial", hekau)  # No celestial set
+
+    def test_detail_view_dynasty_context(self):
+        """Detail view includes dynasty in context."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        self.assertIn("dynasty", response.context)
+        self.assertEqual(response.context["dynasty"], self.dynasty)
+
+    def test_detail_view_without_dynasty(self):
+        """Detail view works without a dynasty."""
+        mummy_no_dynasty = Mummy.objects.create(
+            name="No Dynasty Mummy",
+            owner=self.player,
+        )
+        self.client.login(username="Player", password="password")
+        response = self.client.get(mummy_no_dynasty.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("dynasty", response.context)
+
+
+class TestMummyCreateView(TestCase):
+    """Test the Mummy create view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.url = reverse("characters:mummy:create:mummy")
+
+    def test_create_view_status_code(self):
+        """Logged in user can access create view."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Create view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mummy/form.html")
+
+    def test_create_view_form_has_user(self):
+        """Create view passes user to form."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.context["form"].user, self.player)
+
+    def test_create_view_url_resolves(self):
+        """Create view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/create/mummy/")
+
+
+class TestMummyUpdateView(TestCase):
+    """Test the Mummy update view with permission checks."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.other_user = User.objects.create_user(username="other", password="password")
+        self.st = User.objects.create_user(username="st", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.mummy = Mummy.objects.create(
+            name="Test Mummy", owner=self.owner, chronicle=self.chronicle
+        )
+        self.url = reverse("characters:mummy:update:mummy", args=[self.mummy.id])
+
+    def test_st_can_access_update_view(self):
+        """ST should be able to access update view with full form."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("name", response.context["form"].fields)
+
+    def test_owner_gets_limited_form(self):
+        """Owner should get limited form when character is approved."""
+        self.mummy.status = "App"  # Approved status
+        self.mummy.save()
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        # Limited form should be used
+        self.assertIsInstance(response.context["form"], LimitedMummyEditForm)
+
+    def test_other_user_cannot_access(self):
+        """Non-owner/non-ST should not be able to access update view."""
+        self.client.login(username="other", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_update_view_template(self):
+        """Update view uses correct template."""
+        self.client.login(username="st", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mummy/form.html")
+
+
+class TestMummyListView(TestCase):
+    """Test the Mummy list view."""
+
+    def setUp(self):
+        self.player = User.objects.create_user(username="Player", password="password")
+        self.dynasty = Dynasty.objects.create(name="Test Dynasty")
+        self.url = reverse("characters:mummy:list:mummy")
+
+    def test_list_url_resolves(self):
+        """List view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/list/mummy/")
+
+    def test_list_view_status_code(self):
+        """List view is accessible."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """List view uses correct template."""
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/mummy/list.html")
+
+    def test_list_view_queryset_ordering(self):
+        """List view orders by name and includes related objects."""
+        Mummy.objects.create(
+            name="Zebra Mummy", owner=self.player, dynasty=self.dynasty
+        )
+        Mummy.objects.create(
+            name="Alpha Mummy", owner=self.player, dynasty=self.dynasty
+        )
+
+        self.client.login(username="Player", password="password")
+        response = self.client.get(self.url)
+
+        mummies = list(response.context["mummies"])
+        self.assertEqual(mummies[0].name, "Alpha Mummy")
+        self.assertEqual(mummies[1].name, "Zebra Mummy")

--- a/characters/tests/views/mummy/test_mummy_title.py
+++ b/characters/tests/views/mummy/test_mummy_title.py
@@ -1,5 +1,119 @@
-"""Tests for mummy_title module."""
+"""Tests for MummyTitle views."""
 
+from characters.models.mummy.mummy_title import MummyTitle
 from django.test import TestCase
+from django.urls import reverse
 
-# TODO: Move relevant tests from existing test files here
+
+class TestMummyTitleDetailView(TestCase):
+    """Test the MummyTitle detail view."""
+
+    def setUp(self):
+        self.title = MummyTitle.objects.create(
+            name="Test Title",
+            rank_level=3,
+            description="A test title",
+        )
+        self.url = self.title.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """MummyTitle detail view is publicly accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Detail view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/title/detail.html")
+
+
+class TestMummyTitleCreateView(TestCase):
+    """Test the MummyTitle create view."""
+
+    def setUp(self):
+        self.url = reverse("characters:mummy:create:title")
+
+    def test_create_view_status_code(self):
+        """Create view is accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Create view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/title/form.html")
+
+    def test_create_view_url_resolves(self):
+        """Create view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/create/title/")
+
+    def test_create_view_success_url(self):
+        """Create view redirects to title detail after successful creation."""
+        response = self.client.post(
+            self.url,
+            data={
+                "name": "New Title",
+                "rank_level": 5,
+                "description": "A newly created title",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        title = MummyTitle.objects.get(name="New Title")
+        self.assertEqual(response.redirect_chain[-1][0], title.get_absolute_url())
+
+
+class TestMummyTitleUpdateView(TestCase):
+    """Test the MummyTitle update view."""
+
+    def setUp(self):
+        self.title = MummyTitle.objects.create(
+            name="Test Title",
+            rank_level=3,
+        )
+        self.url = reverse("characters:mummy:update:title", args=[self.title.id])
+
+    def test_update_view_status_code(self):
+        """Update view is accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Update view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/title/form.html")
+
+
+class TestMummyTitleListView(TestCase):
+    """Test the MummyTitle list view."""
+
+    def setUp(self):
+        self.url = reverse("characters:mummy:list:title")
+
+    def test_list_url_resolves(self):
+        """List view URL should resolve correctly."""
+        self.assertEqual(self.url, "/characters/mummy/list/title/")
+
+    def test_list_view_status_code(self):
+        """List view is accessible."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """List view uses correct template."""
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "characters/mummy/title/list.html")
+
+    def test_list_view_queryset_ordering(self):
+        """List view orders by rank_level, then name."""
+        MummyTitle.objects.create(name="Zebra Title", rank_level=1)
+        MummyTitle.objects.create(name="Alpha Title", rank_level=3)
+        MummyTitle.objects.create(name="Beta Title", rank_level=1)
+
+        response = self.client.get(self.url)
+
+        titles = list(response.context["mummytitle_list"])
+        # Ordered by rank_level first, then name
+        self.assertEqual(titles[0].name, "Beta Title")  # rank 1
+        self.assertEqual(titles[1].name, "Zebra Title")  # rank 1
+        self.assertEqual(titles[2].name, "Alpha Title")  # rank 3


### PR DESCRIPTION
Improve test coverage for Hunter and Mummy gamelines to achieve 95%+ coverage:

Hunter tests:
- Add tests for spend_xp on edges (all edge types)
- Add HtRHuman view tests (detail, create, update with limited form, list)
- Add Hunter view tests (detail with edges context, create, update with limited form, list)

Mummy tests:
- Add Mummy view tests (detail with hekau/dynasty context, create, update, list)
- Add MtRHuman view tests (detail, create, update with limited form, list)
- Add Dynasty view tests (CRUD, get_success_url)
- Add MummyTitle view tests (CRUD, get_success_url)

Fixes #1237