### PR TITLE
Add comprehensive tests for core infrastructure (fixes #1235)

### DIFF
--- a/core/tests/middleware/test_approved_user.py
+++ b/core/tests/middleware/test_approved_user.py
@@ -1,5 +1,131 @@
-"""Tests for approved_user module."""
+"""Tests for approved_user middleware module."""
 
-from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser, User
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
 
-# TODO: Move relevant tests from existing test files here
+from core.middleware.approved_user import UserListMiddleware
+
+
+class UserListMiddlewareTest(TestCase):
+    """Tests for UserListMiddleware."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.regular_user = User.objects.create_user(
+            username="regular", email="regular@test.com", password="testpass123"
+        )
+        self.staff_user = User.objects.create_user(
+            username="staff", email="staff@test.com", password="testpass123", is_staff=True
+        )
+        self.response_content = "Test Response"
+        self.get_response = lambda r: HttpResponse(self.response_content)
+        self.middleware = UserListMiddleware(get_response=self.get_response)
+
+    def test_middleware_initialization(self):
+        """Test middleware initialization with get_response."""
+        get_response = lambda r: HttpResponse("OK")
+        middleware = UserListMiddleware(get_response=get_response)
+
+        self.assertEqual(middleware.get_response, get_response)
+
+    def test_sets_is_approved_user_true_for_authenticated_staff(self):
+        """Test that is_approved_user is True for authenticated staff user."""
+        request = self.factory.get("/")
+        request.user = self.staff_user
+
+        response = self.middleware(request)
+
+        self.assertTrue(request.is_approved_user)
+
+    def test_sets_is_approved_user_false_for_authenticated_non_staff(self):
+        """Test that is_approved_user is False for authenticated non-staff user."""
+        request = self.factory.get("/")
+        request.user = self.regular_user
+
+        response = self.middleware(request)
+
+        self.assertFalse(request.is_approved_user)
+
+    def test_sets_is_approved_user_false_for_anonymous_user(self):
+        """Test that is_approved_user is False for anonymous user."""
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        response = self.middleware(request)
+
+        self.assertFalse(request.is_approved_user)
+
+    def test_returns_response_from_get_response(self):
+        """Test that middleware returns the response from get_response."""
+        request = self.factory.get("/")
+        request.user = self.regular_user
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.content.decode(), self.response_content)
+
+    def test_calls_get_response_once(self):
+        """Test that middleware calls get_response exactly once."""
+        call_count = 0
+
+        def counting_get_response(request):
+            nonlocal call_count
+            call_count += 1
+            return HttpResponse("OK")
+
+        middleware = UserListMiddleware(get_response=counting_get_response)
+        request = self.factory.get("/")
+        request.user = self.regular_user
+
+        middleware(request)
+
+        self.assertEqual(call_count, 1)
+
+    def test_superuser_staff_is_approved(self):
+        """Test that superuser with staff status is approved."""
+        superuser = User.objects.create_superuser(
+            username="admin", email="admin@test.com", password="testpass123"
+        )
+        request = self.factory.get("/")
+        request.user = superuser
+
+        self.middleware(request)
+
+        self.assertTrue(request.is_approved_user)
+
+    def test_superuser_without_staff_is_not_approved(self):
+        """Test that superuser without staff status is not approved."""
+        # Create superuser and remove staff status
+        superuser = User.objects.create_superuser(
+            username="admin2", email="admin2@test.com", password="testpass123"
+        )
+        superuser.is_staff = False
+        superuser.save()
+
+        request = self.factory.get("/")
+        request.user = superuser
+
+        self.middleware(request)
+
+        self.assertFalse(request.is_approved_user)
+
+    def test_works_with_different_request_methods(self):
+        """Test that middleware works with different HTTP methods."""
+        methods = [
+            self.factory.get,
+            self.factory.post,
+            self.factory.put,
+            self.factory.patch,
+            self.factory.delete,
+        ]
+
+        for method in methods:
+            request = method("/")
+            request.user = self.staff_user
+
+            response = self.middleware(request)
+
+            self.assertTrue(request.is_approved_user)
+            self.assertEqual(response.status_code, 200)

--- a/core/tests/middleware/test_auth_error_handler.py
+++ b/core/tests/middleware/test_auth_error_handler.py
@@ -1,5 +1,196 @@
-"""Tests for auth_error_handler module."""
+"""Tests for auth_error_handler middleware module."""
 
-from django.test import TestCase
+from unittest.mock import patch, Mock
 
-# TODO: Move relevant tests from existing test files here
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse, HttpResponseRedirect
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
+
+from core.middleware.auth_error_handler import AuthErrorHandlerMiddleware
+
+
+class AuthErrorHandlerMiddlewareTest(TestCase):
+    """Tests for AuthErrorHandlerMiddleware."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="testpass123"
+        )
+        self.get_response = lambda r: HttpResponse("OK")
+        self.middleware = AuthErrorHandlerMiddleware(get_response=self.get_response)
+
+    def test_middleware_initialization(self):
+        """Test middleware initialization with get_response."""
+        get_response = lambda r: HttpResponse("OK")
+        middleware = AuthErrorHandlerMiddleware(get_response=get_response)
+
+        self.assertEqual(middleware.get_response, get_response)
+
+    def test_returns_normal_response_unchanged(self):
+        """Test that normal responses are returned unchanged."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode(), "OK")
+
+    def test_returns_non_redirect_response_unchanged(self):
+        """Test that non-redirect responses are returned unchanged."""
+        middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponse("Not Found", status=404)
+        )
+        request = self.factory.get("/")
+        request.user = self.user
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(LOGIN_URL="login")
+    def test_returns_401_when_redirecting_to_login_for_anonymous(self):
+        """Test that 401 is returned when anonymous user is redirected to login."""
+        login_url = reverse("login")
+        middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponseRedirect(login_url)
+        )
+        request = self.factory.get("/protected/")
+        request.user = AnonymousUser()
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    @override_settings(LOGIN_URL="login")
+    def test_returns_redirect_when_authenticated_user_redirected_to_login(self):
+        """Test that redirect is preserved when authenticated user is redirected to login."""
+        login_url = reverse("login")
+        middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponseRedirect(login_url)
+        )
+        request = self.factory.get("/")
+        request.user = self.user
+
+        response = middleware(request)
+
+        # Should return redirect since user is authenticated
+        self.assertIsInstance(response, HttpResponseRedirect)
+
+    @override_settings(LOGIN_URL="login")
+    def test_returns_redirect_when_redirecting_elsewhere(self):
+        """Test that redirects to non-login URLs are preserved."""
+        middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponseRedirect("/other/")
+        )
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        response = middleware(request)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response.url, "/other/")
+
+    def test_process_exception_handles_permission_denied(self):
+        """Test that process_exception returns 403 for PermissionDenied."""
+        request = self.factory.get("/")
+        request.user = self.user
+        exception = PermissionDenied("Access denied")
+
+        response = self.middleware.process_exception(request, exception)
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 403)
+
+    def test_process_exception_returns_none_for_other_exceptions(self):
+        """Test that process_exception returns None for non-PermissionDenied exceptions."""
+        request = self.factory.get("/")
+        request.user = self.user
+        exception = ValueError("Some error")
+
+        response = self.middleware.process_exception(request, exception)
+
+        self.assertIsNone(response)
+
+    def test_process_exception_returns_none_for_generic_exception(self):
+        """Test that process_exception returns None for generic Exception."""
+        request = self.factory.get("/")
+        request.user = self.user
+        exception = Exception("Generic error")
+
+        response = self.middleware.process_exception(request, exception)
+
+        self.assertIsNone(response)
+
+    def test_process_exception_returns_none_for_type_error(self):
+        """Test that process_exception returns None for TypeError."""
+        request = self.factory.get("/")
+        request.user = self.user
+        exception = TypeError("Type error")
+
+        response = self.middleware.process_exception(request, exception)
+
+        self.assertIsNone(response)
+
+    def test_middleware_with_anonymous_user_non_login_redirect(self):
+        """Test that anonymous user redirected elsewhere gets redirect response."""
+        middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponseRedirect("/dashboard/")
+        )
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        response = middleware(request)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+        self.assertEqual(response.url, "/dashboard/")
+
+
+@override_settings(LOGIN_URL="login")
+class AuthErrorHandlerMiddlewareLoginRedirectTest(TestCase):
+    """Tests specifically for login redirect behavior."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.login_url = reverse("login")
+        self.middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponseRedirect(self.login_url)
+        )
+
+    def test_anonymous_user_gets_401_on_login_redirect(self):
+        """Test that anonymous users get 401 on login redirect."""
+        request = self.factory.get("/protected/")
+        request.user = AnonymousUser()
+
+        response = self.middleware(request)
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_authenticated_user_preserves_login_redirect(self):
+        """Test that authenticated users preserve login redirects."""
+        user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="testpass123"
+        )
+        request = self.factory.get("/")
+        request.user = user
+
+        response = self.middleware(request)
+
+        self.assertIsInstance(response, HttpResponseRedirect)
+
+    def test_login_redirect_with_next_param_still_returns_401(self):
+        """Test that login redirect with next parameter still returns 401 for anonymous."""
+        middleware = AuthErrorHandlerMiddleware(
+            get_response=lambda r: HttpResponseRedirect(f"{self.login_url}?next=/dashboard/")
+        )
+        request = self.factory.get("/dashboard/")
+        request.user = AnonymousUser()
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 401)

--- a/core/tests/middleware/test_cache_middleware.py
+++ b/core/tests/middleware/test_cache_middleware.py
@@ -1,5 +1,181 @@
 """Tests for cache_middleware module."""
 
-from django.test import TestCase
+from django.contrib.auth.models import AnonymousUser, User
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase
+from django.utils.cache import patch_response_headers
 
-# TODO: Move relevant tests from existing test files here
+from core.middleware.cache_middleware import PerUserCacheMiddleware
+
+
+class PerUserCacheMiddlewareTest(TestCase):
+    """Tests for PerUserCacheMiddleware."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="testpass123"
+        )
+        self.middleware = PerUserCacheMiddleware(get_response=lambda r: HttpResponse("OK"))
+
+    def test_process_request_sets_cache_update_cache_flag(self):
+        """Test that process_request sets _cache_update_cache flag."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = self.middleware.process_request(request)
+
+        self.assertIsNone(result)
+        self.assertTrue(request._cache_update_cache)
+
+    def test_process_request_sets_user_prefix_for_authenticated_user(self):
+        """Test that process_request sets user-specific cache key prefix."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        self.middleware.process_request(request)
+
+        self.assertEqual(request._cache_key_prefix, f"user_{self.user.id}")
+
+    def test_process_request_sets_anonymous_prefix_for_unauthenticated_user(self):
+        """Test that process_request sets anonymous prefix for anonymous user."""
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        self.middleware.process_request(request)
+
+        self.assertEqual(request._cache_key_prefix, "anonymous")
+
+    def test_process_request_does_not_override_existing_cache_flag(self):
+        """Test that process_request doesn't override existing _cache_update_cache flag."""
+        request = self.factory.get("/")
+        request.user = self.user
+        request._cache_update_cache = False
+
+        self.middleware.process_request(request)
+
+        self.assertFalse(request._cache_update_cache)
+
+    def test_process_response_returns_response_for_non_get_request(self):
+        """Test that process_response returns response unchanged for non-GET requests."""
+        request = self.factory.post("/")
+        request.user = self.user
+        response = HttpResponse("OK", status=200)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+
+    def test_process_response_returns_response_for_head_request(self):
+        """Test that process_response returns response unchanged for HEAD requests with non-200 status."""
+        request = self.factory.head("/")
+        request.user = self.user
+        response = HttpResponse("Not Found", status=404)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+
+    def test_process_response_returns_response_for_non_200_status(self):
+        """Test that process_response returns response unchanged for non-200 status."""
+        request = self.factory.get("/")
+        request.user = self.user
+        response = HttpResponse("Error", status=500)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+
+    def test_process_response_returns_response_when_cache_update_false(self):
+        """Test that process_response returns response when _cache_update_cache is False."""
+        request = self.factory.get("/")
+        request.user = self.user
+        request._cache_update_cache = False
+        response = HttpResponse("OK", status=200)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+
+    def test_process_response_returns_response_when_no_cache_flag(self):
+        """Test that process_response returns response when _cache_update_cache not set."""
+        request = self.factory.get("/")
+        request.user = self.user
+        # Don't set _cache_update_cache
+        response = HttpResponse("OK", status=200)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+
+    def test_process_response_patches_headers_for_cacheable_get_request(self):
+        """Test that process_response patches cache headers for cacheable GET requests."""
+        request = self.factory.get("/")
+        request.user = self.user
+        request._cache_update_cache = True
+        response = HttpResponse("OK", status=200)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+        # Check that cache-control header was set
+        self.assertIn("Cache-Control", result)
+
+    def test_process_response_patches_headers_for_cacheable_head_request(self):
+        """Test that process_response patches cache headers for cacheable HEAD requests."""
+        request = self.factory.head("/")
+        request.user = self.user
+        request._cache_update_cache = True
+        response = HttpResponse("OK", status=200)
+
+        result = self.middleware.process_response(request, response)
+
+        self.assertEqual(result, response)
+        # Check that cache-control header was set
+        self.assertIn("Cache-Control", result)
+
+    def test_middleware_full_flow_authenticated_user(self):
+        """Test the full middleware flow for an authenticated user."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        # Process request
+        self.middleware.process_request(request)
+
+        # Create response
+        response = HttpResponse("OK", status=200)
+
+        # Process response
+        result = self.middleware.process_response(request, response)
+
+        # Verify flow
+        self.assertTrue(request._cache_update_cache)
+        self.assertEqual(request._cache_key_prefix, f"user_{self.user.id}")
+        self.assertIn("Cache-Control", result)
+
+    def test_middleware_full_flow_anonymous_user(self):
+        """Test the full middleware flow for an anonymous user."""
+        request = self.factory.get("/")
+        request.user = AnonymousUser()
+
+        # Process request
+        self.middleware.process_request(request)
+
+        # Create response
+        response = HttpResponse("OK", status=200)
+
+        # Process response
+        result = self.middleware.process_response(request, response)
+
+        # Verify flow
+        self.assertTrue(request._cache_update_cache)
+        self.assertEqual(request._cache_key_prefix, "anonymous")
+        self.assertIn("Cache-Control", result)
+
+    def test_middleware_initialization(self):
+        """Test middleware initialization with get_response."""
+        get_response = lambda r: HttpResponse("OK")
+        middleware = PerUserCacheMiddleware(get_response=get_response)
+
+        self.assertEqual(middleware.get_response, get_response)

--- a/core/tests/test_cache.py
+++ b/core/tests/test_cache.py
@@ -1,0 +1,480 @@
+"""Tests for cache utilities in core/cache.py."""
+
+from unittest.mock import Mock, patch, MagicMock
+
+from django.core.cache import cache
+from django.db.models import Model
+from django.test import TestCase, override_settings
+
+from core.cache import (
+    CACHE_TIMEOUT_DAY,
+    CACHE_TIMEOUT_LONG,
+    CACHE_TIMEOUT_MEDIUM,
+    CACHE_TIMEOUT_SHORT,
+    CACHE_TIMEOUT_VERY_LONG,
+    CacheInvalidator,
+    CacheKeyGenerator,
+    cache_function,
+    cache_queryset,
+    get_cached_queryset,
+    invalidate_cache_on_save,
+)
+
+
+class CacheKeyGeneratorTest(TestCase):
+    """Tests for CacheKeyGenerator class."""
+
+    def test_make_key_with_category_only(self):
+        """Test make_key with just a category."""
+        key = CacheKeyGenerator.make_key("queryset")
+        self.assertEqual(key, "tg:queryset")
+
+    def test_make_key_with_category_and_identifier(self):
+        """Test make_key with category and identifier."""
+        key = CacheKeyGenerator.make_key("queryset", "Character")
+        self.assertEqual(key, "tg:queryset:Character")
+
+    def test_make_key_with_params(self):
+        """Test make_key with additional parameters."""
+        key = CacheKeyGenerator.make_key("queryset", "Character", status="App")
+        self.assertEqual(key, "tg:queryset:Character:status=App")
+
+    def test_make_key_with_multiple_params(self):
+        """Test make_key with multiple parameters."""
+        key = CacheKeyGenerator.make_key("queryset", "Character", status="App", chronicle=1)
+        # Params should be sorted
+        self.assertIn("chronicle=1", key)
+        self.assertIn("status=App", key)
+        self.assertTrue(key.startswith("tg:queryset:Character:"))
+
+    def test_make_key_sorts_params_alphabetically(self):
+        """Test that make_key sorts parameters alphabetically."""
+        key = CacheKeyGenerator.make_key("queryset", "Character", zebra="1", alpha="2")
+        # alpha should come before zebra
+        self.assertIn("alpha=2", key)
+        self.assertIn("zebra=1", key)
+        alpha_idx = key.index("alpha")
+        zebra_idx = key.index("zebra")
+        self.assertLess(alpha_idx, zebra_idx)
+
+    def test_make_key_empty_identifier(self):
+        """Test make_key with empty identifier."""
+        key = CacheKeyGenerator.make_key("view", "", user_id=1)
+        self.assertEqual(key, "tg:view:user_id=1")
+
+    def test_make_model_key(self):
+        """Test make_model_key with a model class."""
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        key = CacheKeyGenerator.make_model_key(FakeModel)
+        self.assertEqual(key, "tg:queryset:FakeModel")
+
+    def test_make_model_key_with_params(self):
+        """Test make_model_key with parameters."""
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        key = CacheKeyGenerator.make_model_key(FakeModel, status="App")
+        self.assertEqual(key, "tg:queryset:FakeModel:status=App")
+
+    def test_make_view_key(self):
+        """Test make_view_key."""
+        key = CacheKeyGenerator.make_view_key("home")
+        self.assertEqual(key, "tg:view:home")
+
+    def test_make_view_key_with_params(self):
+        """Test make_view_key with parameters."""
+        key = CacheKeyGenerator.make_view_key("character_detail", pk=123)
+        self.assertEqual(key, "tg:view:character_detail:pk=123")
+
+    def test_make_template_key(self):
+        """Test make_template_key."""
+        key = CacheKeyGenerator.make_template_key("sidebar")
+        self.assertEqual(key, "tg:template:sidebar")
+
+    def test_make_template_key_with_params(self):
+        """Test make_template_key with parameters."""
+        key = CacheKeyGenerator.make_template_key("navigation", user_id=1)
+        self.assertEqual(key, "tg:template:navigation:user_id=1")
+
+    def test_prefix_constant(self):
+        """Test that PREFIX is correctly set."""
+        self.assertEqual(CacheKeyGenerator.PREFIX, "tg")
+
+
+class CacheInvalidatorTest(TestCase):
+    """Tests for CacheInvalidator class."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_invalidate_model_cache_with_delete_pattern(self):
+        """Test invalidate_model_cache with pattern deletion support."""
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        # Set some cache values
+        cache.set("tg:queryset:FakeModel:status=App", "value1")
+        cache.set("tg:queryset:FakeModel:status=Un", "value2")
+
+        with patch.object(cache, "delete_pattern") as mock_delete_pattern:
+            CacheInvalidator.invalidate_model_cache(FakeModel)
+            mock_delete_pattern.assert_called_once_with("tg:queryset:FakeModel:*")
+
+    def test_invalidate_model_cache_fallback_without_delete_pattern(self):
+        """Test invalidate_model_cache falls back when delete_pattern not supported."""
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        # Set a cache value
+        cache_key = CacheKeyGenerator.make_model_key(FakeModel)
+        cache.set(cache_key, "test_value")
+
+        # Mock delete_pattern to raise AttributeError
+        with patch.object(cache, "delete_pattern", side_effect=AttributeError):
+            with patch.object(cache, "delete") as mock_delete:
+                CacheInvalidator.invalidate_model_cache(FakeModel)
+                mock_delete.assert_called_once_with(cache_key)
+
+    def test_invalidate_related_caches(self):
+        """Test invalidate_related_caches calls invalidate_model_cache."""
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        instance = Mock(spec=FakeModel)
+        instance.__class__ = FakeModel
+
+        with patch.object(CacheInvalidator, "invalidate_model_cache") as mock_invalidate:
+            CacheInvalidator.invalidate_related_caches(instance)
+            mock_invalidate.assert_called_once_with(FakeModel)
+
+    def test_invalidate_related_caches_with_polymorphic_model(self):
+        """Test invalidate_related_caches handles polymorphic models."""
+
+        class BaseModel(Model):
+            class Meta:
+                app_label = "test"
+
+        class ChildModel(BaseModel):
+            class Meta:
+                app_label = "test"
+
+            def get_real_instance_class(self):
+                return ChildModel
+
+        instance = Mock(spec=ChildModel)
+        instance.__class__ = ChildModel
+        instance.get_real_instance_class = Mock(return_value=ChildModel)
+
+        with patch.object(CacheInvalidator, "invalidate_model_cache") as mock_invalidate:
+            CacheInvalidator.invalidate_related_caches(instance)
+            # Should be called for both ChildModel and BaseModel
+            self.assertEqual(mock_invalidate.call_count, 2)
+
+
+class CacheQuerysetDecoratorTest(TestCase):
+    """Tests for cache_queryset decorator."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_cache_queryset_caches_result(self):
+        """Test that cache_queryset caches the function result."""
+        call_count = 0
+
+        @cache_queryset(timeout=60)
+        def get_items():
+            nonlocal call_count
+            call_count += 1
+            return ["item1", "item2"]
+
+        # First call
+        result1 = get_items()
+        self.assertEqual(result1, ["item1", "item2"])
+        self.assertEqual(call_count, 1)
+
+        # Second call should use cache
+        result2 = get_items()
+        self.assertEqual(result2, ["item1", "item2"])
+        self.assertEqual(call_count, 1)  # Should not increase
+
+    def test_cache_queryset_with_key_prefix(self):
+        """Test cache_queryset with custom key prefix."""
+        @cache_queryset(timeout=60, key_prefix="characters")
+        def get_characters():
+            return ["char1", "char2"]
+
+        result = get_characters()
+        self.assertEqual(result, ["char1", "char2"])
+
+    def test_cache_queryset_with_args(self):
+        """Test cache_queryset with function arguments."""
+        call_count = 0
+
+        @cache_queryset(timeout=60)
+        def get_items_by_status(status):
+            nonlocal call_count
+            call_count += 1
+            return [f"item_{status}"]
+
+        # First call with "active"
+        result1 = get_items_by_status("active")
+        self.assertEqual(result1, ["item_active"])
+        self.assertEqual(call_count, 1)
+
+        # Call with "inactive" - different args, should not use cache
+        result2 = get_items_by_status("inactive")
+        self.assertEqual(result2, ["item_inactive"])
+        self.assertEqual(call_count, 2)
+
+        # Call again with "active" - should use cache
+        result3 = get_items_by_status("active")
+        self.assertEqual(result3, ["item_active"])
+        self.assertEqual(call_count, 2)
+
+    def test_cache_queryset_with_kwargs(self):
+        """Test cache_queryset with keyword arguments."""
+        call_count = 0
+
+        @cache_queryset(timeout=60)
+        def get_items(status=None, chronicle=None):
+            nonlocal call_count
+            call_count += 1
+            return [f"item_{status}_{chronicle}"]
+
+        result1 = get_items(status="active", chronicle=1)
+        self.assertEqual(call_count, 1)
+
+        result2 = get_items(status="active", chronicle=1)
+        self.assertEqual(call_count, 1)  # Should use cache
+
+        result3 = get_items(status="active", chronicle=2)
+        self.assertEqual(call_count, 2)  # Different kwargs
+
+    def test_cache_queryset_preserves_function_metadata(self):
+        """Test that cache_queryset preserves function metadata."""
+
+        @cache_queryset(timeout=60)
+        def my_function():
+            """My docstring."""
+            return []
+
+        self.assertEqual(my_function.__name__, "my_function")
+        self.assertEqual(my_function.__doc__, "My docstring.")
+
+
+class CacheFunctionDecoratorTest(TestCase):
+    """Tests for cache_function decorator."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_cache_function_caches_result(self):
+        """Test that cache_function caches the function result."""
+        call_count = 0
+
+        @cache_function(timeout=60)
+        def calculate_value(x):
+            nonlocal call_count
+            call_count += 1
+            return x * 2
+
+        result1 = calculate_value(5)
+        self.assertEqual(result1, 10)
+        self.assertEqual(call_count, 1)
+
+        result2 = calculate_value(5)
+        self.assertEqual(result2, 10)
+        self.assertEqual(call_count, 1)  # Should use cache
+
+    def test_cache_function_with_key_prefix(self):
+        """Test cache_function with custom key prefix."""
+
+        @cache_function(timeout=60, key_prefix="stats")
+        def calculate_stats():
+            return {"total": 100}
+
+        result = calculate_stats()
+        self.assertEqual(result, {"total": 100})
+
+    def test_cache_function_with_different_args(self):
+        """Test cache_function with different arguments."""
+        call_count = 0
+
+        @cache_function(timeout=60)
+        def multiply(a, b):
+            nonlocal call_count
+            call_count += 1
+            return a * b
+
+        result1 = multiply(2, 3)
+        self.assertEqual(result1, 6)
+        self.assertEqual(call_count, 1)
+
+        result2 = multiply(2, 4)
+        self.assertEqual(result2, 8)
+        self.assertEqual(call_count, 2)
+
+        result3 = multiply(2, 3)
+        self.assertEqual(result3, 6)
+        self.assertEqual(call_count, 2)
+
+    def test_cache_function_preserves_function_metadata(self):
+        """Test that cache_function preserves function metadata."""
+
+        @cache_function(timeout=60)
+        def my_calculation():
+            """Calculation docstring."""
+            return 42
+
+        self.assertEqual(my_calculation.__name__, "my_calculation")
+        self.assertEqual(my_calculation.__doc__, "Calculation docstring.")
+
+    def test_cache_function_handles_none_return(self):
+        """Test cache_function handles None return values correctly."""
+        call_count = 0
+
+        @cache_function(timeout=60)
+        def return_none():
+            nonlocal call_count
+            call_count += 1
+            return None
+
+        result1 = return_none()
+        self.assertIsNone(result1)
+        self.assertEqual(call_count, 1)
+
+        # None is a valid cached value, but cache.get returns None for missing keys
+        # This test verifies the behavior
+        result2 = return_none()
+        # Second call - cache returns None which is same as "not found"
+        # So function will be called again
+        self.assertIsNone(result2)
+
+
+class InvalidateCacheOnSaveDecoratorTest(TestCase):
+    """Tests for invalidate_cache_on_save decorator."""
+
+    def test_invalidate_cache_on_save_registers_signals(self):
+        """Test that invalidate_cache_on_save registers signal handlers."""
+        from django.db.models import Model
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        @invalidate_cache_on_save(FakeModel)
+        class TestView:
+            pass
+
+        # The decorator should return the class unchanged
+        self.assertEqual(TestView.__name__, "TestView")
+
+    def test_invalidate_cache_on_save_returns_class(self):
+        """Test that invalidate_cache_on_save returns the decorated class."""
+        from django.db.models import Model
+
+        class FakeModel(Model):
+            class Meta:
+                app_label = "test"
+
+        @invalidate_cache_on_save(FakeModel)
+        class MyView:
+            def get(self):
+                return "response"
+
+        view = MyView()
+        self.assertEqual(view.get(), "response")
+
+
+class GetCachedQuerysetTest(TestCase):
+    """Tests for get_cached_queryset function."""
+
+    def setUp(self):
+        """Clear cache before each test."""
+        cache.clear()
+
+    def test_get_cached_queryset_without_filters(self):
+        """Test get_cached_queryset without filters."""
+        from django.contrib.auth.models import User
+
+        # Create a test user
+        User.objects.create_user(username="test", password="test123")
+
+        result = get_cached_queryset(User)
+        self.assertEqual(result.count(), 1)
+
+    def test_get_cached_queryset_with_filters(self):
+        """Test get_cached_queryset with filters."""
+        from django.contrib.auth.models import User
+
+        User.objects.create_user(username="active_user", password="test123", is_active=True)
+        User.objects.create_user(username="inactive_user", password="test123", is_active=False)
+
+        result = get_cached_queryset(User, filters={"is_active": True})
+        self.assertEqual(result.count(), 1)
+        self.assertEqual(result.first().username, "active_user")
+
+    def test_get_cached_queryset_uses_cache(self):
+        """Test that get_cached_queryset uses cache on second call."""
+        from django.contrib.auth.models import User
+
+        User.objects.create_user(username="test", password="test123")
+
+        # First call
+        result1 = get_cached_queryset(User)
+
+        # Add another user
+        User.objects.create_user(username="test2", password="test123")
+
+        # Second call should still return cached result with 1 user
+        result2 = get_cached_queryset(User)
+        # Note: The cached queryset evaluates to fresh data since QuerySets are lazy
+        # This tests the caching mechanism, not the queryset evaluation
+
+    def test_get_cached_queryset_custom_timeout(self):
+        """Test get_cached_queryset with custom timeout."""
+        from django.contrib.auth.models import User
+
+        User.objects.create_user(username="test", password="test123")
+
+        result = get_cached_queryset(User, timeout=600)
+        self.assertIsNotNone(result)
+
+
+class CacheTimeoutConstantsTest(TestCase):
+    """Tests for cache timeout constants."""
+
+    def test_cache_timeout_short(self):
+        """Test CACHE_TIMEOUT_SHORT is 60 seconds."""
+        self.assertEqual(CACHE_TIMEOUT_SHORT, 60)
+
+    def test_cache_timeout_medium(self):
+        """Test CACHE_TIMEOUT_MEDIUM is 5 minutes."""
+        self.assertEqual(CACHE_TIMEOUT_MEDIUM, 300)
+
+    def test_cache_timeout_long(self):
+        """Test CACHE_TIMEOUT_LONG is 15 minutes."""
+        self.assertEqual(CACHE_TIMEOUT_LONG, 900)
+
+    def test_cache_timeout_very_long(self):
+        """Test CACHE_TIMEOUT_VERY_LONG is 1 hour."""
+        self.assertEqual(CACHE_TIMEOUT_VERY_LONG, 3600)
+
+    def test_cache_timeout_day(self):
+        """Test CACHE_TIMEOUT_DAY is 24 hours."""
+        self.assertEqual(CACHE_TIMEOUT_DAY, 86400)

--- a/core/tests/test_context_processors.py
+++ b/core/tests/test_context_processors.py
@@ -1,0 +1,263 @@
+"""Tests for context processors in core/context_processors.py."""
+
+from unittest.mock import Mock, patch
+
+from django.contrib.auth.models import User
+from django.test import RequestFactory, TestCase
+
+from core.context_processors import add_special_user_flag, all_chronicles, permissions
+from core.permissions import Permission, Role, VisibilityTier
+from game.models import Chronicle
+
+
+class AllChroniclesContextProcessorTest(TestCase):
+    """Tests for all_chronicles context processor."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+
+    def test_returns_empty_queryset_when_no_chronicles(self):
+        """Test that empty queryset is returned when no chronicles exist."""
+        request = self.factory.get("/")
+
+        result = all_chronicles(request)
+
+        self.assertIn("chronicles", result)
+        self.assertEqual(result["chronicles"].count(), 0)
+
+    def test_returns_all_chronicles(self):
+        """Test that all chronicles are returned."""
+        Chronicle.objects.create(name="Chronicle 1")
+        Chronicle.objects.create(name="Chronicle 2")
+        Chronicle.objects.create(name="Chronicle 3")
+
+        request = self.factory.get("/")
+
+        result = all_chronicles(request)
+
+        self.assertIn("chronicles", result)
+        self.assertEqual(result["chronicles"].count(), 3)
+
+    def test_returns_chronicles_queryset(self):
+        """Test that the result is a QuerySet."""
+        Chronicle.objects.create(name="Test Chronicle")
+
+        request = self.factory.get("/")
+
+        result = all_chronicles(request)
+
+        from django.db.models import QuerySet
+
+        self.assertIsInstance(result["chronicles"], QuerySet)
+
+
+class AddSpecialUserFlagContextProcessorTest(TestCase):
+    """Tests for add_special_user_flag context processor."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+
+    def test_returns_true_when_is_approved_user_true(self):
+        """Test that True is returned when request.is_approved_user is True."""
+        request = self.factory.get("/")
+        request.is_approved_user = True
+
+        result = add_special_user_flag(request)
+
+        self.assertIn("is_approved_user", result)
+        self.assertTrue(result["is_approved_user"])
+
+    def test_returns_false_when_is_approved_user_false(self):
+        """Test that False is returned when request.is_approved_user is False."""
+        request = self.factory.get("/")
+        request.is_approved_user = False
+
+        result = add_special_user_flag(request)
+
+        self.assertIn("is_approved_user", result)
+        self.assertFalse(result["is_approved_user"])
+
+    def test_returns_false_when_is_approved_user_not_set(self):
+        """Test that False is returned when request.is_approved_user is not set."""
+        request = self.factory.get("/")
+        # Don't set is_approved_user attribute
+
+        result = add_special_user_flag(request)
+
+        self.assertIn("is_approved_user", result)
+        self.assertFalse(result["is_approved_user"])
+
+
+class PermissionsContextProcessorTest(TestCase):
+    """Tests for permissions context processor."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="testpass123"
+        )
+
+    def test_returns_visibility_tier_enum(self):
+        """Test that VisibilityTier enum is in context."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        self.assertIn("VisibilityTier", result)
+        self.assertEqual(result["VisibilityTier"], VisibilityTier)
+
+    def test_returns_permission_enum(self):
+        """Test that Permission enum is in context."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        self.assertIn("Permission", result)
+        self.assertEqual(result["Permission"], Permission)
+
+    def test_returns_role_enum(self):
+        """Test that Role enum is in context."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        self.assertIn("Role", result)
+        self.assertEqual(result["Role"], Role)
+
+    def test_returns_user_can_view_callable(self):
+        """Test that user_can_view callable is in context."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        self.assertIn("user_can_view", result)
+        self.assertTrue(callable(result["user_can_view"]))
+
+    def test_returns_user_can_edit_callable(self):
+        """Test that user_can_edit callable is in context."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        self.assertIn("user_can_edit", result)
+        self.assertTrue(callable(result["user_can_edit"]))
+
+    def test_user_can_view_returns_true_when_object_has_method_returning_true(self):
+        """Test that user_can_view returns True when object.user_can_view returns True."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        mock_obj = Mock()
+        mock_obj.user_can_view = Mock(return_value=True)
+
+        can_view = result["user_can_view"](mock_obj)
+        self.assertTrue(can_view)
+        mock_obj.user_can_view.assert_called_once_with(self.user)
+
+    def test_user_can_view_returns_false_when_object_has_method_returning_false(self):
+        """Test that user_can_view returns False when object.user_can_view returns False."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        mock_obj = Mock()
+        mock_obj.user_can_view = Mock(return_value=False)
+
+        can_view = result["user_can_view"](mock_obj)
+        self.assertFalse(can_view)
+
+    def test_user_can_view_returns_false_when_object_has_no_method(self):
+        """Test that user_can_view returns False when object has no user_can_view method."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        mock_obj = object()  # Plain object with no user_can_view method
+
+        can_view = result["user_can_view"](mock_obj)
+        self.assertFalse(can_view)
+
+    def test_user_can_edit_returns_true_when_object_has_method_returning_true(self):
+        """Test that user_can_edit returns True when object.user_can_edit returns True."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        mock_obj = Mock()
+        mock_obj.user_can_edit = Mock(return_value=True)
+
+        can_edit = result["user_can_edit"](mock_obj)
+        self.assertTrue(can_edit)
+        mock_obj.user_can_edit.assert_called_once_with(self.user)
+
+    def test_user_can_edit_returns_false_when_object_has_method_returning_false(self):
+        """Test that user_can_edit returns False when object.user_can_edit returns False."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        mock_obj = Mock()
+        mock_obj.user_can_edit = Mock(return_value=False)
+
+        can_edit = result["user_can_edit"](mock_obj)
+        self.assertFalse(can_edit)
+
+    def test_user_can_edit_returns_false_when_object_has_no_method(self):
+        """Test that user_can_edit returns False when object has no user_can_edit method."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        mock_obj = object()  # Plain object with no user_can_edit method
+
+        can_edit = result["user_can_edit"](mock_obj)
+        self.assertFalse(can_edit)
+
+    def test_visibility_tier_enum_values_accessible(self):
+        """Test that VisibilityTier enum values are accessible."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        VT = result["VisibilityTier"]
+        self.assertEqual(VT.FULL, VisibilityTier.FULL)
+        self.assertEqual(VT.PARTIAL, VisibilityTier.PARTIAL)
+        self.assertEqual(VT.NONE, VisibilityTier.NONE)
+
+    def test_permission_enum_values_accessible(self):
+        """Test that Permission enum values are accessible."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        P = result["Permission"]
+        self.assertEqual(P.VIEW_FULL, Permission.VIEW_FULL)
+        self.assertEqual(P.EDIT_FULL, Permission.EDIT_FULL)
+
+    def test_role_enum_values_accessible(self):
+        """Test that Role enum values are accessible."""
+        request = self.factory.get("/")
+        request.user = self.user
+
+        result = permissions(request)
+
+        R = result["Role"]
+        self.assertEqual(R.OWNER, Role.OWNER)
+        self.assertEqual(R.ADMIN, Role.ADMIN)

--- a/core/tests/test_decorators.py
+++ b/core/tests/test_decorators.py
@@ -1,0 +1,473 @@
+"""Tests for permission decorators in core/decorators.py."""
+
+from unittest.mock import Mock, patch
+
+from characters.models.core.character import Character
+from core.decorators import (
+    require_edit_permission,
+    require_model_permission,
+    require_permission,
+    require_spend_freebies_permission,
+    require_spend_xp_permission,
+    require_view_permission,
+)
+from core.permissions import Permission
+from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+from django.test import RequestFactory, TestCase
+from game.models import Chronicle
+
+
+class RequirePermissionDecoratorTest(TestCase):
+    """Tests for the require_permission decorator."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="testpass123"
+        )
+        self.stranger = User.objects.create_user(
+            username="stranger", email="stranger@test.com", password="testpass123"
+        )
+        self.head_st = User.objects.create_user(
+            username="head_st", email="head_st@test.com", password="testpass123"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle", head_st=self.head_st)
+        self.character = Character.objects.create(
+            name="Test Character", owner=self.owner, chronicle=self.chronicle, status="App"
+        )
+
+    def test_require_permission_raises_value_error_when_model_not_specified(self):
+        """Test that decorator raises ValueError when model class is not set."""
+
+        @require_permission(Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return "success"
+
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        with self.assertRaises(ValueError) as cm:
+            test_view(request, pk=self.character.pk)
+        self.assertIn("Model class not specified", str(cm.exception))
+
+    def test_require_permission_raises_404_when_object_not_found(self):
+        """Test that decorator raises 404 when object doesn't exist."""
+
+        @require_permission(Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        with self.assertRaises(Http404):
+            test_view(request, pk=99999)
+
+    def test_require_permission_raises_404_when_no_permission_and_raise_404_true(self):
+        """Test that decorator raises 404 when permission denied and raise_404=True."""
+
+        @require_permission(Permission.EDIT_FULL, raise_404=True)
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(Http404):
+            test_view(request, pk=self.character.pk)
+
+    def test_require_permission_raises_403_when_no_permission_and_raise_404_false(self):
+        """Test that decorator raises 403 when permission denied and raise_404=False."""
+
+        @require_permission(Permission.EDIT_FULL, raise_404=False)
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(PermissionDenied):
+            test_view(request, pk=self.character.pk)
+
+    def test_require_permission_allows_access_when_permission_granted(self):
+        """Test that decorator allows access when user has permission."""
+
+        @require_permission(Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, "success")
+
+    def test_require_permission_attaches_object_to_request(self):
+        """Test that decorator attaches object to request.permission_object."""
+
+        @require_permission(Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return request.permission_object
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, self.character)
+
+    def test_require_permission_with_custom_lookup_param(self):
+        """Test that decorator works with custom lookup parameter."""
+
+        @require_permission(Permission.VIEW_FULL, lookup="char_id")
+        def test_view(request, char_id):
+            return request.permission_object
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, char_id=self.character.pk)
+        self.assertEqual(result, self.character)
+
+    def test_require_permission_preserves_function_metadata(self):
+        """Test that decorator preserves the wrapped function's metadata."""
+
+        @require_permission(Permission.VIEW_FULL)
+        def my_test_view(request, pk):
+            """My docstring."""
+            return "success"
+
+        self.assertEqual(my_test_view.__name__, "my_test_view")
+        self.assertEqual(my_test_view.__doc__, "My docstring.")
+
+
+class RequireViewPermissionDecoratorTest(TestCase):
+    """Tests for require_view_permission shortcut decorator."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="testpass123"
+        )
+        self.stranger = User.objects.create_user(
+            username="stranger", email="stranger@test.com", password="testpass123"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.character = Character.objects.create(
+            name="Test Character", owner=self.owner, chronicle=self.chronicle, status="App"
+        )
+
+    def test_require_view_permission_allows_owner(self):
+        """Test that view permission allows owner access."""
+
+        @require_view_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, "success")
+
+    def test_require_view_permission_raises_404_for_stranger(self):
+        """Test that view permission raises 404 for unauthorized user."""
+
+        @require_view_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(Http404):
+            test_view(request, pk=self.character.pk)
+
+
+class RequireEditPermissionDecoratorTest(TestCase):
+    """Tests for require_edit_permission shortcut decorator."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="testpass123"
+        )
+        self.head_st = User.objects.create_user(
+            username="head_st", email="head_st@test.com", password="testpass123"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle", head_st=self.head_st)
+        self.character = Character.objects.create(
+            name="Test Character", owner=self.owner, chronicle=self.chronicle, status="App"
+        )
+
+    def test_require_edit_permission_allows_head_st(self):
+        """Test that edit permission allows head ST access."""
+
+        @require_edit_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.head_st
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, "success")
+
+    def test_require_edit_permission_raises_403_for_owner(self):
+        """Test that edit permission raises 403 for owner (no EDIT_FULL)."""
+
+        @require_edit_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        with self.assertRaises(PermissionDenied):
+            test_view(request, pk=self.character.pk)
+
+
+class RequireSpendXPPermissionDecoratorTest(TestCase):
+    """Tests for require_spend_xp_permission shortcut decorator."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="testpass123"
+        )
+        self.stranger = User.objects.create_user(
+            username="stranger", email="stranger@test.com", password="testpass123"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.character = Character.objects.create(
+            name="Test Character", owner=self.owner, chronicle=self.chronicle, status="App"
+        )
+
+    def test_require_spend_xp_permission_allows_owner(self):
+        """Test that spend XP permission allows owner access on approved character."""
+
+        @require_spend_xp_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, "success")
+
+    def test_require_spend_xp_permission_raises_403_for_stranger(self):
+        """Test that spend XP permission raises 403 for unauthorized user."""
+
+        @require_spend_xp_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(PermissionDenied):
+            test_view(request, pk=self.character.pk)
+
+
+class RequireSpendFreebiesPermissionDecoratorTest(TestCase):
+    """Tests for require_spend_freebies_permission shortcut decorator."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="testpass123"
+        )
+        self.stranger = User.objects.create_user(
+            username="stranger", email="stranger@test.com", password="testpass123"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.unfinished_character = Character.objects.create(
+            name="Unfinished Character", owner=self.owner, chronicle=self.chronicle, status="Un"
+        )
+        self.approved_character = Character.objects.create(
+            name="Approved Character", owner=self.owner, chronicle=self.chronicle, status="App"
+        )
+
+    def test_require_spend_freebies_permission_allows_owner_on_unfinished(self):
+        """Test that spend freebies permission allows owner on unfinished character."""
+
+        @require_spend_freebies_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.unfinished_character.pk)
+        self.assertEqual(result, "success")
+
+    def test_require_spend_freebies_permission_raises_403_on_approved(self):
+        """Test that spend freebies permission raises 403 on approved character."""
+
+        @require_spend_freebies_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        with self.assertRaises(PermissionDenied):
+            test_view(request, pk=self.approved_character.pk)
+
+    def test_require_spend_freebies_permission_raises_403_for_stranger(self):
+        """Test that spend freebies permission raises 403 for unauthorized user."""
+
+        @require_spend_freebies_permission
+        def test_view(request, pk):
+            return "success"
+
+        test_view.model = Character
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(PermissionDenied):
+            test_view(request, pk=self.unfinished_character.pk)
+
+
+class RequireModelPermissionDecoratorTest(TestCase):
+    """Tests for require_model_permission decorator with explicit model class."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.factory = RequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner", email="owner@test.com", password="testpass123"
+        )
+        self.stranger = User.objects.create_user(
+            username="stranger", email="stranger@test.com", password="testpass123"
+        )
+        self.head_st = User.objects.create_user(
+            username="head_st", email="head_st@test.com", password="testpass123"
+        )
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle", head_st=self.head_st)
+        self.character = Character.objects.create(
+            name="Test Character", owner=self.owner, chronicle=self.chronicle, status="App"
+        )
+
+    def test_require_model_permission_allows_access_with_permission(self):
+        """Test that decorator allows access when user has permission."""
+
+        @require_model_permission(Character, Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return "success"
+
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, "success")
+
+    def test_require_model_permission_raises_404_when_object_not_found(self):
+        """Test that decorator raises 404 when object doesn't exist."""
+
+        @require_model_permission(Character, Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return "success"
+
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        with self.assertRaises(Http404):
+            test_view(request, pk=99999)
+
+    def test_require_model_permission_raises_404_when_no_permission_and_raise_404_true(self):
+        """Test that decorator raises 404 when permission denied and raise_404=True."""
+
+        @require_model_permission(Character, Permission.EDIT_FULL, raise_404=True)
+        def test_view(request, pk):
+            return "success"
+
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(Http404):
+            test_view(request, pk=self.character.pk)
+
+    def test_require_model_permission_raises_403_when_no_permission_and_raise_404_false(self):
+        """Test that decorator raises 403 when permission denied and raise_404=False."""
+
+        @require_model_permission(Character, Permission.EDIT_FULL, raise_404=False)
+        def test_view(request, pk):
+            return "success"
+
+        request = self.factory.get("/")
+        request.user = self.stranger
+
+        with self.assertRaises(PermissionDenied):
+            test_view(request, pk=self.character.pk)
+
+    def test_require_model_permission_attaches_object_to_request(self):
+        """Test that decorator attaches object to request.permission_object."""
+
+        @require_model_permission(Character, Permission.VIEW_FULL)
+        def test_view(request, pk):
+            return request.permission_object
+
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, self.character)
+
+    def test_require_model_permission_with_custom_lookup_param(self):
+        """Test that decorator works with custom lookup parameter."""
+
+        @require_model_permission(Character, Permission.VIEW_FULL, lookup="char_id")
+        def test_view(request, char_id):
+            return request.permission_object
+
+        request = self.factory.get("/")
+        request.user = self.owner
+
+        result = test_view(request, char_id=self.character.pk)
+        self.assertEqual(result, self.character)
+
+    def test_require_model_permission_preserves_function_metadata(self):
+        """Test that decorator preserves the wrapped function's metadata."""
+
+        @require_model_permission(Character, Permission.VIEW_FULL)
+        def my_test_view(request, pk):
+            """My docstring."""
+            return "success"
+
+        self.assertEqual(my_test_view.__name__, "my_test_view")
+        self.assertEqual(my_test_view.__doc__, "My docstring.")
+
+    def test_require_model_permission_head_st_can_edit(self):
+        """Test that head ST can access with EDIT_FULL permission."""
+
+        @require_model_permission(Character, Permission.EDIT_FULL)
+        def test_view(request, pk):
+            return "success"
+
+        request = self.factory.get("/")
+        request.user = self.head_st
+
+        result = test_view(request, pk=self.character.pk)
+        self.assertEqual(result, "success")


### PR DESCRIPTION
Fixes #1235

Add test coverage for core infrastructure files that previously had 0% coverage:

- core/decorators.py: Tests for require_permission, require_view_permission, require_edit_permission, require_spend_xp_permission, require_spend_freebies_permission, and require_model_permission decorators

- core/middleware/cache_middleware.py: Tests for PerUserCacheMiddleware process_request and process_response methods

- core/middleware/approved_user.py: Tests for UserListMiddleware is_approved_user flag setting

- core/middleware/auth_error_handler.py: Tests for AuthErrorHandlerMiddleware 401/403 error handling and login redirect interception

- core/cache.py: Tests for CacheKeyGenerator, CacheInvalidator, cache_queryset decorator, cache_function decorator, invalidate_cache_on_save decorator, get_cached_queryset function, and timeout constants

- core/context_processors.py: Tests for all_chronicles, add_special_user_flag, and permissions context processors