### PR TITLE
Add comprehensive tests for locations app to improve test coverage

### DIFF
--- a/locations/tests/forms/mage/test_paradox_realm.py
+++ b/locations/tests/forms/mage/test_paradox_realm.py
@@ -1,5 +1,319 @@
-"""Tests for paradox_realm module."""
+"""Tests for ParadoxRealm forms."""
 
 from django.test import TestCase
+from locations.forms.mage.paradox_realm import (
+    ParadoxAtmosphereForm,
+    ParadoxAtmosphereFormSet,
+    ParadoxObstacleForm,
+    ParadoxObstacleFormSet,
+    ParadoxRealmForm,
+)
+from locations.models.mage.paradox_realm import (
+    ParadoxAtmosphere,
+    ParadoxObstacle,
+    ParadoxRealm,
+    ParadigmChoices,
+    SphereChoices,
+)
 
-# TODO: Move relevant tests from existing test files here
+
+class TestParadoxObstacleForm(TestCase):
+    """Test ParadoxObstacleForm."""
+
+    def test_form_has_required_fields(self):
+        """Test form has all required fields."""
+        form = ParadoxObstacleForm()
+        self.assertIn("sphere", form.fields)
+        self.assertIn("obstacle_number", form.fields)
+        self.assertIn("order", form.fields)
+        self.assertIn("name", form.fields)
+        self.assertIn("description", form.fields)
+
+    def test_name_placeholder(self):
+        """Test name field has placeholder."""
+        form = ParadoxObstacleForm()
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("placeholder"),
+            "Enter obstacle name",
+        )
+
+    def test_description_placeholder(self):
+        """Test description field has placeholder."""
+        form = ParadoxObstacleForm()
+        self.assertEqual(
+            form.fields["description"].widget.attrs.get("placeholder"),
+            "Enter obstacle description",
+        )
+
+    def test_valid_form(self):
+        """Test form validates with valid data."""
+        data = {
+            "sphere": SphereChoices.FORCES,
+            "obstacle_number": 4,
+            "order": 1,
+            "name": "Fire",
+            "description": "A wall of flames",
+        }
+        form = ParadoxObstacleForm(data=data)
+        self.assertTrue(form.is_valid())
+
+
+class TestParadoxAtmosphereForm(TestCase):
+    """Test ParadoxAtmosphereForm."""
+
+    def test_form_has_required_fields(self):
+        """Test form has all required fields."""
+        form = ParadoxAtmosphereForm()
+        self.assertIn("paradigm", form.fields)
+        self.assertIn("atmosphere_number", form.fields)
+        self.assertIn("description", form.fields)
+
+    def test_description_placeholder(self):
+        """Test description field has placeholder."""
+        form = ParadoxAtmosphereForm()
+        self.assertEqual(
+            form.fields["description"].widget.attrs.get("placeholder"),
+            "Enter atmosphere description",
+        )
+
+    def test_valid_form(self):
+        """Test form validates with valid data."""
+        data = {
+            "paradigm": ParadigmChoices.CHAOS,
+            "atmosphere_number": 1,
+            "description": "Colors pulsating everywhere",
+        }
+        form = ParadoxAtmosphereForm(data=data)
+        self.assertTrue(form.is_valid())
+
+
+class TestParadoxRealmFormBasics(TestCase):
+    """Test basic ParadoxRealmForm functionality."""
+
+    def test_form_has_required_fields(self):
+        """Test form has all required fields."""
+        form = ParadoxRealmForm()
+        self.assertIn("name", form.fields)
+        self.assertIn("description", form.fields)
+        self.assertIn("primary_sphere", form.fields)
+        self.assertIn("secondary_sphere", form.fields)
+        self.assertIn("paradigm", form.fields)
+        self.assertIn("secondary_paradigm", form.fields)
+        self.assertIn("num_primary_obstacles", form.fields)
+        self.assertIn("num_random_obstacles", form.fields)
+        self.assertIn("final_obstacle_type", form.fields)
+        self.assertIn("generate_random", form.fields)
+
+    def test_name_placeholder(self):
+        """Test name field has placeholder."""
+        form = ParadoxRealmForm()
+        self.assertEqual(
+            form.fields["name"].widget.attrs.get("placeholder"),
+            "Enter realm name",
+        )
+
+    def test_description_placeholder(self):
+        """Test description field has placeholder."""
+        form = ParadoxRealmForm()
+        self.assertEqual(
+            form.fields["description"].widget.attrs.get("placeholder"),
+            "Enter description of the realm",
+        )
+
+    def test_secondary_fields_optional(self):
+        """Test secondary fields are optional."""
+        form = ParadoxRealmForm()
+        self.assertFalse(form.fields["secondary_sphere"].required)
+        self.assertFalse(form.fields["secondary_paradigm"].required)
+        self.assertFalse(form.fields["parent"].required)
+
+    def test_form_has_formsets(self):
+        """Test form has obstacle and atmosphere formsets."""
+        form = ParadoxRealmForm()
+        self.assertTrue(hasattr(form, "obstacle_formset"))
+        self.assertTrue(hasattr(form, "atmosphere_formset"))
+
+    def test_generate_random_defaults_false(self):
+        """Test generate_random field defaults to False."""
+        form = ParadoxRealmForm()
+        self.assertFalse(form.fields["generate_random"].initial)
+
+
+class TestParadoxRealmFormValidation(TestCase):
+    """Test ParadoxRealmForm validation."""
+
+    def _get_basic_form_data(self, **overrides):
+        """Helper to create basic form data."""
+        data = {
+            "name": "Test Realm",
+            "description": "A test paradox realm",
+            "primary_sphere": SphereChoices.FORCES,
+            "paradigm": ParadigmChoices.CHAOS,
+            "num_primary_obstacles": 2,
+            "num_random_obstacles": 1,
+            "final_obstacle_type": "maze",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+            # Formset management forms
+            "obstacles-TOTAL_FORMS": "0",
+            "obstacles-INITIAL_FORMS": "0",
+            "obstacles-MIN_NUM_FORMS": "0",
+            "obstacles-MAX_NUM_FORMS": "1000",
+            "atmospheres-TOTAL_FORMS": "0",
+            "atmospheres-INITIAL_FORMS": "0",
+            "atmospheres-MIN_NUM_FORMS": "0",
+            "atmospheres-MAX_NUM_FORMS": "1000",
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_form(self):
+        """Test form validates with valid data."""
+        data = self._get_basic_form_data()
+        form = ParadoxRealmForm(data=data)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_name_required(self):
+        """Test name field is required."""
+        data = self._get_basic_form_data(name="")
+        form = ParadoxRealmForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+
+class TestParadoxRealmFormSave(TestCase):
+    """Test ParadoxRealmForm save functionality."""
+
+    def _get_valid_form_data(self):
+        """Helper to create valid form data."""
+        return {
+            "name": "Saved Realm",
+            "description": "A saved paradox realm",
+            "primary_sphere": SphereChoices.ENTROPY,
+            "paradigm": ParadigmChoices.ANTIMAGICK,
+            "num_primary_obstacles": 1,
+            "num_random_obstacles": 0,
+            "final_obstacle_type": "maze",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+            # Formset management forms
+            "obstacles-TOTAL_FORMS": "0",
+            "obstacles-INITIAL_FORMS": "0",
+            "obstacles-MIN_NUM_FORMS": "0",
+            "obstacles-MAX_NUM_FORMS": "1000",
+            "atmospheres-TOTAL_FORMS": "0",
+            "atmospheres-INITIAL_FORMS": "0",
+            "atmospheres-MIN_NUM_FORMS": "0",
+            "atmospheres-MAX_NUM_FORMS": "1000",
+        }
+
+    def test_save_creates_realm(self):
+        """Test save creates a paradox realm."""
+        data = self._get_valid_form_data()
+        form = ParadoxRealmForm(data=data)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+        realm = form.save()
+        self.assertIsNotNone(realm.pk)
+        self.assertEqual(realm.name, "Saved Realm")
+        self.assertEqual(realm.primary_sphere, SphereChoices.ENTROPY)
+
+    def test_save_with_generate_random(self):
+        """Test save with generate_random creates random realm."""
+        data = self._get_valid_form_data()
+        data["generate_random"] = True
+        data["name"] = "Random Generated Realm"
+        form = ParadoxRealmForm(data=data)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+        realm = form.save()
+        self.assertIsNotNone(realm.pk)
+        self.assertEqual(realm.name, "Random Generated Realm")
+        # When generate_random is true, it uses the random() method
+        # which may set different values than form data
+
+    def test_save_commit_false(self):
+        """Test save with commit=False doesn't save to database."""
+        data = self._get_valid_form_data()
+        form = ParadoxRealmForm(data=data)
+        self.assertTrue(form.is_valid())
+
+        realm = form.save(commit=False)
+        self.assertIsNone(realm.pk)
+
+
+class TestParadoxRealmFormUpdate(TestCase):
+    """Test ParadoxRealmForm for updating existing realms."""
+
+    def setUp(self):
+        self.realm = ParadoxRealm.objects.create(
+            name="Existing Realm",
+            primary_sphere=SphereChoices.MIND,
+            paradigm=ParadigmChoices.FAITH,
+        )
+
+    def test_form_with_instance(self):
+        """Test form loads instance data."""
+        form = ParadoxRealmForm(instance=self.realm)
+        self.assertEqual(form.initial["name"], "Existing Realm")
+        self.assertEqual(form.initial["primary_sphere"], SphereChoices.MIND)
+
+    def test_update_realm(self):
+        """Test updating an existing realm."""
+        data = {
+            "name": "Updated Realm",
+            "description": "Updated description",
+            "primary_sphere": SphereChoices.TIME,
+            "paradigm": ParadigmChoices.TECH,
+            "num_primary_obstacles": 3,
+            "num_random_obstacles": 2,
+            "final_obstacle_type": "maze",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+            "obstacles-TOTAL_FORMS": "0",
+            "obstacles-INITIAL_FORMS": "0",
+            "obstacles-MIN_NUM_FORMS": "0",
+            "obstacles-MAX_NUM_FORMS": "1000",
+            "atmospheres-TOTAL_FORMS": "0",
+            "atmospheres-INITIAL_FORMS": "0",
+            "atmospheres-MIN_NUM_FORMS": "0",
+            "atmospheres-MAX_NUM_FORMS": "1000",
+        }
+        form = ParadoxRealmForm(data=data, instance=self.realm)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+        realm = form.save()
+        self.assertEqual(realm.pk, self.realm.pk)
+        self.assertEqual(realm.name, "Updated Realm")
+        self.assertEqual(realm.primary_sphere, SphereChoices.TIME)
+
+
+class TestParadoxObstacleFormSet(TestCase):
+    """Test ParadoxObstacleFormSet."""
+
+    def test_formset_exists(self):
+        """Test formset class exists and can be instantiated."""
+        formset = ParadoxObstacleFormSet()
+        self.assertIsNotNone(formset)
+
+    def test_formset_allows_deletion(self):
+        """Test formset allows deletion."""
+        formset = ParadoxObstacleFormSet()
+        self.assertTrue(formset.can_delete)
+
+
+class TestParadoxAtmosphereFormSet(TestCase):
+    """Test ParadoxAtmosphereFormSet."""
+
+    def test_formset_exists(self):
+        """Test formset class exists and can be instantiated."""
+        formset = ParadoxAtmosphereFormSet()
+        self.assertIsNotNone(formset)
+
+    def test_formset_allows_deletion(self):
+        """Test formset allows deletion."""
+        formset = ParadoxAtmosphereFormSet()
+        self.assertTrue(formset.can_delete)

--- a/locations/tests/models/hunter/test_safehouse.py
+++ b/locations/tests/models/hunter/test_safehouse.py
@@ -1,5 +1,328 @@
-"""Tests for safehouse module."""
+"""Tests for Safehouse model."""
 
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
+from locations.models.hunter.safehouse import Safehouse
 
-# TODO: Move relevant tests from existing test files here
+
+class TestSafehouseBasics(TestCase):
+    """Test basic Safehouse model functionality."""
+
+    def test_safehouse_creation(self):
+        """Test creating a safehouse."""
+        safehouse = Safehouse.objects.create(
+            name="The Bunker",
+            size=3,
+            security_level=4,
+            armory_level=3,
+        )
+        self.assertEqual(safehouse.name, "The Bunker")
+        self.assertEqual(safehouse.size, 3)
+        self.assertEqual(safehouse.security_level, 4)
+        self.assertEqual(safehouse.armory_level, 3)
+        self.assertEqual(safehouse.type, "safehouse")
+        self.assertEqual(safehouse.gameline, "htr")
+
+    def test_safehouse_defaults(self):
+        """Test safehouse default values."""
+        safehouse = Safehouse.objects.create(name="Test Safehouse")
+        self.assertEqual(safehouse.size, 1)
+        self.assertEqual(safehouse.capacity, 5)
+        self.assertEqual(safehouse.security_level, 1)
+        self.assertEqual(safehouse.armory_level, 0)
+        self.assertEqual(safehouse.surveillance_level, 0)
+        self.assertEqual(safehouse.medical_facilities, 0)
+        self.assertFalse(safehouse.is_compromised)
+        self.assertFalse(safehouse.is_mobile)
+        self.assertFalse(safehouse.has_panic_room)
+        self.assertFalse(safehouse.has_escape_routes)
+        self.assertFalse(safehouse.has_dead_drop)
+        self.assertTrue(safehouse.has_communications)
+        self.assertEqual(safehouse.cover_story, "")
+        self.assertEqual(safehouse.legal_owner, "")
+
+    def test_safehouse_get_heading(self):
+        """Test get_heading returns htr_heading."""
+        safehouse = Safehouse.objects.create(name="Test")
+        self.assertEqual(safehouse.get_heading(), "htr_heading")
+
+    def test_safehouse_get_update_url(self):
+        """Test get_update_url returns valid URL."""
+        safehouse = Safehouse.objects.create(name="Test")
+        url = safehouse.get_update_url()
+        self.assertIn(str(safehouse.id), url)
+        self.assertIn("safehouse", url)
+
+    def test_safehouse_get_creation_url(self):
+        """Test get_creation_url returns valid URL."""
+        url = Safehouse.get_creation_url()
+        self.assertIn("safehouse", url)
+
+
+class TestSafehouseTotalRating(TestCase):
+    """Test Safehouse total rating calculation."""
+
+    def test_calculate_total_rating_basic(self):
+        """Test basic total rating calculation."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            size=2,
+            security_level=3,
+            armory_level=1,
+            surveillance_level=2,
+            medical_facilities=1,
+        )
+        # Total = 2 + 3 + 1 + 2 + 1 = 9
+        self.assertEqual(safehouse.total_rating, 9)
+
+    def test_calculate_total_rating_with_features(self):
+        """Test total rating with bonus features."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            size=2,
+            security_level=2,
+            armory_level=1,
+            surveillance_level=1,
+            medical_facilities=1,
+            has_panic_room=True,  # +1
+            has_escape_routes=True,  # +1
+            has_dead_drop=True,  # +1
+        )
+        # Total = 2 + 2 + 1 + 1 + 1 + 1 + 1 + 1 = 10
+        self.assertEqual(safehouse.total_rating, 10)
+
+    def test_calculate_total_rating_compromised_penalty(self):
+        """Test total rating with compromised penalty."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            size=2,
+            security_level=2,
+            armory_level=1,
+            surveillance_level=1,
+            medical_facilities=1,
+            is_compromised=True,  # -2
+        )
+        # Total = 2 + 2 + 1 + 1 + 1 - 2 = 5
+        self.assertEqual(safehouse.total_rating, 5)
+
+    def test_calculate_total_rating_features_and_compromised(self):
+        """Test total rating with both features and compromised."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            size=2,
+            security_level=2,
+            armory_level=1,
+            surveillance_level=1,
+            medical_facilities=1,
+            has_panic_room=True,  # +1
+            has_escape_routes=True,  # +1
+            is_compromised=True,  # -2
+        )
+        # Total = 2 + 2 + 1 + 1 + 1 + 1 + 1 - 2 = 7
+        self.assertEqual(safehouse.total_rating, 7)
+
+    def test_calculate_total_rating_no_negative(self):
+        """Test total rating cannot go negative."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            size=1,
+            security_level=1,
+            armory_level=0,
+            surveillance_level=0,
+            medical_facilities=0,
+            is_compromised=True,  # -2
+        )
+        # Total = 1 + 1 + 0 + 0 + 0 - 2 = 0 (clamped)
+        self.assertEqual(safehouse.total_rating, 0)
+
+    def test_save_recalculates_total_rating(self):
+        """Test save() recalculates total rating."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            size=1,
+            security_level=1,
+            armory_level=0,
+        )
+        self.assertEqual(safehouse.total_rating, 2)
+
+        safehouse.size = 3
+        safehouse.security_level = 4
+        safehouse.armory_level = 3
+        safehouse.has_panic_room = True
+        safehouse.save()
+        safehouse.refresh_from_db()
+        self.assertEqual(safehouse.total_rating, 11)  # 3 + 4 + 3 + 1
+
+
+class TestSafehouseFeatures(TestCase):
+    """Test Safehouse special features."""
+
+    def test_is_compromised(self):
+        """Test is_compromised feature."""
+        safehouse = Safehouse.objects.create(name="Test", is_compromised=True)
+        self.assertTrue(safehouse.is_compromised)
+
+    def test_is_mobile(self):
+        """Test is_mobile feature."""
+        safehouse = Safehouse.objects.create(name="Test", is_mobile=True)
+        self.assertTrue(safehouse.is_mobile)
+
+    def test_has_panic_room(self):
+        """Test has_panic_room feature."""
+        safehouse = Safehouse.objects.create(name="Test", has_panic_room=True)
+        self.assertTrue(safehouse.has_panic_room)
+
+    def test_has_escape_routes(self):
+        """Test has_escape_routes feature."""
+        safehouse = Safehouse.objects.create(name="Test", has_escape_routes=True)
+        self.assertTrue(safehouse.has_escape_routes)
+
+    def test_has_dead_drop(self):
+        """Test has_dead_drop feature."""
+        safehouse = Safehouse.objects.create(name="Test", has_dead_drop=True)
+        self.assertTrue(safehouse.has_dead_drop)
+
+    def test_has_communications(self):
+        """Test has_communications feature (default True)."""
+        safehouse = Safehouse.objects.create(name="Test")
+        self.assertTrue(safehouse.has_communications)
+
+    def test_cover_story(self):
+        """Test cover_story field."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            cover_story="Abandoned warehouse rented for storage",
+        )
+        self.assertEqual(safehouse.cover_story, "Abandoned warehouse rented for storage")
+
+    def test_legal_owner(self):
+        """Test legal_owner field."""
+        safehouse = Safehouse.objects.create(
+            name="Test",
+            legal_owner="Shell Corporation LLC",
+        )
+        self.assertEqual(safehouse.legal_owner, "Shell Corporation LLC")
+
+
+class TestSafehouseViews(TestCase):
+    """Test Safehouse views integration."""
+
+    def test_safehouse_list_view(self):
+        """Test safehouse list view."""
+        Safehouse.objects.create(name="Safehouse 1")
+        Safehouse.objects.create(name="Safehouse 2")
+        response = self.client.get("/locations/hunter/safehouse/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Safehouse 1")
+        self.assertContains(response, "Safehouse 2")
+
+    def test_safehouse_detail_view(self):
+        """Test safehouse detail view."""
+        user = User.objects.create_user(username="testuser", password="password")
+        safehouse = Safehouse.objects.create(
+            name="Test Safehouse",
+            size=3,
+            security_level=4,
+            owner=user,
+            status="App",
+        )
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(safehouse.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Safehouse")
+
+    def test_safehouse_create_view(self):
+        """Test safehouse create view."""
+        user = User.objects.create_user(username="testuser", password="password")
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(Safehouse.get_creation_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_safehouse_create_post(self):
+        """Test creating safehouse via POST."""
+        user = User.objects.create_user(username="testuser", password="password")
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Safehouse",
+            "description": "A new safehouse",
+            "size": 2,
+            "capacity": 6,
+            "security_level": 3,
+            "armory_level": 2,
+            "surveillance_level": 1,
+            "medical_facilities": 1,
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(Safehouse.get_creation_url(), data=data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Safehouse.objects.filter(name="New Safehouse").exists())
+        safehouse = Safehouse.objects.get(name="New Safehouse")
+        self.assertEqual(safehouse.total_rating, 9)  # 2 + 3 + 2 + 1 + 1
+
+    def test_safehouse_update_view(self):
+        """Test safehouse update view."""
+        st = User.objects.create_user(username="st_user", password="password")
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        chronicle.storytellers.add(st)
+        safehouse = Safehouse.objects.create(
+            name="Existing Safehouse",
+            size=2,
+            security_level=2,
+            owner=st,
+            chronicle=chronicle,
+            status="App",
+        )
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(safehouse.get_update_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_safehouse_update_post(self):
+        """Test updating safehouse via POST."""
+        st = User.objects.create_user(username="st_user", password="password")
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        chronicle.storytellers.add(st)
+        safehouse = Safehouse.objects.create(
+            name="Existing Safehouse",
+            size=2,
+            security_level=2,
+            owner=st,
+            chronicle=chronicle,
+            status="App",
+        )
+        self.client.login(username="st_user", password="password")
+        data = {
+            "name": "Updated Safehouse",
+            "description": "Updated description",
+            "size": 4,
+            "capacity": 8,
+            "security_level": 5,
+            "armory_level": 4,
+            "surveillance_level": 3,
+            "medical_facilities": 2,
+            "has_panic_room": True,
+            "has_escape_routes": True,
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(safehouse.get_update_url(), data=data)
+        self.assertEqual(response.status_code, 302)
+        safehouse.refresh_from_db()
+        self.assertEqual(safehouse.name, "Updated Safehouse")
+        # 4 + 5 + 4 + 3 + 2 + 1 + 1 = 20
+        self.assertEqual(safehouse.total_rating, 20)
+
+
+class TestSafehouseMeta(TestCase):
+    """Test Safehouse Meta class."""
+
+    def test_verbose_name(self):
+        """Test verbose name."""
+        self.assertEqual(Safehouse._meta.verbose_name, "Safehouse")
+
+    def test_verbose_name_plural(self):
+        """Test verbose name plural."""
+        self.assertEqual(Safehouse._meta.verbose_name_plural, "Safehouses")

--- a/locations/tests/models/mage/test_paradox_realm.py
+++ b/locations/tests/models/mage/test_paradox_realm.py
@@ -1,5 +1,601 @@
-"""Tests for paradox_realm module."""
+"""Tests for ParadoxRealm model."""
+
+from unittest.mock import patch
 
 from django.test import TestCase
+from locations.models.mage.paradox_realm import (
+    FinalObstacleTypeChoices,
+    ParadoxAtmosphere,
+    ParadoxObstacle,
+    ParadoxRealm,
+    ParadigmChoices,
+    SphereChoices,
+)
 
-# TODO: Move relevant tests from existing test files here
+
+class TestParadoxRealmBasics(TestCase):
+    """Test basic ParadoxRealm model functionality."""
+
+    def test_paradox_realm_creation(self):
+        """Test creating a basic paradox realm."""
+        realm = ParadoxRealm.objects.create(
+            name="Test Realm",
+            primary_sphere=SphereChoices.CORRESPONDENCE,
+            paradigm=ParadigmChoices.ANTIMAGICK,
+        )
+        self.assertEqual(realm.name, "Test Realm")
+        self.assertEqual(realm.primary_sphere, SphereChoices.CORRESPONDENCE)
+        self.assertEqual(realm.paradigm, ParadigmChoices.ANTIMAGICK)
+        self.assertEqual(realm.type, "paradox_realm")
+        self.assertEqual(realm.gameline, "mta")
+
+    def test_paradox_realm_str(self):
+        """Test string representation of paradox realm."""
+        realm = ParadoxRealm.objects.create(
+            name="Twisted Reality",
+            primary_sphere=SphereChoices.ENTROPY,
+        )
+        self.assertIn("Twisted Reality", str(realm))
+        self.assertIn("Entropy", str(realm))
+
+    def test_paradox_realm_str_with_secondary_sphere(self):
+        """Test string representation with secondary sphere."""
+        realm = ParadoxRealm.objects.create(
+            name="Dual Realm",
+            primary_sphere=SphereChoices.FORCES,
+            secondary_sphere=SphereChoices.MATTER,
+        )
+        result = str(realm)
+        self.assertIn("Dual Realm", result)
+        self.assertIn("Forces", result)
+        self.assertIn("Matter", result)
+
+    def test_paradox_realm_defaults(self):
+        """Test default values for paradox realm."""
+        realm = ParadoxRealm.objects.create(name="Default Realm")
+        self.assertEqual(realm.primary_sphere, SphereChoices.CORRESPONDENCE)
+        self.assertEqual(realm.paradigm, ParadigmChoices.ANTIMAGICK)
+        self.assertEqual(realm.num_primary_obstacles, 0)
+        self.assertEqual(realm.num_random_obstacles, 0)
+        self.assertEqual(realm.final_obstacle_type, FinalObstacleTypeChoices.MAZE)
+        self.assertEqual(realm.atmosphere_details, [])
+        self.assertEqual(realm.final_obstacle_details, {})
+
+    def test_paradox_realm_get_heading(self):
+        """Test get_heading returns correct gameline heading."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        self.assertEqual(realm.get_heading(), "mta_heading")
+
+    def test_paradox_realm_get_update_url(self):
+        """Test get_update_url returns valid URL."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        url = realm.get_update_url()
+        self.assertIn(str(realm.id), url)
+        self.assertIn("paradox_realm", url)
+
+    def test_paradox_realm_get_creation_url(self):
+        """Test get_creation_url returns valid URL."""
+        url = ParadoxRealm.get_creation_url()
+        self.assertIn("paradox_realm", url)
+
+    def test_paradox_realm_get_obstacles(self):
+        """Test get_obstacles returns ordered obstacles."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        obs1 = ParadoxObstacle.objects.create(
+            realm=realm,
+            sphere=SphereChoices.ENTROPY,
+            obstacle_number=1,
+            order=2,
+            name="Second",
+        )
+        obs2 = ParadoxObstacle.objects.create(
+            realm=realm,
+            sphere=SphereChoices.FORCES,
+            obstacle_number=2,
+            order=1,
+            name="First",
+        )
+        obstacles = realm.get_obstacles()
+        self.assertEqual(obstacles[0], obs2)
+        self.assertEqual(obstacles[1], obs1)
+
+    def test_paradox_realm_get_atmosphere_elements(self):
+        """Test get_atmosphere_elements returns all atmospheres."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        atm1 = ParadoxAtmosphere.objects.create(
+            realm=realm,
+            paradigm=ParadigmChoices.CHAOS,
+            atmosphere_number=1,
+            description="Chaos atmosphere",
+        )
+        atm2 = ParadoxAtmosphere.objects.create(
+            realm=realm,
+            paradigm=ParadigmChoices.DATA,
+            atmosphere_number=2,
+            description="Data atmosphere",
+        )
+        atmospheres = realm.get_atmosphere_elements()
+        self.assertEqual(atmospheres.count(), 2)
+        self.assertIn(atm1, atmospheres)
+        self.assertIn(atm2, atmospheres)
+
+
+class TestParadoxRealmDice(TestCase):
+    """Test dice rolling methods."""
+
+    def test_roll_d10(self):
+        """Test d10 roll returns value in range 1-10."""
+        for _ in range(100):
+            result = ParadoxRealm.roll_d10()
+            self.assertGreaterEqual(result, 1)
+            self.assertLessEqual(result, 10)
+
+    def test_roll_d5(self):
+        """Test d5 roll returns value in range 1-5."""
+        for _ in range(100):
+            result = ParadoxRealm.roll_d5()
+            self.assertGreaterEqual(result, 1)
+            self.assertLessEqual(result, 5)
+
+    def test_roll_2d10(self):
+        """Test 2d10 roll returns value in range 2-20."""
+        for _ in range(100):
+            result = ParadoxRealm.roll_2d10()
+            self.assertGreaterEqual(result, 2)
+            self.assertLessEqual(result, 20)
+
+    def test_roll_d100(self):
+        """Test d100 roll returns value in range 1-100."""
+        for _ in range(100):
+            result = ParadoxRealm.roll_d100()
+            self.assertGreaterEqual(result, 1)
+            self.assertLessEqual(result, 100)
+
+
+class TestParadoxRealmRandomSphere(TestCase):
+    """Test random sphere selection."""
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_correspondence(self, mock_roll):
+        """Test roll 1 returns Correspondence."""
+        mock_roll.return_value = 1
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.CORRESPONDENCE)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_entropy(self, mock_roll):
+        """Test roll 2 returns Entropy."""
+        mock_roll.return_value = 2
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.ENTROPY)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_forces(self, mock_roll):
+        """Test roll 3 returns Forces."""
+        mock_roll.return_value = 3
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.FORCES)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_life(self, mock_roll):
+        """Test roll 4 returns Life."""
+        mock_roll.return_value = 4
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.LIFE)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_matter(self, mock_roll):
+        """Test roll 5 returns Matter."""
+        mock_roll.return_value = 5
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.MATTER)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_mind(self, mock_roll):
+        """Test roll 6 returns Mind."""
+        mock_roll.return_value = 6
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.MIND)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_prime(self, mock_roll):
+        """Test roll 7 returns Prime."""
+        mock_roll.return_value = 7
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.PRIME)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_spirit(self, mock_roll):
+        """Test roll 8 returns Spirit."""
+        mock_roll.return_value = 8
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.SPIRIT)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_time(self, mock_roll):
+        """Test roll 9 returns Time."""
+        mock_roll.return_value = 9
+        sphere = ParadoxRealm.random_sphere()
+        self.assertEqual(sphere, SphereChoices.TIME)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_sphere_two_spheres(self, mock_roll):
+        """Test roll 10 returns None (two spheres indicator)."""
+        mock_roll.return_value = 10
+        sphere = ParadoxRealm.random_sphere()
+        self.assertIsNone(sphere)
+
+
+class TestParadoxRealmRandomParadigm(TestCase):
+    """Test random paradigm selection."""
+
+    @patch.object(ParadoxRealm, "roll_2d10")
+    def test_random_paradigm_unstable(self, mock_roll):
+        """Test roll 1 returns Unstable."""
+        mock_roll.return_value = 1
+        paradigm, secondary = ParadoxRealm.random_paradigm()
+        self.assertEqual(paradigm, ParadigmChoices.UNSTABLE)
+        self.assertIsNone(secondary)
+
+    @patch.object(ParadoxRealm, "roll_2d10")
+    def test_random_paradigm_mechanistic(self, mock_roll):
+        """Test roll 2 returns Mechanistic Cosmos."""
+        mock_roll.return_value = 2
+        paradigm, secondary = ParadoxRealm.random_paradigm()
+        self.assertEqual(paradigm, ParadigmChoices.MECHANISTIC_COSMOS)
+
+    @patch.object(ParadoxRealm, "roll_2d10")
+    def test_random_paradigm_antimagick(self, mock_roll):
+        """Test roll 17-19 returns Antimagick."""
+        mock_roll.return_value = 17
+        paradigm, _ = ParadoxRealm.random_paradigm()
+        self.assertEqual(paradigm, ParadigmChoices.ANTIMAGICK)
+
+    @patch.object(ParadoxRealm, "roll_2d10")
+    def test_random_paradigm_two_paradigms(self, mock_roll):
+        """Test roll 20 returns None (two paradigms indicator)."""
+        mock_roll.return_value = 20
+        paradigm, secondary = ParadoxRealm.random_paradigm()
+        self.assertIsNone(paradigm)
+        self.assertIsNone(secondary)
+
+    @patch.object(ParadoxRealm, "roll_2d10")
+    def test_random_paradigm_characters_paradigm(self, mock_roll):
+        """Test roll 14-16 returns a valid paradigm (character's paradigm)."""
+        mock_roll.return_value = 14
+        paradigm, _ = ParadoxRealm.random_paradigm()
+        # Should be one of the valid paradigms (not UNSTABLE)
+        self.assertIsNotNone(paradigm)
+        self.assertNotEqual(paradigm, ParadigmChoices.UNSTABLE)
+
+
+class TestParadoxRealmRandomObstacleCount(TestCase):
+    """Test random obstacle count selection."""
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_obstacle_count_no_obstacles(self, mock_roll):
+        """Test roll 1 returns 0 obstacles."""
+        mock_roll.return_value = 1
+        primary, random = ParadoxRealm.random_obstacle_count()
+        self.assertEqual(primary, 0)
+        self.assertEqual(random, 0)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_obstacle_count_one_primary(self, mock_roll):
+        """Test roll 2 returns 1 primary obstacle."""
+        mock_roll.return_value = 2
+        primary, random = ParadoxRealm.random_obstacle_count()
+        self.assertEqual(primary, 1)
+        self.assertEqual(random, 0)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_obstacle_count_two_primary(self, mock_roll):
+        """Test roll 3 returns 2 primary obstacles."""
+        mock_roll.return_value = 3
+        primary, random = ParadoxRealm.random_obstacle_count()
+        self.assertEqual(primary, 2)
+        self.assertEqual(random, 0)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_obstacle_count_three_primary(self, mock_roll):
+        """Test roll 4 returns 3 primary obstacles."""
+        mock_roll.return_value = 4
+        primary, random = ParadoxRealm.random_obstacle_count()
+        self.assertEqual(primary, 3)
+        self.assertEqual(random, 0)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    @patch.object(ParadoxRealm, "roll_d5")
+    def test_random_obstacle_count_d5_primary(self, mock_d5, mock_d10):
+        """Test roll 5 returns d5 primary obstacles."""
+        mock_d10.return_value = 5
+        mock_d5.return_value = 4
+        primary, random = ParadoxRealm.random_obstacle_count()
+        self.assertEqual(primary, 4)
+        self.assertEqual(random, 0)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    @patch.object(ParadoxRealm, "roll_d5")
+    def test_random_obstacle_count_mixed(self, mock_d5, mock_d10):
+        """Test roll 6 returns d5 primary and 1 random obstacle."""
+        mock_d10.return_value = 6
+        mock_d5.return_value = 3
+        primary, random = ParadoxRealm.random_obstacle_count()
+        self.assertEqual(primary, 3)
+        self.assertEqual(random, 1)
+
+
+class TestParadoxRealmRandomFinalObstacle(TestCase):
+    """Test random final obstacle selection."""
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_final_obstacle_give_secret(self, mock_roll):
+        """Test roll 1 returns Give Secret."""
+        mock_roll.return_value = 1
+        obstacle, _ = ParadoxRealm.random_final_obstacle()
+        self.assertEqual(obstacle, FinalObstacleTypeChoices.GIVE_SECRET)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_final_obstacle_win_game(self, mock_roll):
+        """Test roll 2 returns Win Game."""
+        mock_roll.return_value = 2
+        obstacle, _ = ParadoxRealm.random_final_obstacle()
+        self.assertEqual(obstacle, FinalObstacleTypeChoices.WIN_GAME)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_final_obstacle_maze(self, mock_roll):
+        """Test roll 5 returns Standard Maze."""
+        mock_roll.return_value = 5
+        obstacle, _ = ParadoxRealm.random_final_obstacle()
+        self.assertEqual(obstacle, FinalObstacleTypeChoices.MAZE)
+
+    @patch.object(ParadoxRealm, "roll_d10")
+    def test_random_final_obstacle_combined(self, mock_roll):
+        """Test roll 10 returns Combined."""
+        mock_roll.return_value = 10
+        obstacle, _ = ParadoxRealm.random_final_obstacle()
+        self.assertEqual(obstacle, FinalObstacleTypeChoices.COMBINED)
+
+
+class TestParadoxRealmRandom(TestCase):
+    """Test complete random realm generation."""
+
+    def test_random_creates_realm(self):
+        """Test random() creates a realm without saving."""
+        realm = ParadoxRealm.random(name="Random Test", save=False)
+        self.assertEqual(realm.name, "Random Test")
+        self.assertIsNone(realm.pk)  # Not saved
+
+    def test_random_saves_realm(self):
+        """Test random() with save=True saves realm."""
+        realm = ParadoxRealm.random(name="Saved Random", save=True)
+        self.assertEqual(realm.name, "Saved Random")
+        self.assertIsNotNone(realm.pk)
+
+    def test_random_generates_valid_spheres(self):
+        """Test random() generates valid sphere values."""
+        realm = ParadoxRealm.random()
+        self.assertIn(realm.primary_sphere, SphereChoices.values)
+        if realm.secondary_sphere:
+            self.assertIn(realm.secondary_sphere, SphereChoices.values)
+
+    def test_random_generates_valid_paradigm(self):
+        """Test random() generates valid paradigm values."""
+        realm = ParadoxRealm.random()
+        self.assertIn(realm.paradigm, ParadigmChoices.values)
+        if realm.secondary_paradigm:
+            self.assertIn(realm.secondary_paradigm, ParadigmChoices.values)
+
+    def test_random_generates_obstacles_when_saved(self):
+        """Test random() generates obstacles when saved."""
+        realm = ParadoxRealm.random(save=True)
+        expected_total = realm.num_primary_obstacles + realm.num_random_obstacles
+        self.assertEqual(realm.realm_obstacles.count(), expected_total)
+
+    def test_random_generates_atmospheres_when_saved(self):
+        """Test random() generates atmospheres when saved."""
+        realm = ParadoxRealm.random(save=True)
+        # Should have 2-3 atmosphere elements
+        self.assertGreaterEqual(realm.realm_atmospheres.count(), 2)
+        self.assertLessEqual(realm.realm_atmospheres.count(), 3)
+
+
+class TestParadoxObstacle(TestCase):
+    """Test ParadoxObstacle model."""
+
+    def test_obstacle_creation(self):
+        """Test creating an obstacle."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        obstacle = ParadoxObstacle.objects.create(
+            realm=realm,
+            sphere=SphereChoices.FORCES,
+            obstacle_number=3,
+            order=1,
+            name="Gap",
+            description="A gap in the forces",
+        )
+        self.assertEqual(obstacle.realm, realm)
+        self.assertEqual(obstacle.sphere, SphereChoices.FORCES)
+        self.assertEqual(obstacle.obstacle_number, 3)
+        self.assertEqual(obstacle.name, "Gap")
+
+    def test_obstacle_str(self):
+        """Test obstacle string representation."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        obstacle = ParadoxObstacle.objects.create(
+            realm=realm,
+            sphere=SphereChoices.MIND,
+            obstacle_number=1,
+            name="Two Guards",
+        )
+        result = str(obstacle)
+        self.assertIn("Two Guards", result)
+        self.assertIn("Mind", result)
+
+    def test_obstacle_ordering(self):
+        """Test obstacles are ordered by order field."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        obs3 = ParadoxObstacle.objects.create(
+            realm=realm, sphere=SphereChoices.TIME, obstacle_number=1, order=3, name="Third"
+        )
+        obs1 = ParadoxObstacle.objects.create(
+            realm=realm, sphere=SphereChoices.TIME, obstacle_number=2, order=1, name="First"
+        )
+        obs2 = ParadoxObstacle.objects.create(
+            realm=realm, sphere=SphereChoices.TIME, obstacle_number=3, order=2, name="Second"
+        )
+        obstacles = list(ParadoxObstacle.objects.filter(realm=realm))
+        self.assertEqual(obstacles[0], obs1)
+        self.assertEqual(obstacles[1], obs2)
+        self.assertEqual(obstacles[2], obs3)
+
+    def test_get_obstacle_name_correspondence(self):
+        """Test get_obstacle_name for Correspondence sphere."""
+        name = ParadoxObstacle.get_obstacle_name(SphereChoices.CORRESPONDENCE, 1)
+        self.assertEqual(name, "Leaning Walls")
+
+    def test_get_obstacle_name_entropy(self):
+        """Test get_obstacle_name for Entropy sphere."""
+        name = ParadoxObstacle.get_obstacle_name(SphereChoices.ENTROPY, 1)
+        self.assertEqual(name, "Shell Game")
+
+    def test_get_obstacle_name_forces(self):
+        """Test get_obstacle_name for Forces sphere."""
+        name = ParadoxObstacle.get_obstacle_name(SphereChoices.FORCES, 4)
+        self.assertEqual(name, "Fire")
+
+    def test_get_obstacle_name_unknown(self):
+        """Test get_obstacle_name for unknown sphere/roll."""
+        name = ParadoxObstacle.get_obstacle_name("unknown", 99)
+        self.assertIn("99", name)
+
+    def test_obstacle_random(self):
+        """Test random obstacle generation."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        obstacle = ParadoxObstacle.random(
+            realm=realm, sphere=SphereChoices.LIFE, order=0, save=False
+        )
+        self.assertEqual(obstacle.realm, realm)
+        self.assertEqual(obstacle.sphere, SphereChoices.LIFE)
+        self.assertIsNone(obstacle.pk)
+
+    def test_obstacle_random_save(self):
+        """Test random obstacle generation with save."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        obstacle = ParadoxObstacle.random(
+            realm=realm, sphere=SphereChoices.MATTER, order=0, save=True
+        )
+        self.assertIsNotNone(obstacle.pk)
+
+
+class TestParadoxAtmosphere(TestCase):
+    """Test ParadoxAtmosphere model."""
+
+    def test_atmosphere_creation(self):
+        """Test creating an atmosphere element."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        atmosphere = ParadoxAtmosphere.objects.create(
+            realm=realm,
+            paradigm=ParadigmChoices.CHAOS,
+            atmosphere_number=1,
+            description="Pulsating colors",
+        )
+        self.assertEqual(atmosphere.realm, realm)
+        self.assertEqual(atmosphere.paradigm, ParadigmChoices.CHAOS)
+        self.assertEqual(atmosphere.atmosphere_number, 1)
+
+    def test_atmosphere_str(self):
+        """Test atmosphere string representation."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        atmosphere = ParadoxAtmosphere.objects.create(
+            realm=realm,
+            paradigm=ParadigmChoices.DATA,
+            atmosphere_number=5,
+            description="Wireframe world",
+        )
+        result = str(atmosphere)
+        self.assertIn("Data", result)
+        self.assertIn("5", result)
+
+    def test_get_atmosphere_description_antimagick(self):
+        """Test get_atmosphere_description for Antimagick paradigm."""
+        desc = ParadoxAtmosphere.get_atmosphere_description(ParadigmChoices.ANTIMAGICK, 1)
+        self.assertIn("chains", desc.lower())
+
+    def test_get_atmosphere_description_chaos(self):
+        """Test get_atmosphere_description for Chaos paradigm."""
+        desc = ParadoxAtmosphere.get_atmosphere_description(ParadigmChoices.CHAOS, 1)
+        self.assertIn("color", desc.lower())
+
+    def test_get_atmosphere_description_unknown(self):
+        """Test get_atmosphere_description for unknown paradigm."""
+        desc = ParadoxAtmosphere.get_atmosphere_description("unknown", 99)
+        self.assertIn("99", desc)
+
+    def test_atmosphere_random(self):
+        """Test random atmosphere generation."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        atmosphere = ParadoxAtmosphere.random(
+            realm=realm, paradigm=ParadigmChoices.FAITH, save=False
+        )
+        self.assertEqual(atmosphere.realm, realm)
+        self.assertEqual(atmosphere.paradigm, ParadigmChoices.FAITH)
+        self.assertIsNone(atmosphere.pk)
+
+    def test_atmosphere_random_save(self):
+        """Test random atmosphere generation with save."""
+        realm = ParadoxRealm.objects.create(name="Test Realm")
+        atmosphere = ParadoxAtmosphere.random(
+            realm=realm, paradigm=ParadigmChoices.TECH, save=True
+        )
+        self.assertIsNotNone(atmosphere.pk)
+
+
+class TestSphereChoices(TestCase):
+    """Test SphereChoices enumeration."""
+
+    def test_all_spheres_present(self):
+        """Test all nine spheres are present."""
+        spheres = SphereChoices.values
+        self.assertEqual(len(spheres), 9)
+        self.assertIn("correspondence", spheres)
+        self.assertIn("entropy", spheres)
+        self.assertIn("forces", spheres)
+        self.assertIn("life", spheres)
+        self.assertIn("matter", spheres)
+        self.assertIn("mind", spheres)
+        self.assertIn("prime", spheres)
+        self.assertIn("spirit", spheres)
+        self.assertIn("time", spheres)
+
+
+class TestParadigmChoices(TestCase):
+    """Test ParadigmChoices enumeration."""
+
+    def test_paradigm_choices_exist(self):
+        """Test paradigm choices are defined."""
+        self.assertGreater(len(ParadigmChoices.values), 0)
+
+    def test_antimagick_paradigm(self):
+        """Test antimagick paradigm exists."""
+        self.assertIn(ParadigmChoices.ANTIMAGICK, ParadigmChoices.values)
+
+    def test_unstable_paradigm(self):
+        """Test unstable paradigm exists."""
+        self.assertIn(ParadigmChoices.UNSTABLE, ParadigmChoices.values)
+
+
+class TestFinalObstacleTypeChoices(TestCase):
+    """Test FinalObstacleTypeChoices enumeration."""
+
+    def test_final_obstacle_choices_exist(self):
+        """Test final obstacle choices are defined."""
+        self.assertGreater(len(FinalObstacleTypeChoices.values), 0)
+
+    def test_maze_obstacle_exists(self):
+        """Test maze obstacle type exists."""
+        self.assertIn(FinalObstacleTypeChoices.MAZE, FinalObstacleTypeChoices.values)
+
+    def test_combined_obstacle_exists(self):
+        """Test combined obstacle type exists."""
+        self.assertIn(FinalObstacleTypeChoices.COMBINED, FinalObstacleTypeChoices.values)

--- a/locations/tests/models/vampire/test_domain.py
+++ b/locations/tests/models/vampire/test_domain.py
@@ -1,5 +1,279 @@
-"""Tests for domain module."""
+"""Tests for Domain model."""
 
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
+from locations.models.vampire.domain import Domain
 
-# TODO: Move relevant tests from existing test files here
+
+class TestDomainBasics(TestCase):
+    """Test basic Domain model functionality."""
+
+    def test_domain_creation(self):
+        """Test creating a domain."""
+        domain = Domain.objects.create(
+            name="Downtown District",
+            size=3,
+            population=2,
+            control=2,
+        )
+        self.assertEqual(domain.name, "Downtown District")
+        self.assertEqual(domain.size, 3)
+        self.assertEqual(domain.population, 2)
+        self.assertEqual(domain.control, 2)
+        self.assertEqual(domain.type, "domain")
+        self.assertEqual(domain.gameline, "vtm")
+
+    def test_domain_defaults(self):
+        """Test domain default values."""
+        domain = Domain.objects.create(name="Test Domain")
+        self.assertEqual(domain.size, 0)
+        self.assertEqual(domain.population, 0)
+        self.assertEqual(domain.control, 0)
+        self.assertFalse(domain.is_elysium)
+        self.assertFalse(domain.has_rack)
+        self.assertFalse(domain.is_disputed)
+        self.assertEqual(domain.domain_type, "")
+
+    def test_domain_get_heading(self):
+        """Test get_heading returns vtm_heading."""
+        domain = Domain.objects.create(name="Test")
+        self.assertEqual(domain.get_heading(), "vtm_heading")
+
+    def test_domain_get_update_url(self):
+        """Test get_update_url returns valid URL."""
+        domain = Domain.objects.create(name="Test")
+        url = domain.get_update_url()
+        self.assertIn(str(domain.id), url)
+        self.assertIn("domain", url)
+
+    def test_domain_get_creation_url(self):
+        """Test get_creation_url returns valid URL."""
+        url = Domain.get_creation_url()
+        self.assertIn("domain", url)
+
+
+class TestDomainTotalRating(TestCase):
+    """Test Domain total rating calculation."""
+
+    def test_calculate_total_rating_basic(self):
+        """Test basic total rating calculation."""
+        domain = Domain.objects.create(
+            name="Test",
+            size=2,
+            population=3,
+            control=1,
+        )
+        # Total = size + population + control = 2 + 3 + 1 = 6
+        self.assertEqual(domain.total_rating, 6)
+
+    def test_calculate_total_rating_with_rack(self):
+        """Test total rating with rack bonus."""
+        domain = Domain.objects.create(
+            name="Test",
+            size=2,
+            population=2,
+            control=2,
+            has_rack=True,
+        )
+        # Total = 2 + 2 + 2 + 1 (rack) = 7
+        self.assertEqual(domain.total_rating, 7)
+
+    def test_calculate_total_rating_disputed(self):
+        """Test total rating with disputed penalty."""
+        domain = Domain.objects.create(
+            name="Test",
+            size=2,
+            population=2,
+            control=2,
+            is_disputed=True,
+        )
+        # Total = 2 + 2 + 2 - 1 (disputed) = 5
+        self.assertEqual(domain.total_rating, 5)
+
+    def test_calculate_total_rating_rack_and_disputed(self):
+        """Test total rating with rack and disputed."""
+        domain = Domain.objects.create(
+            name="Test",
+            size=2,
+            population=2,
+            control=2,
+            has_rack=True,
+            is_disputed=True,
+        )
+        # Total = 2 + 2 + 2 + 1 (rack) - 1 (disputed) = 6
+        self.assertEqual(domain.total_rating, 6)
+
+    def test_calculate_total_rating_no_negative(self):
+        """Test total rating cannot go negative."""
+        domain = Domain.objects.create(
+            name="Test",
+            size=0,
+            population=0,
+            control=0,
+            is_disputed=True,
+        )
+        # Total = 0 + 0 + 0 - 1 (disputed) = -1, but should be clamped to 0
+        self.assertEqual(domain.total_rating, 0)
+
+    def test_save_recalculates_total_rating(self):
+        """Test save() recalculates total rating."""
+        domain = Domain.objects.create(
+            name="Test",
+            size=1,
+            population=1,
+            control=1,
+        )
+        self.assertEqual(domain.total_rating, 3)
+
+        domain.size = 3
+        domain.population = 3
+        domain.control = 3
+        domain.save()
+        domain.refresh_from_db()
+        self.assertEqual(domain.total_rating, 9)
+
+
+class TestDomainFeatures(TestCase):
+    """Test Domain special features."""
+
+    def test_is_elysium(self):
+        """Test is_elysium feature."""
+        domain = Domain.objects.create(name="Test", is_elysium=True)
+        self.assertTrue(domain.is_elysium)
+
+    def test_has_rack(self):
+        """Test has_rack feature."""
+        domain = Domain.objects.create(name="Test", has_rack=True)
+        self.assertTrue(domain.has_rack)
+
+    def test_is_disputed(self):
+        """Test is_disputed feature."""
+        domain = Domain.objects.create(name="Test", is_disputed=True)
+        self.assertTrue(domain.is_disputed)
+
+    def test_domain_type(self):
+        """Test domain_type field."""
+        domain = Domain.objects.create(
+            name="Test",
+            domain_type="Nightclub district",
+        )
+        self.assertEqual(domain.domain_type, "Nightclub district")
+
+
+class TestDomainViews(TestCase):
+    """Test Domain views integration."""
+
+    def test_domain_list_view(self):
+        """Test domain list view."""
+        Domain.objects.create(name="Domain 1")
+        Domain.objects.create(name="Domain 2")
+        response = self.client.get("/locations/vampire/domain/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Domain 1")
+        self.assertContains(response, "Domain 2")
+
+    def test_domain_detail_view(self):
+        """Test domain detail view."""
+        user = User.objects.create_user(username="testuser", password="password")
+        domain = Domain.objects.create(
+            name="Test Domain",
+            size=3,
+            population=2,
+            control=2,
+            owner=user,
+            status="App",
+        )
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(domain.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Domain")
+
+    def test_domain_create_view(self):
+        """Test domain create view."""
+        user = User.objects.create_user(username="testuser", password="password")
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(Domain.get_creation_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_domain_create_post(self):
+        """Test creating domain via POST."""
+        user = User.objects.create_user(username="testuser", password="password")
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Domain",
+            "description": "A new domain",
+            "size": 2,
+            "population": 3,
+            "control": 2,
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(Domain.get_creation_url(), data=data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Domain.objects.filter(name="New Domain").exists())
+        domain = Domain.objects.get(name="New Domain")
+        self.assertEqual(domain.total_rating, 7)  # 2 + 3 + 2
+
+    def test_domain_update_view(self):
+        """Test domain update view."""
+        st = User.objects.create_user(username="st_user", password="password")
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        chronicle.storytellers.add(st)
+        domain = Domain.objects.create(
+            name="Existing Domain",
+            size=1,
+            population=1,
+            control=1,
+            owner=st,
+            chronicle=chronicle,
+            status="App",
+        )
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(domain.get_update_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_domain_update_post(self):
+        """Test updating domain via POST."""
+        st = User.objects.create_user(username="st_user", password="password")
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        chronicle.storytellers.add(st)
+        domain = Domain.objects.create(
+            name="Existing Domain",
+            size=1,
+            population=1,
+            control=1,
+            owner=st,
+            chronicle=chronicle,
+            status="App",
+        )
+        self.client.login(username="st_user", password="password")
+        data = {
+            "name": "Updated Domain",
+            "description": "Updated description",
+            "size": 4,
+            "population": 4,
+            "control": 4,
+            "has_rack": True,
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(domain.get_update_url(), data=data)
+        self.assertEqual(response.status_code, 302)
+        domain.refresh_from_db()
+        self.assertEqual(domain.name, "Updated Domain")
+        self.assertEqual(domain.total_rating, 13)  # 4 + 4 + 4 + 1 (rack)
+
+
+class TestDomainMeta(TestCase):
+    """Test Domain Meta class."""
+
+    def test_verbose_name(self):
+        """Test verbose name."""
+        self.assertEqual(Domain._meta.verbose_name, "Domain")
+
+    def test_verbose_name_plural(self):
+        """Test verbose name plural."""
+        self.assertEqual(Domain._meta.verbose_name_plural, "Domains")

--- a/locations/tests/models/wraith/test_haunt.py
+++ b/locations/tests/models/wraith/test_haunt.py
@@ -1,5 +1,335 @@
-"""Tests for haunt module."""
+"""Tests for Haunt model."""
 
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
+from locations.models.wraith.haunt import Haunt
 
-# TODO: Move relevant tests from existing test files here
+
+class TestHauntBasics(TestCase):
+    """Test basic Haunt model functionality."""
+
+    def test_haunt_creation(self):
+        """Test creating a haunt."""
+        haunt = Haunt.objects.create(
+            name="Old Cemetery",
+            rank=3,
+            shroud_rating=3,
+            haunt_type="sacred_site",
+        )
+        self.assertEqual(haunt.name, "Old Cemetery")
+        self.assertEqual(haunt.rank, 3)
+        self.assertEqual(haunt.shroud_rating, 3)
+        self.assertEqual(haunt.haunt_type, "sacred_site")
+        self.assertEqual(haunt.type, "haunt")
+        self.assertEqual(haunt.gameline, "wto")
+
+    def test_haunt_defaults(self):
+        """Test haunt default values."""
+        haunt = Haunt.objects.create(name="Test Haunt")
+        self.assertEqual(haunt.rank, 1)
+        self.assertEqual(haunt.shroud_rating, 5)
+        self.assertEqual(haunt.haunt_type, "sacred_site")
+        self.assertEqual(haunt.haunt_size, "single_room")
+        self.assertEqual(haunt.faith_resonance, "")
+        self.assertTrue(haunt.attracts_ghosts)
+
+    def test_haunt_str(self):
+        """Test haunt string representation."""
+        haunt = Haunt.objects.create(name="The Morgue")
+        self.assertEqual(str(haunt), "The Morgue (Haunt)")
+
+    def test_haunt_get_heading(self):
+        """Test get_heading returns wto_heading."""
+        haunt = Haunt.objects.create(name="Test")
+        self.assertEqual(haunt.get_heading(), "wto_heading")
+
+    def test_haunt_get_absolute_url(self):
+        """Test get_absolute_url returns valid URL."""
+        haunt = Haunt.objects.create(name="Test")
+        url = haunt.get_absolute_url()
+        self.assertIn(str(haunt.pk), url)
+        self.assertIn("haunt", url)
+
+    def test_haunt_get_update_url(self):
+        """Test get_update_url returns valid URL."""
+        haunt = Haunt.objects.create(name="Test")
+        url = haunt.get_update_url()
+        self.assertIn(str(haunt.id), url)
+        self.assertIn("haunt", url)
+
+    def test_haunt_get_creation_url(self):
+        """Test get_creation_url returns valid URL."""
+        url = Haunt.get_creation_url()
+        self.assertIn("haunt", url)
+
+
+class TestHauntSetRank(TestCase):
+    """Test Haunt set_rank method."""
+
+    def test_set_rank_1(self):
+        """Test set_rank for rank 1 sets shroud 5."""
+        haunt = Haunt.objects.create(name="Test")
+        result = haunt.set_rank(1)
+        self.assertTrue(result)
+        self.assertEqual(haunt.rank, 1)
+        self.assertEqual(haunt.shroud_rating, 5)
+
+    def test_set_rank_2(self):
+        """Test set_rank for rank 2 sets shroud 4."""
+        haunt = Haunt.objects.create(name="Test")
+        result = haunt.set_rank(2)
+        self.assertTrue(result)
+        self.assertEqual(haunt.rank, 2)
+        self.assertEqual(haunt.shroud_rating, 4)
+
+    def test_set_rank_3(self):
+        """Test set_rank for rank 3 sets shroud 3."""
+        haunt = Haunt.objects.create(name="Test")
+        result = haunt.set_rank(3)
+        self.assertTrue(result)
+        self.assertEqual(haunt.rank, 3)
+        self.assertEqual(haunt.shroud_rating, 3)
+
+    def test_set_rank_4(self):
+        """Test set_rank for rank 4 sets shroud 2."""
+        haunt = Haunt.objects.create(name="Test")
+        result = haunt.set_rank(4)
+        self.assertTrue(result)
+        self.assertEqual(haunt.rank, 4)
+        self.assertEqual(haunt.shroud_rating, 2)
+
+    def test_set_rank_5(self):
+        """Test set_rank for rank 5 sets shroud 1."""
+        haunt = Haunt.objects.create(name="Test")
+        result = haunt.set_rank(5)
+        self.assertTrue(result)
+        self.assertEqual(haunt.rank, 5)
+        self.assertEqual(haunt.shroud_rating, 1)
+
+    def test_set_rank_invalid(self):
+        """Test set_rank for invalid rank uses default shroud 5."""
+        haunt = Haunt.objects.create(name="Test")
+        result = haunt.set_rank(10)
+        self.assertTrue(result)
+        self.assertEqual(haunt.rank, 10)
+        self.assertEqual(haunt.shroud_rating, 5)
+
+
+class TestHauntTypes(TestCase):
+    """Test Haunt type choices."""
+
+    def test_haunt_type_sacred_site(self):
+        """Test sacred_site haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="sacred_site")
+        self.assertEqual(haunt.haunt_type, "sacred_site")
+
+    def test_haunt_type_battlefield(self):
+        """Test battlefield haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="battlefield")
+        self.assertEqual(haunt.haunt_type, "battlefield")
+
+    def test_haunt_type_crime_scene(self):
+        """Test crime_scene haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="crime_scene")
+        self.assertEqual(haunt.haunt_type, "crime_scene")
+
+    def test_haunt_type_sickroom(self):
+        """Test sickroom haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="sickroom")
+        self.assertEqual(haunt.haunt_type, "sickroom")
+
+    def test_haunt_type_place_of_worship(self):
+        """Test place_of_worship haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="place_of_worship")
+        self.assertEqual(haunt.haunt_type, "place_of_worship")
+
+    def test_haunt_type_place_of_tragedy(self):
+        """Test place_of_tragedy haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="place_of_tragedy")
+        self.assertEqual(haunt.haunt_type, "place_of_tragedy")
+
+    def test_haunt_type_other(self):
+        """Test other haunt type."""
+        haunt = Haunt.objects.create(name="Test", haunt_type="other")
+        self.assertEqual(haunt.haunt_type, "other")
+
+
+class TestHauntSizes(TestCase):
+    """Test Haunt size choices."""
+
+    def test_haunt_size_single_room(self):
+        """Test single_room size."""
+        haunt = Haunt.objects.create(name="Test", haunt_size="single_room")
+        self.assertEqual(haunt.haunt_size, "single_room")
+
+    def test_haunt_size_apartment(self):
+        """Test apartment size."""
+        haunt = Haunt.objects.create(name="Test", haunt_size="apartment")
+        self.assertEqual(haunt.haunt_size, "apartment")
+
+    def test_haunt_size_house(self):
+        """Test house size."""
+        haunt = Haunt.objects.create(name="Test", haunt_size="house")
+        self.assertEqual(haunt.haunt_size, "house")
+
+    def test_haunt_size_mansion(self):
+        """Test mansion size."""
+        haunt = Haunt.objects.create(name="Test", haunt_size="mansion")
+        self.assertEqual(haunt.haunt_size, "mansion")
+
+    def test_haunt_size_estate(self):
+        """Test estate size."""
+        haunt = Haunt.objects.create(name="Test", haunt_size="estate")
+        self.assertEqual(haunt.haunt_size, "estate")
+
+
+class TestHauntFeatures(TestCase):
+    """Test Haunt features."""
+
+    def test_faith_resonance(self):
+        """Test faith_resonance field."""
+        haunt = Haunt.objects.create(
+            name="Test",
+            faith_resonance="Strong Catholic devotion",
+        )
+        self.assertEqual(haunt.faith_resonance, "Strong Catholic devotion")
+
+    def test_attracts_ghosts_default(self):
+        """Test attracts_ghosts defaults to True."""
+        haunt = Haunt.objects.create(name="Test")
+        self.assertTrue(haunt.attracts_ghosts)
+
+    def test_attracts_ghosts_false(self):
+        """Test attracts_ghosts can be False."""
+        haunt = Haunt.objects.create(name="Test", attracts_ghosts=False)
+        self.assertFalse(haunt.attracts_ghosts)
+
+
+class TestHauntViews(TestCase):
+    """Test Haunt views integration."""
+
+    def test_haunt_list_view(self):
+        """Test haunt list view."""
+        Haunt.objects.create(name="Haunt 1")
+        Haunt.objects.create(name="Haunt 2")
+        response = self.client.get("/locations/wraith/haunt/")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Haunt 1")
+        self.assertContains(response, "Haunt 2")
+
+    def test_haunt_detail_view(self):
+        """Test haunt detail view."""
+        user = User.objects.create_user(username="testuser", password="password")
+        haunt = Haunt.objects.create(
+            name="Test Haunt",
+            rank=3,
+            shroud_rating=3,
+            owner=user,
+            status="App",
+        )
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(haunt.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Test Haunt")
+
+    def test_haunt_create_view(self):
+        """Test haunt create view."""
+        user = User.objects.create_user(username="testuser", password="password")
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(Haunt.get_creation_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_haunt_create_post(self):
+        """Test creating haunt via POST."""
+        user = User.objects.create_user(username="testuser", password="password")
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Haunt",
+            "description": "A new haunt",
+            "rank": 4,
+            "shroud_rating": 2,
+            "haunt_type": "battlefield",
+            "haunt_size": "house",
+            "faith_resonance": "War dead",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(Haunt.get_creation_url(), data=data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Haunt.objects.filter(name="New Haunt").exists())
+        haunt = Haunt.objects.get(name="New Haunt")
+        self.assertEqual(haunt.rank, 4)
+        self.assertEqual(haunt.shroud_rating, 2)
+
+    def test_haunt_update_view(self):
+        """Test haunt update view."""
+        st = User.objects.create_user(username="st_user", password="password")
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        chronicle.storytellers.add(st)
+        haunt = Haunt.objects.create(
+            name="Existing Haunt",
+            rank=2,
+            shroud_rating=4,
+            owner=st,
+            chronicle=chronicle,
+            status="App",
+        )
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(haunt.get_update_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_haunt_update_post(self):
+        """Test updating haunt via POST."""
+        st = User.objects.create_user(username="st_user", password="password")
+        chronicle = Chronicle.objects.create(name="Test Chronicle")
+        chronicle.storytellers.add(st)
+        haunt = Haunt.objects.create(
+            name="Existing Haunt",
+            rank=2,
+            shroud_rating=4,
+            owner=st,
+            chronicle=chronicle,
+            status="App",
+        )
+        self.client.login(username="st_user", password="password")
+        data = {
+            "name": "Updated Haunt",
+            "description": "Updated description",
+            "rank": 5,
+            "shroud_rating": 1,
+            "haunt_type": "place_of_tragedy",
+            "haunt_size": "mansion",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(haunt.get_update_url(), data=data)
+        self.assertEqual(response.status_code, 302)
+        haunt.refresh_from_db()
+        self.assertEqual(haunt.name, "Updated Haunt")
+        self.assertEqual(haunt.rank, 5)
+        self.assertEqual(haunt.shroud_rating, 1)
+
+
+class TestHauntMeta(TestCase):
+    """Test Haunt Meta class."""
+
+    def test_verbose_name(self):
+        """Test verbose name."""
+        self.assertEqual(Haunt._meta.verbose_name, "Haunt")
+
+    def test_verbose_name_plural(self):
+        """Test verbose name plural."""
+        self.assertEqual(Haunt._meta.verbose_name_plural, "Haunts")
+
+    def test_ordering(self):
+        """Test ordering by name."""
+        Haunt.objects.create(name="Zeta Haunt")
+        Haunt.objects.create(name="Alpha Haunt")
+        Haunt.objects.create(name="Beta Haunt")
+        haunts = list(Haunt.objects.all())
+        self.assertEqual(haunts[0].name, "Alpha Haunt")
+        self.assertEqual(haunts[1].name, "Beta Haunt")
+        self.assertEqual(haunts[2].name, "Zeta Haunt")

--- a/locations/tests/views/mage/test_chantry.py
+++ b/locations/tests/views/mage/test_chantry.py
@@ -1,5 +1,343 @@
-"""Tests for chantry module."""
+"""Tests for Chantry views."""
 
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
+from locations.models.mage.chantry import Chantry
 
-# TODO: Move relevant tests from existing test files here
+
+class TestChantryListView(TestCase):
+    """Test ChantryListView."""
+
+    def test_list_view_status_code(self):
+        """Test list view returns 200."""
+        response = self.client.get("/locations/mage/chantry/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """Test list view uses correct template."""
+        response = self.client.get("/locations/mage/chantry/")
+        self.assertTemplateUsed(response, "locations/mage/chantry/list.html")
+
+    def test_list_view_content(self):
+        """Test list view shows chantries."""
+        for i in range(5):
+            Chantry.objects.create(name=f"Test Chantry {i}")
+        response = self.client.get("/locations/mage/chantry/")
+        for i in range(5):
+            self.assertContains(response, f"Test Chantry {i}")
+
+    def test_list_view_ordering(self):
+        """Test list view orders by name."""
+        Chantry.objects.create(name="Zeta Chantry")
+        Chantry.objects.create(name="Alpha Chantry")
+        Chantry.objects.create(name="Beta Chantry")
+        response = self.client.get("/locations/mage/chantry/")
+        content = response.content.decode()
+        alpha_pos = content.find("Alpha Chantry")
+        beta_pos = content.find("Beta Chantry")
+        zeta_pos = content.find("Zeta Chantry")
+        self.assertLess(alpha_pos, beta_pos)
+        self.assertLess(beta_pos, zeta_pos)
+
+
+class TestChantryDetailView(TestCase):
+    """Test ChantryDetailView."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.chantry = Chantry.objects.create(
+            name="Test Chantry",
+            description="A test chantry",
+            owner=self.user,
+            status="App",
+            total_points=20,
+        )
+        self.url = self.chantry.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/mage/chantry/detail.html")
+
+    def test_detail_view_content(self):
+        """Test detail view shows chantry details."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Chantry")
+
+
+class TestChantryCreateView(TestCase):
+    """Test ChantryCreateView."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.url = Chantry.get_creation_url()
+
+    def test_create_view_requires_login(self):
+        """Test create view requires authentication."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response.url)
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200 for logged-in user."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/mage/chantry/form.html")
+
+    def test_create_view_post(self):
+        """Test successful POST creates chantry."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Chantry",
+            "description": "A new chantry",
+            "total_points": 30,
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(Chantry.objects.filter(name="New Chantry").exists())
+
+
+class TestChantryUpdateView(TestCase):
+    """Test ChantryUpdateView."""
+
+    def setUp(self):
+        self.st = User.objects.create_user(username="st_user", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.chantry = Chantry.objects.create(
+            name="Existing Chantry",
+            description="An existing chantry",
+            owner=self.st,
+            chronicle=self.chronicle,
+            status="App",
+            total_points=25,
+        )
+        self.url = self.chantry.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200 for ST."""
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/mage/chantry/form.html")
+
+    def test_update_view_post(self):
+        """Test successful POST updates chantry."""
+        self.client.login(username="st_user", password="password")
+        data = {
+            "name": "Updated Chantry",
+            "description": "Updated description",
+            "total_points": 35,
+            "gauntlet": 4,
+            "shroud": 5,
+            "dimension_barrier": 5,
+        }
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 302)
+        self.chantry.refresh_from_db()
+        self.assertEqual(self.chantry.name, "Updated Chantry")
+        self.assertEqual(self.chantry.total_points, 35)
+
+
+class TestChantryModel(TestCase):
+    """Test Chantry model methods accessed by views."""
+
+    def test_chantry_creation(self):
+        """Test creating a chantry."""
+        chantry = Chantry.objects.create(
+            name="Test Chantry",
+            total_points=30,
+        )
+        self.assertEqual(chantry.name, "Test Chantry")
+        self.assertEqual(chantry.total_points, 30)
+        self.assertEqual(chantry.type, "chantry")
+        self.assertEqual(chantry.gameline, "mta")
+
+    def test_chantry_get_heading(self):
+        """Test get_heading returns mta_heading."""
+        chantry = Chantry.objects.create(name="Test")
+        self.assertEqual(chantry.get_heading(), "mta_heading")
+
+    def test_chantry_points_property(self):
+        """Test points property calculation."""
+        chantry = Chantry.objects.create(name="Test", total_points=30)
+        # Points = total_points - total_cost
+        # With no backgrounds or effects, points should equal total_points
+        self.assertEqual(chantry.points, 30)
+
+    def test_chantry_rank_property(self):
+        """Test rank property based on total_points."""
+        # Rank 1: < 11 points
+        c1 = Chantry.objects.create(name="Rank1", total_points=10)
+        self.assertEqual(c1.rank, 1)
+
+        # Rank 2: 11-20 points
+        c2 = Chantry.objects.create(name="Rank2", total_points=15)
+        self.assertEqual(c2.rank, 2)
+
+        # Rank 3: 21-30 points
+        c3 = Chantry.objects.create(name="Rank3", total_points=25)
+        self.assertEqual(c3.rank, 3)
+
+        # Rank 4: 31-70 points
+        c4 = Chantry.objects.create(name="Rank4", total_points=50)
+        self.assertEqual(c4.rank, 4)
+
+        # Rank 5: > 70 points
+        c5 = Chantry.objects.create(name="Rank5", total_points=100)
+        self.assertEqual(c5.rank, 5)
+
+    def test_chantry_has_season(self):
+        """Test has_season method."""
+        chantry = Chantry.objects.create(name="Test")
+        self.assertFalse(chantry.has_season())
+        chantry.season = "spring"
+        chantry.save()
+        self.assertTrue(chantry.has_season())
+
+    def test_chantry_set_season(self):
+        """Test set_season method."""
+        chantry = Chantry.objects.create(name="Test")
+        result = chantry.set_season("winter")
+        self.assertTrue(result)
+        self.assertEqual(chantry.season, "winter")
+
+    def test_chantry_has_chantry_type(self):
+        """Test has_chantry_type method."""
+        chantry = Chantry.objects.create(name="Test")
+        self.assertFalse(chantry.has_chantry_type())
+        chantry.chantry_type = "exploration"
+        chantry.save()
+        self.assertTrue(chantry.has_chantry_type())
+
+    def test_chantry_set_chantry_type(self):
+        """Test set_chantry_type method."""
+        chantry = Chantry.objects.create(name="Test")
+        result = chantry.set_chantry_type("fortress")
+        self.assertTrue(result)
+        self.assertEqual(chantry.chantry_type, "fortress")
+
+    def test_chantry_trait_cost(self):
+        """Test trait_cost method."""
+        chantry = Chantry.objects.create(name="Test")
+        # Cost 2 traits
+        self.assertEqual(chantry.trait_cost("allies"), 2)
+        self.assertEqual(chantry.trait_cost("library"), 2)
+        # Cost 3 traits
+        self.assertEqual(chantry.trait_cost("node"), 3)
+        self.assertEqual(chantry.trait_cost("resources"), 3)
+        # Cost 4 traits
+        self.assertEqual(chantry.trait_cost("enhancement"), 4)
+        self.assertEqual(chantry.trait_cost("requisitions"), 4)
+        # Cost 5 traits
+        self.assertEqual(chantry.trait_cost("sanctum"), 5)
+        # Unknown - high cost
+        self.assertEqual(chantry.trait_cost("unknown"), 1000)
+
+    def test_chantry_integrated_effects_number(self):
+        """Test integrated_effects_number method."""
+        chantry = Chantry.objects.create(name="Test")
+        # Score 0 -> 0 points
+        self.assertEqual(chantry.integrated_effects_number(), 0)
+        chantry.integrated_effects_score = 1
+        self.assertEqual(chantry.integrated_effects_number(), 4)
+        chantry.integrated_effects_score = 5
+        self.assertEqual(chantry.integrated_effects_number(), 25)
+
+    def test_chantry_allowed_backgrounds(self):
+        """Test allowed_backgrounds class attribute."""
+        self.assertIn("allies", Chantry.allowed_backgrounds)
+        self.assertIn("node", Chantry.allowed_backgrounds)
+        self.assertIn("library", Chantry.allowed_backgrounds)
+        self.assertIn("sanctum", Chantry.allowed_backgrounds)
+
+
+class TestChantryLeadership(TestCase):
+    """Test Chantry leadership choices."""
+
+    def test_leadership_choices(self):
+        """Test leadership type choices exist."""
+        choices = dict(Chantry.LEADERSHIP_CHOICES)
+        self.assertIn("panel", choices)
+        self.assertIn("democracy", choices)
+        self.assertIn("single_deacon", choices)
+        self.assertIn("council_of_elders", choices)
+
+    def test_set_leadership(self):
+        """Test setting leadership type."""
+        chantry = Chantry.objects.create(name="Test")
+        chantry.leadership_type = "triumvirate"
+        chantry.save()
+        chantry.refresh_from_db()
+        self.assertEqual(chantry.leadership_type, "triumvirate")
+
+
+class TestChantrySeasons(TestCase):
+    """Test Chantry season choices."""
+
+    def test_season_choices(self):
+        """Test season choices exist."""
+        choices = dict(Chantry.SEASONS)
+        self.assertIn("spring", choices)
+        self.assertIn("summer", choices)
+        self.assertIn("autumn", choices)
+        self.assertIn("winter", choices)
+
+
+class TestChantryTypes(TestCase):
+    """Test Chantry type choices."""
+
+    def test_chantry_type_choices(self):
+        """Test chantry type choices exist."""
+        choices = dict(Chantry.CHANTRY_TYPES)
+        self.assertIn("exploration", choices)
+        self.assertIn("ancestral", choices)
+        self.assertIn("college", choices)
+        self.assertIn("war", choices)
+        self.assertIn("library", choices)
+        self.assertIn("research", choices)
+        self.assertIn("fortress", choices)
+
+
+class TestChantryFactionalNames(TestCase):
+    """Test Chantry factional names mapping."""
+
+    def test_factional_names_exist(self):
+        """Test factional names mapping exists."""
+        self.assertIn("Order of Hermes", Chantry.factional_names)
+        self.assertIn("Virtual Adepts", Chantry.factional_names)
+        self.assertIn("Technocratic Union", Chantry.factional_names)
+
+    def test_hermetic_chantry_names(self):
+        """Test Order of Hermes chantry names."""
+        names = Chantry.factional_names["Order of Hermes"]
+        self.assertIn("Covenant", names)
+        self.assertIn("Chantry", names)
+
+    def test_technocracy_construct_name(self):
+        """Test Technocracy uses Construct."""
+        names = Chantry.factional_names["Technocratic Union"]
+        self.assertIn("Construct", names)

--- a/locations/tests/views/mage/test_paradox_realm.py
+++ b/locations/tests/views/mage/test_paradox_realm.py
@@ -1,5 +1,250 @@
-"""Tests for paradox_realm module."""
+"""Tests for ParadoxRealm views."""
 
+from django.contrib.auth.models import User
 from django.test import TestCase
+from game.models import Chronicle
+from locations.models.mage.paradox_realm import (
+    ParadoxAtmosphere,
+    ParadoxObstacle,
+    ParadoxRealm,
+    ParadigmChoices,
+    SphereChoices,
+)
 
-# TODO: Move relevant tests from existing test files here
+
+class TestParadoxRealmListView(TestCase):
+    """Test ParadoxRealmListView."""
+
+    def test_list_view_status_code(self):
+        """Test list view returns 200."""
+        response = self.client.get("/locations/mage/paradox_realm/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_list_view_template(self):
+        """Test list view uses correct template."""
+        response = self.client.get("/locations/mage/paradox_realm/")
+        self.assertTemplateUsed(response, "locations/mage/paradox_realm/list.html")
+
+    def test_list_view_content(self):
+        """Test list view shows realms."""
+        for i in range(5):
+            ParadoxRealm.objects.create(name=f"Test Realm {i}")
+        response = self.client.get("/locations/mage/paradox_realm/")
+        for i in range(5):
+            self.assertContains(response, f"Test Realm {i}")
+
+    def test_list_view_ordering(self):
+        """Test list view orders by name."""
+        ParadoxRealm.objects.create(name="Zeta Realm")
+        ParadoxRealm.objects.create(name="Alpha Realm")
+        ParadoxRealm.objects.create(name="Beta Realm")
+        response = self.client.get("/locations/mage/paradox_realm/")
+        content = response.content.decode()
+        alpha_pos = content.find("Alpha Realm")
+        beta_pos = content.find("Beta Realm")
+        zeta_pos = content.find("Zeta Realm")
+        self.assertLess(alpha_pos, beta_pos)
+        self.assertLess(beta_pos, zeta_pos)
+
+
+class TestParadoxRealmDetailView(TestCase):
+    """Test ParadoxRealmDetailView."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.realm = ParadoxRealm.objects.create(
+            name="Test Realm",
+            primary_sphere=SphereChoices.FORCES,
+            paradigm=ParadigmChoices.CHAOS,
+            description="A chaotic realm of forces",
+            owner=self.user,
+            status="App",
+        )
+        self.url = self.realm.get_absolute_url()
+
+    def test_detail_view_status_code(self):
+        """Test detail view returns 200."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_detail_view_template(self):
+        """Test detail view uses correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/mage/paradox_realm/detail.html")
+
+    def test_detail_view_content(self):
+        """Test detail view shows realm details."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertContains(response, "Test Realm")
+        self.assertContains(response, "Forces")
+
+    def test_detail_view_shows_obstacles(self):
+        """Test detail view shows obstacles in context."""
+        self.client.login(username="testuser", password="password")
+        ParadoxObstacle.objects.create(
+            realm=self.realm,
+            sphere=SphereChoices.FORCES,
+            obstacle_number=4,
+            order=0,
+            name="Fire",
+        )
+        response = self.client.get(self.url)
+        self.assertIn("obstacles", response.context)
+
+    def test_detail_view_shows_atmospheres(self):
+        """Test detail view shows atmospheres in context."""
+        self.client.login(username="testuser", password="password")
+        ParadoxAtmosphere.objects.create(
+            realm=self.realm,
+            paradigm=ParadigmChoices.CHAOS,
+            atmosphere_number=1,
+            description="Colors pulsating",
+        )
+        response = self.client.get(self.url)
+        self.assertIn("atmospheres", response.context)
+
+
+class TestParadoxRealmCreateView(TestCase):
+    """Test ParadoxRealmCreateView."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.url = ParadoxRealm.get_creation_url()
+
+    def test_create_view_requires_login(self):
+        """Test create view requires authentication."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response.url)
+
+    def test_create_view_status_code(self):
+        """Test create view returns 200 for logged-in user."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_create_view_template(self):
+        """Test create view uses correct template."""
+        self.client.login(username="testuser", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/mage/paradox_realm/form.html")
+
+    def test_create_view_post(self):
+        """Test successful POST creates realm."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "New Paradox Realm",
+            "description": "A new realm",
+            "primary_sphere": SphereChoices.MIND,
+            "paradigm": ParadigmChoices.ILLUSION,
+            "num_primary_obstacles": 2,
+            "num_random_obstacles": 1,
+            "final_obstacle_type": "maze",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+            "obstacles-TOTAL_FORMS": "0",
+            "obstacles-INITIAL_FORMS": "0",
+            "obstacles-MIN_NUM_FORMS": "0",
+            "obstacles-MAX_NUM_FORMS": "1000",
+            "atmospheres-TOTAL_FORMS": "0",
+            "atmospheres-INITIAL_FORMS": "0",
+            "atmospheres-MIN_NUM_FORMS": "0",
+            "atmospheres-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(ParadoxRealm.objects.filter(name="New Paradox Realm").exists())
+
+    def test_create_view_random_generation(self):
+        """Test POST with generate_random creates random realm."""
+        self.client.login(username="testuser", password="password")
+        data = {
+            "name": "Random Realm",
+            "description": "",
+            "primary_sphere": SphereChoices.PRIME,
+            "paradigm": ParadigmChoices.ANTIMAGICK,
+            "num_primary_obstacles": 0,
+            "num_random_obstacles": 0,
+            "final_obstacle_type": "maze",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+            "generate_random": True,
+            "obstacles-TOTAL_FORMS": "0",
+            "obstacles-INITIAL_FORMS": "0",
+            "obstacles-MIN_NUM_FORMS": "0",
+            "obstacles-MAX_NUM_FORMS": "1000",
+            "atmospheres-TOTAL_FORMS": "0",
+            "atmospheres-INITIAL_FORMS": "0",
+            "atmospheres-MIN_NUM_FORMS": "0",
+            "atmospheres-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 302)
+        realm = ParadoxRealm.objects.get(name="Random Realm")
+        # Random generation creates atmosphere elements
+        self.assertGreaterEqual(realm.realm_atmospheres.count(), 2)
+
+
+class TestParadoxRealmUpdateView(TestCase):
+    """Test ParadoxRealmUpdateView."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.st = User.objects.create_user(username="st_user", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.chronicle.storytellers.add(self.st)
+        self.realm = ParadoxRealm.objects.create(
+            name="Existing Realm",
+            primary_sphere=SphereChoices.ENTROPY,
+            paradigm=ParadigmChoices.OBLIVION,
+            owner=self.st,
+            chronicle=self.chronicle,
+            status="App",
+        )
+        self.url = self.realm.get_update_url()
+
+    def test_update_view_status_code(self):
+        """Test update view returns 200 for ST."""
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_view_template(self):
+        """Test update view uses correct template."""
+        self.client.login(username="st_user", password="password")
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, "locations/mage/paradox_realm/form.html")
+
+    def test_update_view_post(self):
+        """Test successful POST updates realm."""
+        self.client.login(username="st_user", password="password")
+        data = {
+            "name": "Updated Realm",
+            "description": "Updated description",
+            "primary_sphere": SphereChoices.TIME,
+            "paradigm": ParadigmChoices.TECH,
+            "num_primary_obstacles": 3,
+            "num_random_obstacles": 2,
+            "final_obstacle_type": "button",
+            "gauntlet": 5,
+            "shroud": 5,
+            "dimension_barrier": 5,
+            "obstacles-TOTAL_FORMS": "0",
+            "obstacles-INITIAL_FORMS": "0",
+            "obstacles-MIN_NUM_FORMS": "0",
+            "obstacles-MAX_NUM_FORMS": "1000",
+            "atmospheres-TOTAL_FORMS": "0",
+            "atmospheres-INITIAL_FORMS": "0",
+            "atmospheres-MIN_NUM_FORMS": "0",
+            "atmospheres-MAX_NUM_FORMS": "1000",
+        }
+        response = self.client.post(self.url, data=data)
+        self.assertEqual(response.status_code, 302)
+        self.realm.refresh_from_db()
+        self.assertEqual(self.realm.name, "Updated Realm")
+        self.assertEqual(self.realm.primary_sphere, SphereChoices.TIME)


### PR DESCRIPTION
Fixes #1248

This commit adds extensive tests for multiple location types:
- ParadoxRealm: model tests (dice rolls, random generation, obstacles, atmospheres), form tests (validation, formsets), and view tests (CRUD operations)
- Chantry: view tests and model method tests (rank, seasons, leadership, trait costs)
- Domain: model tests (total rating calculation with rack/disputed bonuses), view tests
- Safehouse: model tests (total rating with features/penalties), view tests
- Haunt: model tests (set_rank method, types, sizes), view tests

Tests cover:
- Model creation and default values
- URL generation methods (get_absolute_url, get_update_url, get_creation_url)
- Gameline heading methods
- Rating calculations with bonuses/penalties
- Random generation methods (ParadoxRealm)
- List, detail, create, and update views
- Form validation and submission