### PR TITLE
Add explicit get_success_url() to CreateView/UpdateView classes

### DIFF
--- a/characters/tests/views/demon/test_demon.py
+++ b/characters/tests/views/demon/test_demon.py
@@ -122,6 +122,21 @@ class TestDemonCreateView(TestCase):
         response = self.client.get(url)
         self.assertTemplateUsed(response, "characters/demon/demon/demonbasics.html")
 
+    def test_create_view_has_get_success_url_method(self):
+        """Test that DemonCreateView has explicit get_success_url method."""
+        from characters.views.demon.demon import DemonCreateView
+
+        self.assertTrue(
+            hasattr(DemonCreateView, "get_success_url"),
+            "DemonCreateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            DemonCreateView.__dict__,
+            "get_success_url should be explicitly defined on DemonCreateView",
+        )
+
 
 class TestDemonUpdateView(TestCase):
     """Test DemonUpdateView permissions and functionality."""

--- a/characters/tests/views/demon/test_dtfhuman.py
+++ b/characters/tests/views/demon/test_dtfhuman.py
@@ -83,6 +83,21 @@ class TestDtFHumanCreateView(TestCase):
         response = self.client.get(url)
         self.assertIn(response.status_code, [302, 403])
 
+    def test_create_view_has_get_success_url_method(self):
+        """Test that DtFHumanCreateView has explicit get_success_url method."""
+        from characters.views.demon.dtfhuman import DtFHumanCreateView
+
+        self.assertTrue(
+            hasattr(DtFHumanCreateView, "get_success_url"),
+            "DtFHumanCreateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            DtFHumanCreateView.__dict__,
+            "get_success_url should be explicitly defined on DtFHumanCreateView",
+        )
+
 
 class TestDtFHumanUpdateView(TestCase):
     """Test DtFHumanUpdateView permissions and functionality."""

--- a/characters/tests/views/hunter/test_hunter.py
+++ b/characters/tests/views/hunter/test_hunter.py
@@ -71,6 +71,21 @@ class TestHunterCreateView(TestCase):
         """Create view URL should resolve correctly."""
         self.assertEqual(self.url, "/characters/hunter/create/hunter/")
 
+    def test_create_view_has_get_success_url_method(self):
+        """Test that HunterCreateView has explicit get_success_url method."""
+        from characters.views.hunter.hunter import HunterCreateView
+
+        self.assertTrue(
+            hasattr(HunterCreateView, "get_success_url"),
+            "HunterCreateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            HunterCreateView.__dict__,
+            "get_success_url should be explicitly defined on HunterCreateView",
+        )
+
 
 class TestHunterUpdateView(TestCase):
     """Test the Hunter update view with permission checks."""

--- a/characters/views/demon/demon.py
+++ b/characters/views/demon/demon.py
@@ -106,6 +106,9 @@ class DemonCreateView(MessageMixin, CreateView):
     success_message = "Demon '{name}' created successfully!"
     error_message = "Failed to create demon. Please correct the errors below."
 
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
 
 class DemonUpdateView(EditPermissionMixin, UpdateView):
     model = Demon

--- a/characters/views/demon/dtfhuman.py
+++ b/characters/views/demon/dtfhuman.py
@@ -91,6 +91,9 @@ class DtFHumanCreateView(MessageMixin, CreateView):
     ]
     template_name = "characters/demon/dtfhuman/form.html"
 
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
 
 class DtFHumanUpdateView(EditPermissionMixin, UpdateView):
     model = DtFHuman

--- a/characters/views/hunter/hunter.py
+++ b/characters/views/hunter/hunter.py
@@ -115,6 +115,9 @@ class HunterCreateView(MessageMixin, CreateView):
     success_message = "Hunter '{name}' created successfully!"
     error_message = "Failed to create hunter. Please correct the errors below."
 
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
 
 class HunterUpdateView(EditPermissionMixin, UpdateView):
     model = Hunter

--- a/items/tests/views/mage/test_artifact.py
+++ b/items/tests/views/mage/test_artifact.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.db import connection
 from django.test import Client, TestCase
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 from items.models.mage import WonderResonanceRating
 from items.models.mage.artifact import Artifact
 
@@ -49,3 +50,41 @@ class TestArtifactDetailViewQueryOptimization(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("resonance", response.context)
         self.assertEqual(response.context["resonance"].count(), 5)
+
+
+class TestArtifactCreateView(TestCase):
+    """Test ArtifactCreateView functionality."""
+
+    def test_create_view_has_get_success_url_method(self):
+        """Test that ArtifactCreateView has explicit get_success_url method."""
+        from items.views.mage.artifact import ArtifactCreateView
+
+        self.assertTrue(
+            hasattr(ArtifactCreateView, "get_success_url"),
+            "ArtifactCreateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            ArtifactCreateView.__dict__,
+            "get_success_url should be explicitly defined on ArtifactCreateView",
+        )
+
+
+class TestArtifactUpdateView(TestCase):
+    """Test ArtifactUpdateView functionality."""
+
+    def test_update_view_has_get_success_url_method(self):
+        """Test that ArtifactUpdateView has explicit get_success_url method."""
+        from items.views.mage.artifact import ArtifactUpdateView
+
+        self.assertTrue(
+            hasattr(ArtifactUpdateView, "get_success_url"),
+            "ArtifactUpdateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            ArtifactUpdateView.__dict__,
+            "get_success_url should be explicitly defined on ArtifactUpdateView",
+        )

--- a/items/tests/views/mage/test_wonder.py
+++ b/items/tests/views/mage/test_wonder.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.db import connection
 from django.test import Client, TestCase
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 from items.models.mage import Wonder, WonderResonanceRating
 
 
@@ -48,3 +49,41 @@ class TestWonderDetailViewQueryOptimization(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("resonance", response.context)
         self.assertEqual(response.context["resonance"].count(), 5)
+
+
+class TestWonderCreateView(TestCase):
+    """Test WonderCreateView functionality."""
+
+    def test_create_view_has_get_success_url_method(self):
+        """Test that WonderCreateView has explicit get_success_url method."""
+        from items.views.mage.wonder import WonderCreateView
+
+        self.assertTrue(
+            hasattr(WonderCreateView, "get_success_url"),
+            "WonderCreateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            WonderCreateView.__dict__,
+            "get_success_url should be explicitly defined on WonderCreateView",
+        )
+
+
+class TestWonderUpdateView(TestCase):
+    """Test WonderUpdateView functionality."""
+
+    def test_update_view_has_get_success_url_method(self):
+        """Test that WonderUpdateView has explicit get_success_url method."""
+        from items.views.mage.wonder import WonderUpdateView
+
+        self.assertTrue(
+            hasattr(WonderUpdateView, "get_success_url"),
+            "WonderUpdateView should have get_success_url method",
+        )
+        # Verify it's defined on the class itself, not inherited
+        self.assertIn(
+            "get_success_url",
+            WonderUpdateView.__dict__,
+            "get_success_url should be explicitly defined on WonderUpdateView",
+        )

--- a/items/views/mage/artifact.py
+++ b/items/views/mage/artifact.py
@@ -46,6 +46,9 @@ class ArtifactCreateView(MessageMixin, CreateView):
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
         return form
 
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
 
 class ArtifactUpdateView(MessageMixin, UpdateView):
     model = Artifact
@@ -66,3 +69,6 @@ class ArtifactUpdateView(MessageMixin, UpdateView):
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
         return form
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()

--- a/items/views/mage/wonder.py
+++ b/items/views/mage/wonder.py
@@ -32,6 +32,9 @@ class WonderCreateView(MessageMixin, CreateView):
     success_message = "Wonder '{name}' created successfully!"
     error_message = "Failed to create wonder. Please correct the errors below."
 
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
 
 class WonderUpdateView(MessageMixin, UpdateView):
     model = Wonder
@@ -39,3 +42,6 @@ class WonderUpdateView(MessageMixin, UpdateView):
     template_name = "items/mage/wonder/form.html"
     success_message = "Wonder '{name}' updated successfully!"
     error_message = "Failed to update wonder. Please correct the errors below."
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()


### PR DESCRIPTION
## Summary
- Adds explicit `get_success_url()` methods to CreateView and UpdateView classes that were missing them
- Each method returns `self.object.get_absolute_url()` which matches Django's default behavior but makes it explicit
- Adds tests to verify each view class has the method explicitly defined

## Affected Views
- `WonderCreateView`, `WonderUpdateView` (items/views/mage/wonder.py)
- `ArtifactCreateView`, `ArtifactUpdateView` (items/views/mage/artifact.py)
- `DemonCreateView` (characters/views/demon/demon.py)
- `DtFHumanCreateView` (characters/views/demon/dtfhuman.py)
- `HunterCreateView` (characters/views/hunter/hunter.py)

## Test plan
- [x] New tests verify each view has `get_success_url` explicitly defined
- [x] All 7 new tests pass

Closes #1066

🤖 Generated with [Claude Code](https://claude.com/claude-code)