### PR TITLE
Consolidate ResonanceRating models using abstract base class (fixes #1149)

### DIFF
--- a/characters/models/mage/mage.py
+++ b/characters/models/mage/mage.py
@@ -14,6 +14,7 @@ from characters.models.mage.mtahuman import MtAHuman
 from characters.models.mage.resonance import Resonance
 from characters.models.mage.rote import Rote
 from characters.models.mage.sphere import Sphere
+from core.models import BaseResonanceRating
 from core.utils import add_dot, weighted_choice
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
@@ -827,12 +828,9 @@ class Mage(MtAHuman):
         return trait, value, cost
 
 
-class ResRating(models.Model):
+class ResRating(BaseResonanceRating):
     mage = models.ForeignKey("Mage", on_delete=models.SET_NULL, null=True)
     resonance = models.ForeignKey(Resonance, on_delete=models.SET_NULL, null=True)
-    rating = models.IntegerField(
-        default=0, validators=[MinValueValidator(0), MaxValueValidator(10)]
-    )
 
     class Meta:
         verbose_name = "Mage Resonance Rating"

--- a/core/models.py
+++ b/core/models.py
@@ -947,3 +947,31 @@ class TemplateApplication(models.Model):
         """Ensure validation runs on save."""
         self.full_clean()
         super().save(*args, **kwargs)
+
+
+class BaseResonanceRating(models.Model):
+    """
+    Abstract base class for all Resonance rating models.
+
+    Provides shared structure for rating Resonance across different contexts:
+    - Mages (ResRating)
+    - Wonders (WonderResonanceRating)
+    - Nodes (NodeResonanceRating)
+    - Mummy Relics (RelicResonanceRating)
+
+    Subclasses must define:
+    - A ForeignKey named 'resonance' to characters.Resonance
+    - A ForeignKey to their parent model (mage, wonder, node, relic, etc.)
+    - Meta constraints with unique constraint names
+    """
+
+    rating = models.IntegerField(
+        default=0,
+        validators=[MinValueValidator(0), MaxValueValidator(10)],
+    )
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return f"{self.resonance}: {self.rating}"

--- a/core/tests/models/test_base_resonance_rating.py
+++ b/core/tests/models/test_base_resonance_rating.py
@@ -1,0 +1,202 @@
+"""
+Tests for BaseResonanceRating abstract base class.
+
+Verifies that all concrete implementations inherit the shared functionality
+correctly and maintain database constraints.
+"""
+
+from characters.models.mage.mage import Mage, ResRating
+from characters.models.mage.resonance import Resonance
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from items.models.mage.wonder import Wonder, WonderResonanceRating
+from items.models.mummy.relic import MummyRelic, RelicResonanceRating
+from locations.models.mage.node import Node, NodeResonanceRating
+
+
+class TestBaseResonanceRatingInheritance(TestCase):
+    """Test that all concrete implementations inherit from BaseResonanceRating."""
+
+    def test_resrating_inherits_base(self):
+        """Test ResRating inherits from BaseResonanceRating."""
+        from core.models import BaseResonanceRating
+
+        self.assertTrue(issubclass(ResRating, BaseResonanceRating))
+
+    def test_wonderresonancerating_inherits_base(self):
+        """Test WonderResonanceRating inherits from BaseResonanceRating."""
+        from core.models import BaseResonanceRating
+
+        self.assertTrue(issubclass(WonderResonanceRating, BaseResonanceRating))
+
+    def test_noderesonancerating_inherits_base(self):
+        """Test NodeResonanceRating inherits from BaseResonanceRating."""
+        from core.models import BaseResonanceRating
+
+        self.assertTrue(issubclass(NodeResonanceRating, BaseResonanceRating))
+
+    def test_relicresonancerating_inherits_base(self):
+        """Test RelicResonanceRating inherits from BaseResonanceRating."""
+        from core.models import BaseResonanceRating
+
+        self.assertTrue(issubclass(RelicResonanceRating, BaseResonanceRating))
+
+
+class TestResonanceRatingSharedBehavior(TestCase):
+    """Test shared behavior inherited from BaseResonanceRating."""
+
+    def setUp(self):
+        self.resonance = Resonance.objects.create(name="Dynamic")
+
+    def test_str_method_inherited(self):
+        """Test __str__ returns expected format for implementations using base class."""
+        # Test ResRating - uses base class __str__
+        mage = Mage.objects.create(name="Test Mage")
+        mage_rating = ResRating.objects.create(mage=mage, resonance=self.resonance, rating=2)
+        self.assertEqual(str(mage_rating), "Dynamic: 2")
+
+        # Test WonderResonanceRating - uses base class __str__
+        wonder = Wonder.objects.create(name="Test Wonder")
+        wonder_rating = WonderResonanceRating.objects.create(
+            wonder=wonder, resonance=self.resonance, rating=3
+        )
+        self.assertEqual(str(wonder_rating), "Dynamic: 3")
+
+        # Test RelicResonanceRating - uses base class __str__
+        relic = MummyRelic.objects.create(name="Test Relic")
+        relic_rating = RelicResonanceRating.objects.create(
+            relic=relic, resonance=self.resonance, rating=5
+        )
+        self.assertEqual(str(relic_rating), "Dynamic: 5")
+
+    def test_str_method_overridden(self):
+        """Test NodeResonanceRating uses custom __str__ that includes node name."""
+        node = Node.objects.create(name="Test Node")
+        node_rating = NodeResonanceRating.objects.create(
+            node=node, resonance=self.resonance, rating=4
+        )
+        # NodeResonanceRating has custom __str__: f"{self.node}: {self.resonance} {self.rating}"
+        self.assertEqual(str(node_rating), "Test Node: Dynamic 4")
+
+    def test_default_rating_is_zero(self):
+        """Test that default rating is 0 for all implementations."""
+        mage = Mage.objects.create(name="Test Mage")
+        mage_rating = ResRating.objects.create(mage=mage, resonance=self.resonance)
+        self.assertEqual(mage_rating.rating, 0)
+
+        wonder = Wonder.objects.create(name="Test Wonder")
+        wonder_rating = WonderResonanceRating.objects.create(
+            wonder=wonder, resonance=self.resonance
+        )
+        self.assertEqual(wonder_rating.rating, 0)
+
+        node = Node.objects.create(name="Test Node")
+        node_rating = NodeResonanceRating.objects.create(node=node, resonance=self.resonance)
+        self.assertEqual(node_rating.rating, 0)
+
+
+class TestResonanceRatingValidation(TestCase):
+    """Test rating validation for all implementations."""
+
+    def setUp(self):
+        self.resonance = Resonance.objects.create(name="Dynamic")
+
+    def test_rating_at_boundary_values(self):
+        """Test ratings at 0 and 10 are valid."""
+        mage = Mage.objects.create(name="Test Mage")
+
+        # Test 0
+        rating_zero = ResRating(mage=mage, resonance=self.resonance, rating=0)
+        rating_zero.full_clean()  # Should not raise
+        rating_zero.save()
+        self.assertEqual(rating_zero.rating, 0)
+
+        # Test 10
+        resonance2 = Resonance.objects.create(name="Static")
+        rating_max = ResRating(mage=mage, resonance=resonance2, rating=10)
+        rating_max.full_clean()  # Should not raise
+        rating_max.save()
+        self.assertEqual(rating_max.rating, 10)
+
+    def test_rating_outside_range_fails_validation(self):
+        """Test ratings outside 0 to 10 fail validation."""
+        mage = Mage.objects.create(name="Test Mage")
+
+        # Test > 10
+        rating_high = ResRating(mage=mage, resonance=self.resonance, rating=11)
+        with self.assertRaises(ValidationError):
+            rating_high.full_clean()
+
+        # Test < 0
+        rating_low = ResRating(mage=mage, resonance=self.resonance, rating=-1)
+        with self.assertRaises(ValidationError):
+            rating_low.full_clean()
+
+    def test_all_implementations_validate_range(self):
+        """Test all implementations enforce 0-10 range."""
+        # Test WonderResonanceRating
+        wonder = Wonder.objects.create(name="Test Wonder")
+        wonder_rating = WonderResonanceRating(
+            wonder=wonder, resonance=self.resonance, rating=11
+        )
+        with self.assertRaises(ValidationError):
+            wonder_rating.full_clean()
+
+        # Test NodeResonanceRating
+        node = Node.objects.create(name="Test Node")
+        node_rating = NodeResonanceRating(node=node, resonance=self.resonance, rating=11)
+        with self.assertRaises(ValidationError):
+            node_rating.full_clean()
+
+        # Test RelicResonanceRating
+        relic = MummyRelic.objects.create(name="Test Relic")
+        relic_rating = RelicResonanceRating(
+            relic=relic, resonance=self.resonance, rating=11
+        )
+        with self.assertRaises(ValidationError):
+            relic_rating.full_clean()
+
+
+class TestResonanceRatingForeignKeyBehavior(TestCase):
+    """Test FK behavior for different ResonanceRating implementations."""
+
+    def setUp(self):
+        self.resonance = Resonance.objects.create(name="Dynamic")
+
+    def test_set_null_on_resonance_delete_for_mage(self):
+        """Test that deleting resonance sets FK to NULL for ResRating."""
+        mage = Mage.objects.create(name="Test Mage")
+        rating = ResRating.objects.create(mage=mage, resonance=self.resonance, rating=3)
+
+        self.assertEqual(ResRating.objects.count(), 1)
+        self.resonance.delete()
+        # ResRating uses SET_NULL, so record should remain with null resonance
+        self.assertEqual(ResRating.objects.count(), 1)
+        rating.refresh_from_db()
+        self.assertIsNone(rating.resonance)
+
+    def test_set_null_on_parent_delete_for_wonder(self):
+        """Test that deleting Wonder sets FK to NULL for WonderResonanceRating."""
+        wonder = Wonder.objects.create(name="Test Wonder")
+        rating = WonderResonanceRating.objects.create(
+            wonder=wonder, resonance=self.resonance, rating=3
+        )
+
+        self.assertEqual(WonderResonanceRating.objects.count(), 1)
+        wonder.delete()
+        # WonderResonanceRating uses SET_NULL, so record remains
+        self.assertEqual(WonderResonanceRating.objects.count(), 1)
+        rating.refresh_from_db()
+        self.assertIsNone(rating.wonder)
+
+    def test_cascade_delete_for_relic(self):
+        """Test that deleting Relic cascades to RelicResonanceRating."""
+        relic = MummyRelic.objects.create(name="Test Relic")
+        RelicResonanceRating.objects.create(
+            relic=relic, resonance=self.resonance, rating=3
+        )
+
+        self.assertEqual(RelicResonanceRating.objects.count(), 1)
+        relic.delete()
+        # RelicResonanceRating uses CASCADE, so record is deleted
+        self.assertEqual(RelicResonanceRating.objects.count(), 0)

--- a/items/models/mage/wonder.py
+++ b/items/models/mage/wonder.py
@@ -1,4 +1,4 @@
-from characters.models.mage.resonance import Resonance
+from core.models import BaseResonanceRating
 from core.utils import fast_selector
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
@@ -7,7 +7,10 @@ from django.urls import reverse
 from items.models.core import ItemModel
 
 
-class WonderResonanceRating(models.Model):
+class WonderResonanceRating(BaseResonanceRating):
+    wonder = models.ForeignKey("Wonder", on_delete=models.SET_NULL, null=True)
+    resonance = models.ForeignKey("characters.Resonance", on_delete=models.SET_NULL, null=True)
+
     class Meta:
         verbose_name = "Wonder Resonance Rating"
         verbose_name_plural = "Wonder Resonance Ratings"
@@ -18,15 +21,6 @@ class WonderResonanceRating(models.Model):
                 violation_error_message="Wonder resonance rating must be between 0 and 10",
             ),
         ]
-
-    wonder = models.ForeignKey("Wonder", on_delete=models.SET_NULL, null=True)
-    resonance = models.ForeignKey("characters.Resonance", on_delete=models.SET_NULL, null=True)
-    rating = models.IntegerField(
-        default=0, validators=[MinValueValidator(0), MaxValueValidator(10)]
-    )
-
-    def __str__(self):
-        return f"{self.resonance}: {self.rating}"
 
 
 class Wonder(ItemModel):

--- a/items/models/mummy/relic.py
+++ b/items/models/mummy/relic.py
@@ -1,3 +1,4 @@
+from core.models import BaseResonanceRating
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.urls import reverse
@@ -196,9 +197,10 @@ class MummyRelic(ItemModel):
 
 
 # Through model for Resonance
-class RelicResonanceRating(models.Model):
+class RelicResonanceRating(BaseResonanceRating):
     relic = models.ForeignKey(MummyRelic, on_delete=models.CASCADE)
     resonance = models.ForeignKey("characters.Resonance", on_delete=models.CASCADE)
+    # Override default to 1 for RelicResonanceRating
     rating = models.IntegerField(
         default=1, validators=[MinValueValidator(0), MaxValueValidator(10)]
     )

--- a/locations/models/mage/node.py
+++ b/locations/models/mage/node.py
@@ -2,7 +2,7 @@ from characters.models.core import MeritFlaw
 from characters.models.core.merit_flaw_block import MeritFlawBlock
 from characters.models.mage.resonance import Resonance
 from characters.models.mage.sphere import Sphere
-from core.models import BaseMeritFlawRating
+from core.models import BaseMeritFlawRating, BaseResonanceRating
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import CheckConstraint, Q
@@ -237,12 +237,9 @@ class NodeMeritFlawRating(BaseMeritFlawRating):
         ]
 
 
-class NodeResonanceRating(models.Model):
+class NodeResonanceRating(BaseResonanceRating):
     node = models.ForeignKey(Node, on_delete=models.SET_NULL, null=True)
     resonance = models.ForeignKey(Resonance, on_delete=models.SET_NULL, null=True)
-    rating = models.IntegerField(
-        default=0, validators=[MinValueValidator(0), MaxValueValidator(10)]
-    )
 
     class Meta:
         verbose_name = "Node Resonance Rating"


### PR DESCRIPTION
Fixes #1149 

## Summary

- Created `BaseResonanceRating` abstract base class in `core/models.py`
- Refactored 4 concrete models to inherit from the base class:
  - `ResRating` (characters/models/mage/mage.py)
  - `WonderResonanceRating` (items/models/mage/wonder.py)
  - `NodeResonanceRating` (locations/models/mage/node.py)
  - `RelicResonanceRating` (items/models/mummy/relic.py)
- Added comprehensive test suite for the base class and inheritance

## Changes

The base class provides:
- Shared `rating` IntegerField with validators (0-10)
- Default `__str__` method returning `"{resonance}: {rating}"`

Each subclass retains:
- Its own FK to the parent model (mage, wonder, node, relic)
- Its own FK to Resonance with existing on_delete behavior
- Existing Meta constraints and verbose names
- Custom `__str__` where needed (NodeResonanceRating)

## Test plan

- [x] Verify all 4 models inherit from BaseResonanceRating
- [x] Verify shared `__str__` method works for 3 models
- [x] Verify custom `__str__` preserved for NodeResonanceRating
- [x] Verify rating validation (0-10 range) for all models
- [x] Verify FK behavior preserved (SET_NULL vs CASCADE)
- [x] Verify no migrations needed (`makemigrations --dry-run`)
- [x] Run core model tests (40 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)