### PR TITLE
Change parent field to contained_within ManyToManyField (fixes #1040)

### DIFF
--- a/locations/forms/changeling/creation.py
+++ b/locations/forms/changeling/creation.py
@@ -141,7 +141,7 @@ class FreeholdDetailsForm(forms.ModelForm):
             "resource_description",
             "passage_description",
             "quirks",
-            "parent",
+            "contained_within",
             "owned_by",
         )
         widgets = {
@@ -169,7 +169,7 @@ class FreeholdDetailsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["academy_ability"].required = False
         self.fields["hearth_ability"].required = False
-        self.fields["parent"].required = False
+        self.fields["contained_within"].required = False
         self.fields["owned_by"].required = False
 
         # Show/hide based on archetype

--- a/locations/forms/changeling/freehold.py
+++ b/locations/forms/changeling/freehold.py
@@ -26,7 +26,7 @@ class FreeholdForm(forms.ModelForm):
             "resource_description",
             "passage_description",
             "balefire_description",
-            "parent",
+            "contained_within",
             "owned_by",
             "gauntlet",
             "shroud",
@@ -79,8 +79,8 @@ class FreeholdForm(forms.ModelForm):
             {"placeholder": "If dual nature second archetype is Academy"}
         )
 
-        # Make parent and owned_by not required
-        self.fields["parent"].required = False
+        # Make contained_within and owned_by not required
+        self.fields["contained_within"].required = False
         self.fields["owned_by"].required = False
 
         # Set help text

--- a/locations/forms/mage/chantry.py
+++ b/locations/forms/mage/chantry.py
@@ -114,7 +114,7 @@ class ChantryCreateForm(forms.ModelForm):
         fields = [
             "name",
             "chronicle",
-            "parent",
+            "contained_within",
             "description",
             "faction",
             "leadership_type",

--- a/locations/forms/mage/demesne.py
+++ b/locations/forms/mage/demesne.py
@@ -7,7 +7,7 @@ from locations.models.mage.reality_zone import RealityZone
 class DemesneForm(forms.ModelForm):
     class Meta:
         model = Demesne
-        fields = ("name", "parent", "description", "rank", "size", "accessibility")
+        fields = ("name", "contained_within", "description", "rank", "size", "accessibility")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -16,7 +16,7 @@ class DemesneForm(forms.ModelForm):
         self.fields["size"].widget.attrs.update(
             {"placeholder": "e.g., Small chamber, Expansive realm"}
         )
-        self.fields["parent"].required = False
+        self.fields["contained_within"].required = False
         if self.instance.pk and self.instance.reality_zone:
             self.reality_zone = self.instance.reality_zone
         else:

--- a/locations/forms/mage/library.py
+++ b/locations/forms/mage/library.py
@@ -5,13 +5,13 @@ from locations.models.mage.library import Library
 class LibraryForm(forms.ModelForm):
     class Meta:
         model = Library
-        fields = ("name", "description", "parent", "rank", "faction")
+        fields = ("name", "description", "contained_within", "rank", "faction")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         self.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        self.fields["parent"].empty_label = "Choose a Parent Location"
+        self.fields["contained_within"].required = False
         self.fields["faction"].empty_label = "Choose a Faction"
 
     def save(self, commit=True):

--- a/locations/forms/mage/node.py
+++ b/locations/forms/mage/node.py
@@ -108,7 +108,7 @@ class NodeForm(forms.ModelForm):
             "size",
             "quintessence_form",
             "tass_form",
-            "parent",
+            "contained_within",
             "gauntlet",
             "shroud",
             "dimension_barrier",
@@ -122,7 +122,7 @@ class NodeForm(forms.ModelForm):
         )
         self.fields["tass_form"].widget.attrs.update({"placeholder": "Enter Tass Form here"})
         self.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        self.fields["parent"].required = False
+        self.fields["contained_within"].required = False
 
         self.resonance_formset = NodeResonanceRatingFormSet(
             instance=self.instance,

--- a/locations/forms/mage/paradox_realm.py
+++ b/locations/forms/mage/paradox_realm.py
@@ -65,7 +65,7 @@ class ParadoxRealmForm(forms.ModelForm):
             "num_random_obstacles",
             "final_obstacle_type",
             "final_obstacle_details",
-            "parent",
+            "contained_within",
             "gauntlet",
             "shroud",
             "dimension_barrier",
@@ -86,7 +86,7 @@ class ParadoxRealmForm(forms.ModelForm):
         self.fields["description"].widget.attrs.update(
             {"placeholder": "Enter description of the realm", "rows": 4}
         )
-        self.fields["parent"].required = False
+        self.fields["contained_within"].required = False
         self.fields["secondary_sphere"].required = False
         self.fields["secondary_paradigm"].required = False
 

--- a/locations/forms/mage/sanctum.py
+++ b/locations/forms/mage/sanctum.py
@@ -7,13 +7,13 @@ from locations.models.mage.sanctum import Sanctum
 class SanctumForm(forms.ModelForm):
     class Meta:
         model = Sanctum
-        fields = ("name", "parent", "description", "rank")
+        fields = ("name", "contained_within", "description", "rank")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         self.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        self.fields["parent"].required = False
+        self.fields["contained_within"].required = False
         if self.instance.pk and self.instance.reality_zone:
             self.reality_zone = self.instance.reality_zone
         else:

--- a/locations/forms/mage/sector.py
+++ b/locations/forms/mage/sector.py
@@ -8,7 +8,7 @@ class SectorForm(forms.ModelForm):
         fields = [
             "name",
             "description",
-            "parent",
+            "contained_within",
             # Classification
             "sector_class",
             "access_level",
@@ -91,9 +91,8 @@ class SectorForm(forms.ModelForm):
             {"placeholder": "Landmarks, AROs, unique properties, special locations..."}
         )
 
-        # Set parent as not required
-        self.fields["parent"].required = False
-        self.fields["parent"].empty_label = "Parent Location (Optional)"
+        # Set contained_within as not required
+        self.fields["contained_within"].required = False
 
         # Optional fields
         for field in ["password_hint", "genre_theme", "data_flow_rate", "reality_zone"]:

--- a/locations/models/core/location.py
+++ b/locations/models/core/location.py
@@ -11,8 +11,8 @@ class LocationQuerySet(ModelQuerySet):
     """Custom queryset for LocationModel with chainable query patterns."""
 
     def top_level(self):
-        """Top-level locations (no parent)"""
-        return self.filter(parent=None)
+        """Top-level locations (not contained within any other location)"""
+        return self.filter(contained_within__isnull=True)
 
 
 # Create LocationModelManager from ModelManager to inherit polymorphic_ctype optimization
@@ -28,6 +28,11 @@ class LocationModel(Model):
         null=True,
         on_delete=models.SET_NULL,
         related_name="children",
+    )
+    contained_within = models.ManyToManyField(
+        "LocationModel",
+        blank=True,
+        related_name="contains",
     )
     owned_by = models.ForeignKey(CharacterModel, blank=True, null=True, on_delete=models.SET_NULL)
 

--- a/locations/models/mage/chantry.py
+++ b/locations/models/mage/chantry.py
@@ -283,8 +283,7 @@ class Chantry(BackgroundBlock, LocationModel):
 
     def set_library(self, library):
         self.chantry_library = library
-        library.parent = self
-        library.save()
+        library.contained_within.add(self)
         return True
 
     def set_rank(self, rank):

--- a/locations/templates/locations/changeling/dream_realm/detail.html
+++ b/locations/templates/locations/changeling/dream_realm/detail.html
@@ -5,9 +5,12 @@
     <div class="tg-card header-card mb-4" data-gameline="ctd">
         <div class="tg-card-header">
             <h1 class="tg-card-title ctd_heading">{{ object.name }}</h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
             {% if object.realm_type %}

--- a/locations/templates/locations/changeling/freehold/detail.html
+++ b/locations/templates/locations/changeling/freehold/detail.html
@@ -9,9 +9,12 @@
                 {{ object.name }}
                 {% if object.balefire %}<small><span class="dots colored-dots">{{ object.balefire|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
             <p class="tg-card-subtitle mb-0">

--- a/locations/templates/locations/changeling/holding/detail.html
+++ b/locations/templates/locations/changeling/holding/detail.html
@@ -5,9 +5,12 @@
     <div class="tg-card header-card mb-4" data-gameline="ctd">
         <div class="tg-card-header">
             <h1 class="tg-card-title ctd_heading">{{ object.name }}</h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
             {% if object.holding_type %}

--- a/locations/templates/locations/changeling/trod/detail.html
+++ b/locations/templates/locations/changeling/trod/detail.html
@@ -5,9 +5,12 @@
     <div class="tg-card header-card mb-4" data-gameline="ctd">
         <div class="tg-card-header">
             <h1 class="tg-card-title ctd_heading">{{ object.name }}</h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
             {% if object.trod_type %}

--- a/locations/templates/locations/core/location/detail.html
+++ b/locations/templates/locations/core/location/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/core/location/display_includes/title.html
+++ b/locations/templates/locations/core/location/display_includes/title.html
@@ -8,9 +8,12 @@
                     {{ object.name }}
                     {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
                 </h1>
-                {% if object.parent %}
+                {% if object.contained_within.exists %}
                     <p class="tg-card-subtitle mb-0">
-                        Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                        Located in:
+                        {% for container in object.contained_within.all %}
+                            <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
                     </p>
                 {% endif %}
             </div>

--- a/locations/templates/locations/core/location/form.html
+++ b/locations/templates/locations/core/location/form.html
@@ -8,11 +8,11 @@
             <h2 class="col-sm">{{ form.name }}</h2>
         </div>
     {% endblock name %}
-    {% block parent %}
+    {% block contained_within %}
         <div class="row">
-            <div class="col-sm">{{ form.parent }}</div>
+            <div class="col-sm">{{ form.contained_within }}</div>
         </div>
-    {% endblock parent %}
+    {% endblock contained_within %}
     {% block gauntlets %}
         <div class="row">
             <div class="col-sm">Gauntlet</div>

--- a/locations/templates/locations/demon/bastion/detail.html
+++ b/locations/templates/locations/demon/bastion/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/demon/reliquary/detail.html
+++ b/locations/templates/locations/demon/reliquary/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/hunter/huntingground/form.html
+++ b/locations/templates/locations/hunter/huntingground/form.html
@@ -12,8 +12,8 @@
         <div class="col-sm">{{ form.description }}</div>
     </div>
     <div class="row">
-        <div class="col-sm">Parent Location</div>
-        <div class="col-sm">{{ form.parent }}</div>
+        <div class="col-sm">Contained Within</div>
+        <div class="col-sm">{{ form.contained_within }}</div>
     </div>
     <div class="row">
         <h3 class="col-sm htr_heading">Territory</h3>

--- a/locations/templates/locations/hunter/safehouse/form.html
+++ b/locations/templates/locations/hunter/safehouse/form.html
@@ -12,8 +12,8 @@
         <div class="col-sm">{{ form.description }}</div>
     </div>
     <div class="row">
-        <div class="col-sm">Parent Location</div>
-        <div class="col-sm">{{ form.parent }}</div>
+        <div class="col-sm">Contained Within</div>
+        <div class="col-sm">{{ form.contained_within }}</div>
     </div>
     <div class="row">
         <h3 class="col-sm htr_heading">Size & Capacity</h3>

--- a/locations/templates/locations/location_recursive.html
+++ b/locations/templates/locations/location_recursive.html
@@ -4,12 +4,12 @@
 <!-- Parent item -->
 <div class="list-group-item">
     <div class="d-flex align-items-center" style="padding-left: {{ indent_level }}px">
-        {% if location.children.exists %}
-            <a href="#loc-{{ location.id }}-children" 
-               class="btn btn-link btn-sm p-0 mr-2" 
-               data-toggle="collapse" 
-               role="button" 
-               aria-expanded="true" 
+        {% if location.contains.exists %}
+            <a href="#loc-{{ location.id }}-children"
+               class="btn btn-link btn-sm p-0 mr-2"
+               data-toggle="collapse"
+               role="button"
+               aria-expanded="true"
                aria-controls="loc-{{ location.id }}-children">
                 <i class="fas fa-chevron-down"></i>
             </a>
@@ -31,9 +31,9 @@
 </div>
 
 <!-- Child items (if any) -->
-{% if location.children.exists %}
+{% if location.contains.exists %}
     <div id="loc-{{ location.id }}-children" class="collapse show">
-        {% for child in location.children.all %}
+        {% for child in location.contains.all %}
             {% include "locations/location_recursive.html" with location=child indent_level=indent_level|add:"30" %}
         {% endfor %}
     </div>

--- a/locations/templates/locations/location_table_row.html
+++ b/locations/templates/locations/location_table_row.html
@@ -4,7 +4,7 @@
     {% if parent_id %}id="loc-{{ parent_id }}-children"{% endif %}
     style="transition: var(--transition-fast);">
     <td data-label="Location" style="padding-left: {{ level|default:0|add:12 }}px;">
-        {% if location.children.exists %}
+        {% if location.contains.exists %}
             <a href="#loc-{{ location.id }}-children"
                class="btn btn-link btn-sm p-0 mr-2"
                data-toggle="collapse"
@@ -47,8 +47,8 @@
 </tr>
 
 <!-- Child Locations (Recursive) -->
-{% if location.children.exists %}
-    {% for child in location.children.all %}
+{% if location.contains.exists %}
+    {% for child in location.contains.all %}
         {% include "locations/location_table_row.html" with location=child level=level|default:0|add:24 parent_id=location.id %}
     {% endfor %}
 {% endif %}

--- a/locations/templates/locations/mage/chantry/detail.html
+++ b/locations/templates/locations/mage/chantry/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/chantry/select_or_create_form.html
+++ b/locations/templates/locations/mage/chantry/select_or_create_form.html
@@ -18,7 +18,7 @@
         <h3 class="col-sm">{{ form.chantry_creation_form.name }}</h3>
     </div>
     <div class="row">
-        <div class="col-sm">{{ form.chantry_creation_form.parent }}</div>
+        <div class="col-sm">{{ form.chantry_creation_form.contained_within }}</div>
     </div>
     <div class="row">
         <div class="col-sm">Gauntlet</div>

--- a/locations/templates/locations/mage/demesne/detail.html
+++ b/locations/templates/locations/mage/demesne/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/demesne/form_include.html
+++ b/locations/templates/locations/mage/demesne/form_include.html
@@ -13,8 +13,8 @@
     <div class="col-sm">{{ form.description }}</div>
 </div>
 <div class="row">
-    <div class="col-sm">Parent Location</div>
-    <div class="col-sm">{{ form.parent }}</div>
+    <div class="col-sm">Contained Within</div>
+    <div class="col-sm">{{ form.contained_within }}</div>
 </div>
 <div class="row">
     <div class="col-sm">Rank</div>

--- a/locations/templates/locations/mage/library/detail.html
+++ b/locations/templates/locations/mage/library/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/library/form_include.html
+++ b/locations/templates/locations/mage/library/form_include.html
@@ -10,7 +10,7 @@
     <div class="col-sm">{{ form.name }}</div>
 </div>
 <div class="row">
-    <div class="col-sm">{{ form.parent }}</div>
+    <div class="col-sm">{{ form.contained_within }}</div>
 </div>
 <div class="row">
     <div class="col-sm">Rank</div>

--- a/locations/templates/locations/mage/node/detail.html
+++ b/locations/templates/locations/mage/node/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/node/form_include.html
+++ b/locations/templates/locations/mage/node/form_include.html
@@ -29,8 +29,8 @@
                 {{ form.name }}
             </div>
             <div class="col-md-6">
-                <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                {{ form.parent }}
+                <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                {{ form.contained_within }}
             </div>
         </div>
         <div class="row mb-3">

--- a/locations/templates/locations/mage/paradox_realm/detail.html
+++ b/locations/templates/locations/mage/paradox_realm/detail.html
@@ -8,9 +8,12 @@
             <h1 class="tg-card-title mta_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/paradox_realm/form_include.html
+++ b/locations/templates/locations/mage/paradox_realm/form_include.html
@@ -33,8 +33,8 @@
         {{ form.name }}
     </div>
     <div class="col-sm-6">
-        <label for="{{ form.parent.id_for_label }}" style="font-weight: 600; font-size: 0.875rem; margin-bottom: 4px;">Parent Location</label>
-        {{ form.parent }}
+        <label for="{{ form.contained_within.id_for_label }}" style="font-weight: 600; font-size: 0.875rem; margin-bottom: 4px;">Contained Within</label>
+        {{ form.contained_within }}
     </div>
 </div>
 

--- a/locations/templates/locations/mage/realm/detail.html
+++ b/locations/templates/locations/mage/realm/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/sanctum/detail.html
+++ b/locations/templates/locations/mage/sanctum/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mage/sanctum/form_include.html
+++ b/locations/templates/locations/mage/sanctum/form_include.html
@@ -11,8 +11,8 @@
     <div class="col-sm">{{ form.name }}</div>
 </div>
 <div class="row">
-    <div class="col-sm">Parent Location</div>
-    <div class="col-sm">{{ form.parent }}</div>
+    <div class="col-sm">Contained Within</div>
+    <div class="col-sm">{{ form.contained_within }}</div>
 </div>
 <div class="row">
     <div class="col-sm">Rank</div>

--- a/locations/templates/locations/mage/sector/detail.html
+++ b/locations/templates/locations/mage/sector/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mummy/cult_temple/detail.html
+++ b/locations/templates/locations/mummy/cult_temple/detail.html
@@ -7,9 +7,12 @@
                 {{ object.name }}
                 {% if object.cult_size %}<small><span class="dots colored-dots">{{ object.cult_size|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mummy/cult_temple/form.html
+++ b/locations/templates/locations/mummy/cult_temple/form.html
@@ -14,8 +14,8 @@
         <div class="row">
             <div class="col-sm">Name</div>
             <div class="col-sm">{{ form.name }}</div>
-            <div class="col-sm">Parent Location</div>
-            <div class="col-sm">{{ form.parent }}</div>
+            <div class="col-sm">Contained Within</div>
+            <div class="col-sm">{{ form.contained_within }}</div>
         </div>
         <div class="row">
             <div class="col-sm">Cult Size</div>

--- a/locations/templates/locations/mummy/sanctuary/detail.html
+++ b/locations/templates/locations/mummy/sanctuary/detail.html
@@ -7,9 +7,12 @@
                 {{ object.name }}
                 {% if object.concealment_rating %}<small><span class="dots colored-dots">{{ object.concealment_rating|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mummy/sanctuary/form.html
+++ b/locations/templates/locations/mummy/sanctuary/form.html
@@ -14,8 +14,8 @@
         <div class="row">
             <div class="col-sm">Name</div>
             <div class="col-sm">{{ form.name }}</div>
-            <div class="col-sm">Parent Location</div>
-            <div class="col-sm">{{ form.parent }}</div>
+            <div class="col-sm">Contained Within</div>
+            <div class="col-sm">{{ form.contained_within }}</div>
         </div>
         <div class="row">
             <div class="col-sm">Type</div>

--- a/locations/templates/locations/mummy/tomb/detail.html
+++ b/locations/templates/locations/mummy/tomb/detail.html
@@ -7,9 +7,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/mummy/tomb/form.html
+++ b/locations/templates/locations/mummy/tomb/form.html
@@ -14,8 +14,8 @@
         <div class="row">
             <div class="col-sm">Name</div>
             <div class="col-sm">{{ form.name }}</div>
-            <div class="col-sm">Parent Location</div>
-            <div class="col-sm">{{ form.parent }}</div>
+            <div class="col-sm">Contained Within</div>
+            <div class="col-sm">{{ form.contained_within }}</div>
         </div>
         <div class="row">
             <div class="col-sm">Size</div>

--- a/locations/templates/locations/vampire/barrens/detail.html
+++ b/locations/templates/locations/vampire/barrens/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title vtm_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/vampire/barrens/form.html
+++ b/locations/templates/locations/vampire/barrens/form.html
@@ -14,8 +14,8 @@
                     {{ form.name }}
                 </div>
                 <div class="col-md-6">
-                    <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                    {{ form.parent }}
+                    <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                    {{ form.contained_within }}
                 </div>
             </div>
 

--- a/locations/templates/locations/vampire/barrens/list.html
+++ b/locations/templates/locations/vampire/barrens/list.html
@@ -25,7 +25,7 @@
                     {% for barrens in object_list %}
                     <tr>
                         <td><a href="{{ barrens.get_absolute_url }}">{{ barrens.name }}</a></td>
-                        <td>{% if barrens.parent %}<a href="{{ barrens.parent.get_absolute_url }}">{{ barrens.parent.name }}</a>{% else %}-{% endif %}</td>
+                        <td>{% if barrens.contained_within.exists %}{% for container in barrens.contained_within.all %}<a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</td>
                         <td>{{ barrens.get_control_status }}</td>
                         <td>{{ barrens.size|dots }}</td>
                         <td>{{ barrens.danger_level|dots }}</td>

--- a/locations/templates/locations/vampire/chantry/detail.html
+++ b/locations/templates/locations/vampire/chantry/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title vtm_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/vampire/chantry/form.html
+++ b/locations/templates/locations/vampire/chantry/form.html
@@ -14,8 +14,8 @@
                     {{ form.name }}
                 </div>
                 <div class="col-md-6">
-                    <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                    {{ form.parent }}
+                    <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                    {{ form.contained_within }}
                 </div>
             </div>
 

--- a/locations/templates/locations/vampire/chantry/list.html
+++ b/locations/templates/locations/vampire/chantry/list.html
@@ -26,7 +26,7 @@
                     {% for chantry in object_list %}
                     <tr>
                         <td><a href="{{ chantry.get_absolute_url }}">{{ chantry.name }}</a></td>
-                        <td>{% if chantry.parent %}<a href="{{ chantry.parent.get_absolute_url }}">{{ chantry.parent.name }}</a>{% else %}-{% endif %}</td>
+                        <td>{% if chantry.contained_within.exists %}{% for container in chantry.contained_within.all %}<a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</td>
                         <td>{{ chantry.regent_name|default:"-" }}</td>
                         <td>{{ chantry.size|dots }}</td>
                         <td>{{ chantry.security_level|dots }}</td>

--- a/locations/templates/locations/vampire/domain/detail.html
+++ b/locations/templates/locations/vampire/domain/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title vtm_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/vampire/domain/form.html
+++ b/locations/templates/locations/vampire/domain/form.html
@@ -14,8 +14,8 @@
                     {{ form.name }}
                 </div>
                 <div class="col-md-6">
-                    <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                    {{ form.parent }}
+                    <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                    {{ form.contained_within }}
                 </div>
             </div>
 

--- a/locations/templates/locations/vampire/domain/list.html
+++ b/locations/templates/locations/vampire/domain/list.html
@@ -26,7 +26,7 @@
                     {% for domain in object_list %}
                     <tr>
                         <td><a href="{{ domain.get_absolute_url }}">{{ domain.name }}</a></td>
-                        <td>{% if domain.parent %}<a href="{{ domain.parent.get_absolute_url }}">{{ domain.parent.name }}</a>{% else %}-{% endif %}</td>
+                        <td>{% if domain.contained_within.exists %}{% for container in domain.contained_within.all %}<a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</td>
                         <td>{{ domain.size|dots }}</td>
                         <td>{{ domain.population|dots }}</td>
                         <td>{{ domain.control|dots }}</td>

--- a/locations/templates/locations/vampire/elysium/detail.html
+++ b/locations/templates/locations/vampire/elysium/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title vtm_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/vampire/elysium/form.html
+++ b/locations/templates/locations/vampire/elysium/form.html
@@ -14,8 +14,8 @@
                     {{ form.name }}
                 </div>
                 <div class="col-md-6">
-                    <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                    {{ form.parent }}
+                    <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                    {{ form.contained_within }}
                 </div>
             </div>
 

--- a/locations/templates/locations/vampire/elysium/list.html
+++ b/locations/templates/locations/vampire/elysium/list.html
@@ -25,7 +25,7 @@
                     {% for elysium in object_list %}
                     <tr>
                         <td><a href="{{ elysium.get_absolute_url }}">{{ elysium.name }}</a></td>
-                        <td>{% if elysium.parent %}<a href="{{ elysium.parent.get_absolute_url }}">{{ elysium.parent.name }}</a>{% else %}-{% endif %}</td>
+                        <td>{% if elysium.contained_within.exists %}{% for container in elysium.contained_within.all %}<a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</td>
                         <td>{{ elysium.prestige|dots }}</td>
                         <td>{{ elysium.elysium_type|default:"-" }}</td>
                         <td>{{ elysium.keeper_name|default:"-" }}</td>

--- a/locations/templates/locations/vampire/haven/detail.html
+++ b/locations/templates/locations/vampire/haven/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title vtm_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/vampire/haven/form.html
+++ b/locations/templates/locations/vampire/haven/form.html
@@ -14,8 +14,8 @@
                     {{ form.name }}
                 </div>
                 <div class="col-md-6">
-                    <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                    {{ form.parent }}
+                    <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                    {{ form.contained_within }}
                 </div>
             </div>
 

--- a/locations/templates/locations/vampire/haven/list.html
+++ b/locations/templates/locations/vampire/haven/list.html
@@ -25,7 +25,7 @@
                     {% for haven in object_list %}
                     <tr>
                         <td><a href="{{ haven.get_absolute_url }}">{{ haven.name }}</a></td>
-                        <td>{% if haven.parent %}<a href="{{ haven.parent.get_absolute_url }}">{{ haven.parent.name }}</a>{% else %}-{% endif %}</td>
+                        <td>{% if haven.contained_within.exists %}{% for container in haven.contained_within.all %}<a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</td>
                         <td>{{ haven.get_size_display }}</td>
                         <td>{{ haven.security|dots }}</td>
                         <td>{{ haven.location|dots }}</td>

--- a/locations/templates/locations/vampire/rack/detail.html
+++ b/locations/templates/locations/vampire/rack/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title vtm_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/vampire/rack/form.html
+++ b/locations/templates/locations/vampire/rack/form.html
@@ -14,8 +14,8 @@
                     {{ form.name }}
                 </div>
                 <div class="col-md-6">
-                    <label for="{{ form.parent.id_for_label }}" class="form-label">Parent Location</label>
-                    {{ form.parent }}
+                    <label for="{{ form.contained_within.id_for_label }}" class="form-label">Contained Within</label>
+                    {{ form.contained_within }}
                 </div>
             </div>
 

--- a/locations/templates/locations/vampire/rack/list.html
+++ b/locations/templates/locations/vampire/rack/list.html
@@ -26,7 +26,7 @@
                     {% for rack in object_list %}
                     <tr>
                         <td><a href="{{ rack.get_absolute_url }}">{{ rack.name }}</a></td>
-                        <td>{% if rack.parent %}<a href="{{ rack.parent.get_absolute_url }}">{{ rack.parent.name }}</a>{% else %}-{% endif %}</td>
+                        <td>{% if rack.contained_within.exists %}{% for container in rack.contained_within.all %}<a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}{% else %}-{% endif %}</td>
                         <td>{{ rack.rack_type|default:"-" }}</td>
                         <td>{{ rack.quality|dots }}</td>
                         <td>{{ rack.population_density|dots }}</td>

--- a/locations/templates/locations/werewolf/caern/detail.html
+++ b/locations/templates/locations/werewolf/caern/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/wraith/citadel/detail.html
+++ b/locations/templates/locations/wraith/citadel/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title wto_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/wraith/haunt/detail.html
+++ b/locations/templates/locations/wraith/haunt/detail.html
@@ -8,9 +8,12 @@
                 {{ object.name }}
                 {% if object.rank %}<small><span class="dots colored-dots">{{ object.rank|dots }}</span></small>{% endif %}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/templates/locations/wraith/necropolis/detail.html
+++ b/locations/templates/locations/wraith/necropolis/detail.html
@@ -7,9 +7,12 @@
             <h1 class="tg-card-title wto_heading">
                 {{ object.name }}
             </h1>
-            {% if object.parent %}
+            {% if object.contained_within.exists %}
                 <p class="tg-card-subtitle mb-0">
-                    Located in: <a href="{{ object.parent.get_absolute_url }}">{{ object.parent.name }}</a>
+                    Located in:
+                    {% for container in object.contained_within.all %}
+                        <a href="{{ container.get_absolute_url }}">{{ container.name }}</a>{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
                 </p>
             {% endif %}
         </div>

--- a/locations/tests/forms/changeling/test_freehold.py
+++ b/locations/tests/forms/changeling/test_freehold.py
@@ -55,11 +55,11 @@ class TestFreeholdFormBasics(TestFreeholdFormSetup):
 
         self.assertEqual(form.fields["description"].widget.attrs.get("rows"), 4)
 
-    def test_parent_not_required(self):
-        """Test that parent field is not required."""
+    def test_contained_within_not_required(self):
+        """Test that contained_within field is not required."""
         form = FreeholdForm()
 
-        self.assertFalse(form.fields["parent"].required)
+        self.assertFalse(form.fields["contained_within"].required)
 
     def test_owned_by_not_required(self):
         """Test that owned_by field is not required."""

--- a/locations/tests/forms/mage/test_chantry.py
+++ b/locations/tests/forms/mage/test_chantry.py
@@ -264,7 +264,7 @@ class TestChantryCreateFormBasics(TestChantryCreateFormSetup):
 
         self.assertIn("name", form.fields)
         self.assertIn("chronicle", form.fields)
-        self.assertIn("parent", form.fields)
+        self.assertIn("contained_within", form.fields)
         self.assertIn("description", form.fields)
         self.assertIn("faction", form.fields)
         self.assertIn("leadership_type", form.fields)

--- a/locations/tests/forms/mage/test_demesne.py
+++ b/locations/tests/forms/mage/test_demesne.py
@@ -35,7 +35,7 @@ class TestDemesneFormBasics(TestDemesneFormSetup):
         form = DemesneForm()
 
         self.assertIn("name", form.fields)
-        self.assertIn("parent", form.fields)
+        self.assertIn("contained_within", form.fields)
         self.assertIn("description", form.fields)
         self.assertIn("rank", form.fields)
         self.assertIn("size", form.fields)
@@ -59,11 +59,11 @@ class TestDemesneFormBasics(TestDemesneFormSetup):
 
         self.assertIn("placeholder", form.fields["size"].widget.attrs)
 
-    def test_parent_not_required(self):
-        """Test that parent field is not required."""
+    def test_contained_within_not_required(self):
+        """Test that contained_within field is not required."""
         form = DemesneForm()
 
-        self.assertFalse(form.fields["parent"].required)
+        self.assertFalse(form.fields["contained_within"].required)
 
     def test_form_has_reality_zone_formset(self):
         """Test that form has embedded reality zone formset."""

--- a/locations/tests/forms/mage/test_node.py
+++ b/locations/tests/forms/mage/test_node.py
@@ -60,7 +60,7 @@ class TestNodeFormBasics(TestCase):
         self.assertIn("size", form.fields)
         self.assertIn("quintessence_form", form.fields)
         self.assertIn("tass_form", form.fields)
-        self.assertIn("parent", form.fields)
+        self.assertIn("contained_within", form.fields)
         self.assertIn("gauntlet", form.fields)
         self.assertIn("shroud", form.fields)
         self.assertIn("dimension_barrier", form.fields)

--- a/locations/tests/forms/mage/test_paradox_realm.py
+++ b/locations/tests/forms/mage/test_paradox_realm.py
@@ -125,7 +125,7 @@ class TestParadoxRealmFormBasics(TestCase):
         form = ParadoxRealmForm()
         self.assertFalse(form.fields["secondary_sphere"].required)
         self.assertFalse(form.fields["secondary_paradigm"].required)
-        self.assertFalse(form.fields["parent"].required)
+        self.assertFalse(form.fields["contained_within"].required)
 
     def test_form_has_formsets(self):
         """Test form has obstacle and atmosphere formsets."""

--- a/locations/tests/models/changeling/test_freehold.py
+++ b/locations/tests/models/changeling/test_freehold.py
@@ -115,7 +115,7 @@ class TestFreeholdMultiStepCreation(TestCase):
             "resource_description": "Generates mundane revenue",
             "passage_description": "One trod to the Near Dreaming",
             "quirks": "The grass whispers encouragement",
-            "parent": "",
+            "contained_within": [],
             "owned_by": self.character.pk,
         }
 
@@ -184,7 +184,7 @@ class TestFreeholdMultiStepCreation(TestCase):
             "resource_description": "",
             "passage_description": "",
             "quirks": "",
-            "parent": "",
+            "contained_within": [],
             "owned_by": self.character.pk,
         }
 
@@ -221,7 +221,7 @@ class TestFreeholdMultiStepCreation(TestCase):
             "resource_description": "",
             "passage_description": "",
             "quirks": "",
-            "parent": "",
+            "contained_within": [],
             "owned_by": self.character.pk,
         }
 
@@ -314,7 +314,7 @@ class TestFreeholdMultiStepCreation(TestCase):
             "resource_description": "Ancient texts",
             "passage_description": "Portal to the Deep Dreaming",
             "quirks": "Books rearrange themselves",
-            "parent": "",
+            "contained_within": [],
             "owned_by": self.character.pk,
         }
         response = self.client.post(url, data, follow=True)

--- a/locations/tests/models/core/test_location.py
+++ b/locations/tests/models/core/test_location.py
@@ -7,11 +7,111 @@ from locations.models.core import LocationModel
 class TestLocation(TestCase):
     def setUp(self) -> None:
         self.location = LocationModel.objects.create(name="Location 1")
-        self.child = LocationModel.objects.create(name="Location 2", parent=self.location)
+        self.child = LocationModel.objects.create(name="Location 2")
+        self.child.contained_within.add(self.location)
 
-    def test_location_parent(self):
-        self.assertEqual(self.child.parent, self.location)
-        self.assertIn(self.child, self.location.children.all())
+    def test_location_contained_within(self):
+        self.assertIn(self.location, self.child.contained_within.all())
+        self.assertIn(self.child, self.location.contains.all())
+
+
+class TestLocationContainedWithinM2M(TestCase):
+    """Tests for the contained_within ManyToManyField (Issue #1040)."""
+
+    def setUp(self) -> None:
+        self.parent1 = LocationModel.objects.create(name="Parent 1")
+        self.parent2 = LocationModel.objects.create(name="Parent 2")
+        self.child = LocationModel.objects.create(name="Child Location")
+
+    def test_location_can_have_multiple_parents(self):
+        """Test that a location can be contained within multiple parent locations."""
+        self.child.contained_within.add(self.parent1)
+        self.child.contained_within.add(self.parent2)
+
+        self.assertEqual(self.child.contained_within.count(), 2)
+        self.assertIn(self.parent1, self.child.contained_within.all())
+        self.assertIn(self.parent2, self.child.contained_within.all())
+
+    def test_parent_contains_multiple_children(self):
+        """Test that a parent location can contain multiple child locations."""
+        child2 = LocationModel.objects.create(name="Child 2")
+        self.child.contained_within.add(self.parent1)
+        child2.contained_within.add(self.parent1)
+
+        self.assertEqual(self.parent1.contains.count(), 2)
+        self.assertIn(self.child, self.parent1.contains.all())
+        self.assertIn(child2, self.parent1.contains.all())
+
+    def test_contains_reverse_relation(self):
+        """Test that the 'contains' reverse relation works correctly."""
+        self.child.contained_within.add(self.parent1)
+
+        self.assertIn(self.child, self.parent1.contains.all())
+        self.assertEqual(self.parent1.contains.count(), 1)
+
+    def test_remove_from_contained_within(self):
+        """Test that removing a parent from contained_within works correctly."""
+        self.child.contained_within.add(self.parent1)
+        self.child.contained_within.add(self.parent2)
+        self.assertEqual(self.child.contained_within.count(), 2)
+
+        self.child.contained_within.remove(self.parent1)
+
+        self.assertEqual(self.child.contained_within.count(), 1)
+        self.assertNotIn(self.parent1, self.child.contained_within.all())
+        self.assertIn(self.parent2, self.child.contained_within.all())
+
+    def test_clear_contained_within(self):
+        """Test that clearing contained_within removes all parent relationships."""
+        self.child.contained_within.add(self.parent1)
+        self.child.contained_within.add(self.parent2)
+
+        self.child.contained_within.clear()
+
+        self.assertEqual(self.child.contained_within.count(), 0)
+
+
+class TestLocationTopLevel(TestCase):
+    """Tests for the top_level() queryset method."""
+
+    def setUp(self) -> None:
+        self.top_level_location = LocationModel.objects.create(name="Top Level")
+        self.contained_location = LocationModel.objects.create(name="Contained")
+        self.contained_location.contained_within.add(self.top_level_location)
+
+    def test_top_level_returns_locations_without_parents(self):
+        """Test that top_level() returns locations not contained within any other."""
+        top_level_qs = LocationModel.objects.top_level()
+
+        self.assertIn(self.top_level_location, top_level_qs)
+        self.assertNotIn(self.contained_location, top_level_qs)
+
+    def test_top_level_excludes_contained_locations(self):
+        """Test that locations with any parent are excluded from top_level()."""
+        another_top = LocationModel.objects.create(name="Another Top")
+
+        top_level_qs = LocationModel.objects.top_level()
+
+        self.assertEqual(top_level_qs.count(), 2)
+        self.assertIn(self.top_level_location, top_level_qs)
+        self.assertIn(another_top, top_level_qs)
+
+    def test_location_with_cleared_parents_is_top_level(self):
+        """Test that clearing parents makes a location top-level again."""
+        self.contained_location.contained_within.clear()
+
+        top_level_qs = LocationModel.objects.top_level()
+
+        self.assertIn(self.contained_location, top_level_qs)
+
+    def test_location_with_multiple_parents_not_top_level(self):
+        """Test that a location with multiple parents is not top-level."""
+        parent2 = LocationModel.objects.create(name="Parent 2")
+        self.contained_location.contained_within.add(parent2)
+
+        top_level_qs = LocationModel.objects.top_level()
+
+        self.assertNotIn(self.contained_location, top_level_qs)
 
 
 class TestLocationDetailView(TestCase):

--- a/locations/views/core/city.py
+++ b/locations/views/core/city.py
@@ -19,7 +19,7 @@ class CityCreateView(MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "gauntlet",
         "shroud",
         "dimension_barrier",
@@ -43,7 +43,7 @@ class CityCreateView(MessageMixin, CreateView):
         form.fields["media"].widget.attrs.update({"placeholder": "Enter media here"})
         form.fields["politicians"].widget.attrs.update({"placeholder": "Enter politicians here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form
 
 
@@ -52,7 +52,7 @@ class CityUpdateView(MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "gauntlet",
         "shroud",
         "dimension_barrier",
@@ -76,5 +76,5 @@ class CityUpdateView(MessageMixin, UpdateView):
         form.fields["media"].widget.attrs.update({"placeholder": "Enter media here"})
         form.fields["politicians"].widget.attrs.update({"placeholder": "Enter politicians here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/core/location.py
+++ b/locations/views/core/location.py
@@ -15,7 +15,7 @@ class LocationCreateView(LoginRequiredMixin, CreateView):
     model = LocationModel
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "gauntlet",
         "shroud",
         "dimension_barrier",
@@ -29,7 +29,7 @@ class LocationCreateView(LoginRequiredMixin, CreateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form
 
     def form_valid(self, form):
@@ -43,7 +43,7 @@ class LocationUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = LocationModel
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "gauntlet",
         "shroud",
         "dimension_barrier",
@@ -80,6 +80,6 @@ class LocationUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
             form.fields["description"].widget.attrs.update(
                 {"placeholder": "Enter description here"}
             )
-        if "parent" in form.fields:
-            form.fields["parent"].empty_label = "Parent Location"
+        if "contained_within" in form.fields:
+            form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/demon/bastion.py
+++ b/locations/views/demon/bastion.py
@@ -19,7 +19,7 @@ class BastionCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = Bastion
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "ritual_strength",
         "warding_level",
@@ -33,7 +33,7 @@ class BastionCreateView(LoginRequiredMixin, MessageMixin, CreateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form
 
 
@@ -42,7 +42,7 @@ class BastionUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "ritual_strength",
         "warding_level",
         "consecration_date",
@@ -55,5 +55,5 @@ class BastionUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/demon/reliquary.py
+++ b/locations/views/demon/reliquary.py
@@ -19,7 +19,7 @@ class ReliquaryCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = Reliquary
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "reliquary_type",
         "location_size",
@@ -38,7 +38,7 @@ class ReliquaryCreateView(LoginRequiredMixin, MessageMixin, CreateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form
 
 
@@ -47,7 +47,7 @@ class ReliquaryUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "reliquary_type",
         "location_size",
         "max_health_levels",
@@ -65,5 +65,5 @@ class ReliquaryUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/hunter/huntingground.py
+++ b/locations/views/hunter/huntingground.py
@@ -19,7 +19,7 @@ class HuntingGroundCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = HuntingGround
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "size",
         "population",
@@ -43,7 +43,7 @@ class HuntingGroundUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = HuntingGround
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "size",
         "population",

--- a/locations/views/hunter/safehouse.py
+++ b/locations/views/hunter/safehouse.py
@@ -19,7 +19,7 @@ class SafehouseCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = Safehouse
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "size",
         "capacity",
@@ -45,7 +45,7 @@ class SafehouseUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = Safehouse
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "size",
         "capacity",

--- a/locations/views/mage/chantry.py
+++ b/locations/views/mage/chantry.py
@@ -55,7 +55,7 @@ class ChantryCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = Chantry
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "faction",
         "leadership_type",
@@ -87,7 +87,7 @@ class ChantryUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = Chantry
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "faction",
         "leadership_type",

--- a/locations/views/mage/demesne.py
+++ b/locations/views/mage/demesne.py
@@ -32,7 +32,7 @@ class DemesneCreateView(LoginRequiredMixin, MessageMixin, FormView):
 
 class DemesneUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = Demesne
-    fields = ["name", "description", "parent", "size", "accessibility"]
+    fields = ["name", "description", "contained_within", "size", "accessibility"]
     template_name = "locations/mage/demesne/form.html"
     success_message = "Demesne '{name}' updated successfully!"
     error_message = "Failed to update demesne. Please correct the errors below."
@@ -41,5 +41,5 @@ class DemesneUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/mage/library.py
+++ b/locations/views/mage/library.py
@@ -32,7 +32,7 @@ class LibraryCreateView(LoginRequiredMixin, MessageMixin, FormView):
 
 class LibraryUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = Library
-    fields = ["name", "description", "parent", "rank", "faction", "books"]
+    fields = ["name", "description", "contained_within", "rank", "faction", "books"]
     template_name = "locations/mage/library/form.html"
     success_message = "Library '{name}' updated successfully!"
     error_message = "Failed to update library. Please correct the errors below."

--- a/locations/views/mage/node.py
+++ b/locations/views/mage/node.py
@@ -51,7 +51,7 @@ class NodeUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = Node
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "reality_zone",
         "description",
         "rank",

--- a/locations/views/mage/realm.py
+++ b/locations/views/mage/realm.py
@@ -17,7 +17,7 @@ class RealmListView(ListView):
 
 class RealmCreateView(LoginRequiredMixin, CreateView):
     model = HorizonRealm
-    fields = ["name", "description", "parent"]
+    fields = ["name", "description", "contained_within"]
     template_name = "locations/mage/realm/form.html"
     success_message = "Horizon Realm '{name}' created successfully!"
     error_message = "Failed to create horizon realm. Please correct the errors below."
@@ -26,13 +26,13 @@ class RealmCreateView(LoginRequiredMixin, CreateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form
 
 
 class RealmUpdateView(EditPermissionMixin, UpdateView):
     model = HorizonRealm
-    fields = ["name", "description", "parent"]
+    fields = ["name", "description", "contained_within"]
     template_name = "locations/mage/realm/form.html"
     success_message = "Horizon Realm '{name}' updated successfully!"
     error_message = "Failed to update horizon realm. Please correct the errors below."
@@ -41,5 +41,5 @@ class RealmUpdateView(EditPermissionMixin, UpdateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/mage/sanctum.py
+++ b/locations/views/mage/sanctum.py
@@ -32,7 +32,7 @@ class SanctumCreateView(LoginRequiredMixin, MessageMixin, FormView):
 
 class SanctumUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     model = Sanctum
-    fields = ["name", "description", "parent"]
+    fields = ["name", "description", "contained_within"]
     template_name = "locations/mage/sanctum/form.html"
     success_message = "Sanctum '{name}' updated successfully!"
     error_message = "Failed to update sanctum. Please correct the errors below."
@@ -41,5 +41,5 @@ class SanctumUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/mummy.py
+++ b/locations/views/mummy.py
@@ -16,7 +16,7 @@ class TombCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "security",
         "sanctity",
@@ -43,7 +43,7 @@ class TombUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "security",
         "sanctity",
@@ -82,7 +82,7 @@ class CultTempleCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "cult_size",
         "public_cover",
         "cult_leader_name",
@@ -100,7 +100,7 @@ class CultTempleUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "cult_size",
         "public_cover",
         "cult_leader_name",
@@ -129,7 +129,7 @@ class UndergroundSanctuaryCreateView(LoginRequiredMixin, MessageMixin, CreateVie
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "sanctuary_type",
         "concealment_rating",
     ]
@@ -143,7 +143,7 @@ class UndergroundSanctuaryUpdateView(EditPermissionMixin, MessageMixin, UpdateVi
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "sanctuary_type",
         "concealment_rating",
     ]

--- a/locations/views/vampire/__init__.py
+++ b/locations/views/vampire/__init__.py
@@ -32,7 +32,7 @@ class HavenCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "security",
         "location",
@@ -52,7 +52,7 @@ class HavenUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "security",
         "location",
@@ -84,7 +84,7 @@ class DomainCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "population",
         "control",
@@ -103,7 +103,7 @@ class DomainUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "population",
         "control",
@@ -134,7 +134,7 @@ class ElysiumCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "prestige",
         "keeper_name",
         "elysium_type",
@@ -155,7 +155,7 @@ class ElysiumUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "prestige",
         "keeper_name",
         "elysium_type",
@@ -188,7 +188,7 @@ class RackCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "quality",
         "population_density",
         "risk_level",
@@ -209,7 +209,7 @@ class RackUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "quality",
         "population_density",
         "risk_level",
@@ -242,7 +242,7 @@ class TremereChantryCreateView(CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "security_level",
         "library_rating",
@@ -267,7 +267,7 @@ class TremereChantryUpdateView(UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "security_level",
         "library_rating",
@@ -304,7 +304,7 @@ class BarrensCreateView(CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "danger_level",
         "population_density",
@@ -332,7 +332,7 @@ class BarrensUpdateView(UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "size",
         "danger_level",
         "population_density",

--- a/locations/views/werewolf/caern.py
+++ b/locations/views/werewolf/caern.py
@@ -19,7 +19,7 @@ class CaernCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     model = Caern
     fields = [
         "name",
-        "parent",
+        "contained_within",
         "description",
         "rank",
         "caern_type",
@@ -32,7 +32,7 @@ class CaernCreateView(LoginRequiredMixin, MessageMixin, CreateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form
 
 
@@ -41,7 +41,7 @@ class CaernUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "rank",
         "caern_type",
     ]
@@ -53,5 +53,5 @@ class CaernUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         form = super().get_form(form_class)
         form.fields["name"].widget.attrs.update({"placeholder": "Enter name here"})
         form.fields["description"].widget.attrs.update({"placeholder": "Enter description here"})
-        form.fields["parent"].empty_label = "Parent Location"
+        form.fields["contained_within"].help_text = "Select one or more parent locations"
         return form

--- a/locations/views/wraith/byway.py
+++ b/locations/views/wraith/byway.py
@@ -14,7 +14,7 @@ class BywayCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "danger_level",
         "stability",
         "origin",
@@ -36,7 +36,7 @@ class BywayUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "danger_level",
         "stability",
         "origin",

--- a/locations/views/wraith/citadel.py
+++ b/locations/views/wraith/citadel.py
@@ -14,7 +14,7 @@ class CitadelCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "purpose",
         "defense_rating",
         "garrison_size",
@@ -34,7 +34,7 @@ class CitadelUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "purpose",
         "defense_rating",
         "garrison_size",

--- a/locations/views/wraith/freehold.py
+++ b/locations/views/wraith/freehold.py
@@ -14,7 +14,7 @@ class WraithFreeholdCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "population",
         "government_type",
         "leader",
@@ -38,7 +38,7 @@ class WraithFreeholdUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "population",
         "government_type",
         "leader",

--- a/locations/views/wraith/haunt.py
+++ b/locations/views/wraith/haunt.py
@@ -20,7 +20,7 @@ class HauntCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "rank",
         "shroud_rating",
         "haunt_type",
@@ -38,7 +38,7 @@ class HauntUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "rank",
         "shroud_rating",
         "haunt_type",

--- a/locations/views/wraith/necropolis.py
+++ b/locations/views/wraith/necropolis.py
@@ -19,7 +19,7 @@ class NecropolisCreateView(LoginRequiredMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "region",
         "population",
         "deathlord",
@@ -34,7 +34,7 @@ class NecropolisUpdateView(EditPermissionMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "region",
         "population",
         "deathlord",

--- a/locations/views/wraith/nihil.py
+++ b/locations/views/wraith/nihil.py
@@ -14,7 +14,7 @@ class NihilCreateView(LoginRequiredMixin, MessageMixin, CreateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "void_type",
         "stability",
         "hazard_level",
@@ -41,7 +41,7 @@ class NihilUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "description",
-        "parent",
+        "contained_within",
         "void_type",
         "stability",
         "hazard_level",


### PR DESCRIPTION
Fixes #1040 

## Summary

- Adds `contained_within` ManyToManyField to `LocationModel` allowing locations to be contained within multiple parent locations
- Updates `top_level()` queryset method to filter locations without any parents
- Migrates existing `parent` ForeignKey data to the new M2M relationship
- Updates all templates to display multiple parent locations with comma separation
- Updates all forms and views to use the new `contained_within` field
- Adds comprehensive tests for the M2M functionality

## Changes

### Model Changes
- Added `contained_within = ManyToManyField("LocationModel", blank=True, related_name="contains")` to `LocationModel`
- Updated `top_level()` to use `contained_within__isnull=True` filter
- Updated `Chantry.set_library()` to use `contained_within.add()` instead of `parent` assignment

### Migration Strategy
- `0003_add_contained_within_m2m.py`: Adds the new M2M field
- `0004_copy_parent_to_contained_within.py`: Data migration that copies existing `parent` relationships to `contained_within`
- The old `parent` ForeignKey is preserved for backward compatibility

### Template Updates
- Updated all detail templates to iterate over `contained_within.all` instead of accessing single `parent`
- Updated `location_table_row.html` and `location_recursive.html` to use `contains` instead of `children`
- Updated form templates to use `contained_within` field

### Test Updates
- Updated all existing tests to use `contained_within` instead of `parent`
- Added comprehensive tests for M2M functionality:
  - Multiple parent relationships
  - `contains` reverse relation
  - `top_level()` queryset method
  - Adding/removing parent relationships

## Test plan

- [x] Run `python manage.py test locations.tests.models.core` - All 19 tests pass
- [x] Run `python manage.py test locations.tests.forms` - All 165 tests pass
- [x] Run `python manage.py test locations.tests.models.changeling` - All 18 tests pass
- [x] Verify migrations apply cleanly
- [x] Test that existing parent relationships are migrated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)