### PR TITLE
Add PhysicalPlace model for cross-gameline location integration

### DIFF
--- a/locations/models/__init__.py
+++ b/locations/models/__init__.py
@@ -1,2 +1,2 @@
 from . import demon, hunter, mage, vampire, werewolf, wraith
-from .core import City, LocationModel
+from .core import City, LocationModel, PhysicalPlace

--- a/locations/models/core/__init__.py
+++ b/locations/models/core/__init__.py
@@ -1,2 +1,3 @@
 from .city import City
 from .location import LocationModel
+from .physical_place import PhysicalPlace

--- a/locations/models/core/location.py
+++ b/locations/models/core/location.py
@@ -31,6 +31,16 @@ class LocationModel(Model):
     )
     owned_by = models.ForeignKey(CharacterModel, blank=True, null=True, on_delete=models.SET_NULL)
 
+    # Link to physical place for cross-gameline location tracking
+    physical_place = models.ForeignKey(
+        "locations.PhysicalPlace",
+        blank=True,
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="locations",
+        help_text="The physical real-world location this supernatural place exists at",
+    )
+
     gauntlet = models.IntegerField(default=7)
     shroud = models.IntegerField(default=7)
     dimension_barrier = models.IntegerField(default=6)
@@ -63,6 +73,18 @@ class LocationModel(Model):
             return [self.owned_by]
         else:
             return []
+
+    def get_sibling_locations(self):
+        """
+        Get other supernatural locations at the same physical place.
+
+        Returns a queryset of LocationModel instances that share the same
+        PhysicalPlace as this location, excluding this location itself.
+        Returns an empty queryset if no physical_place is set.
+        """
+        if self.physical_place is None:
+            return LocationModel.objects.none()
+        return self.physical_place.locations.exclude(pk=self.pk)
 
     def clean(self):
         """Validate location data before saving."""

--- a/locations/models/core/physical_place.py
+++ b/locations/models/core/physical_place.py
@@ -1,0 +1,160 @@
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.urls import reverse
+from game.models import Chronicle
+
+
+class PhysicalPlace(models.Model):
+    """
+    Represents a mundane physical location in the real world.
+
+    A PhysicalPlace can be associated with multiple LocationModel instances
+    (e.g., a Node, Elysium, Haunt, etc.) to represent different supernatural
+    aspects of the same physical location.
+
+    This allows cross-gameline integration where:
+    - Pike Place Market can be both a Node (Mage) and a Rack (Vampire)
+    - A church can be an Elysium (Vampire), a Haunt (Wraith), and more
+    - Seattle as a City can have multiple supernatural Domains, Holdings, etc.
+    """
+
+    name = models.CharField(max_length=200)
+    description = models.TextField(default="", blank=True)
+
+    # Address/location info
+    address = models.CharField(max_length=500, blank=True)
+    city = models.CharField(max_length=200, blank=True)
+    state = models.CharField(max_length=100, blank=True)
+    country = models.CharField(max_length=100, blank=True)
+    postal_code = models.CharField(max_length=20, blank=True)
+
+    # Geographic coordinates (optional)
+    latitude = models.DecimalField(
+        max_digits=9, decimal_places=6, null=True, blank=True
+    )
+    longitude = models.DecimalField(
+        max_digits=9, decimal_places=6, null=True, blank=True
+    )
+
+    # Place type (mundane classification)
+    PLACE_TYPE_CHOICES = [
+        ("building", "Building"),
+        ("landmark", "Landmark"),
+        ("park", "Park/Green Space"),
+        ("district", "District/Neighborhood"),
+        ("city", "City"),
+        ("region", "Region/Area"),
+        ("underground", "Underground/Subterranean"),
+        ("waterway", "Waterway"),
+        ("other", "Other"),
+    ]
+    place_type = models.CharField(
+        max_length=20, choices=PLACE_TYPE_CHOICES, default="building"
+    )
+
+    # Ownership and access
+    owner = models.ForeignKey(
+        User, on_delete=models.SET_NULL, blank=True, null=True
+    )
+    chronicle = models.ForeignKey(
+        Chronicle, on_delete=models.SET_NULL, blank=True, null=True
+    )
+
+    # Visibility
+    display = models.BooleanField(default=True)
+
+    class Meta:
+        verbose_name = "Physical Place"
+        verbose_name_plural = "Physical Places"
+        ordering = ["name"]
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("locations:physical_place", args=[str(self.id)])
+
+    def get_update_url(self):
+        return reverse("locations:update:physical_place", args=[str(self.id)])
+
+    @classmethod
+    def get_creation_url(cls):
+        return reverse("locations:create:physical_place")
+
+    def get_supernatural_locations(self):
+        """
+        Get all supernatural locations linked to this physical place.
+
+        Returns a queryset of all LocationModel instances that reference
+        this PhysicalPlace.
+        """
+        return self.locations.all()
+
+    def get_supernatural_locations_by_gameline(self):
+        """
+        Get supernatural locations grouped by gameline.
+
+        Returns a dict mapping gameline codes to lists of locations.
+        """
+        from django.conf import settings
+
+        locations = self.get_supernatural_locations().select_related("polymorphic_ctype")
+        result = {}
+        for loc in locations:
+            gameline = loc.get_gameline()
+            if gameline not in result:
+                result[gameline] = []
+            result[gameline].append(loc)
+        return result
+
+    def get_full_address(self):
+        """Return formatted full address."""
+        parts = []
+        if self.address:
+            parts.append(self.address)
+        if self.city:
+            parts.append(self.city)
+        if self.state:
+            parts.append(self.state)
+        if self.postal_code:
+            parts.append(self.postal_code)
+        if self.country:
+            parts.append(self.country)
+        return ", ".join(parts)
+
+    def has_coordinates(self):
+        """Check if geographic coordinates are set."""
+        return self.latitude is not None and self.longitude is not None
+
+    def clean(self):
+        """Validate physical place data before saving."""
+        super().clean()
+        errors = {}
+
+        # Validate name is not empty
+        if not self.name or not self.name.strip():
+            errors["name"] = "Name is required"
+
+        # Validate coordinates are both set or both empty
+        if (self.latitude is None) != (self.longitude is None):
+            errors["latitude"] = "Both latitude and longitude must be provided, or neither"
+            errors["longitude"] = "Both latitude and longitude must be provided, or neither"
+
+        # Validate latitude range
+        if self.latitude is not None:
+            if self.latitude < -90 or self.latitude > 90:
+                errors["latitude"] = "Latitude must be between -90 and 90"
+
+        # Validate longitude range
+        if self.longitude is not None:
+            if self.longitude < -180 or self.longitude > 180:
+                errors["longitude"] = "Longitude must be between -180 and 180"
+
+        if errors:
+            raise ValidationError(errors)
+
+    def save(self, *args, **kwargs):
+        """Ensure validation runs on save."""
+        self.full_clean()
+        super().save(*args, **kwargs)

--- a/locations/templates/locations/core/location/detail.html
+++ b/locations/templates/locations/core/location/detail.html
@@ -28,5 +28,6 @@
     {% endblock additional_content %}
 {% endblock contents %}
 {% block post_content %}
+    {% include "locations/core/location/display_includes/physical_place.html" %}
     {% include "locations/core/location/display_includes/scenes.html" %}
 {% endblock post_content %}

--- a/locations/templates/locations/core/location/display_includes/physical_place.html
+++ b/locations/templates/locations/core/location/display_includes/physical_place.html
@@ -1,0 +1,32 @@
+{% if object.physical_place %}
+<div class="tg-card mb-4">
+    <div class="tg-card-header">
+        <h3 class="tg-card-title">Physical Location</h3>
+    </div>
+    <div class="tg-card-body">
+        <p class="mb-2">
+            <strong>Located at:</strong>
+            <a href="{{ object.physical_place.get_absolute_url }}">{{ object.physical_place.name }}</a>
+            {% if object.physical_place.city %}<span class="text-muted">- {{ object.physical_place.city }}</span>{% endif %}
+        </p>
+
+        {% with siblings=object.get_sibling_locations %}
+        {% if siblings %}
+        <hr>
+        <h5>Other Supernatural Aspects at This Location</h5>
+        <div class="row">
+            {% for sibling in siblings %}
+            <div class="col-sm-6 col-md-4 mb-2">
+                <div class="d-flex align-items-center">
+                    <span class="tg-badge {{ sibling.get_badge_class }} me-2">{{ sibling.get_gameline|upper }}</span>
+                    <a href="{{ sibling.get_absolute_url }}">{{ sibling.name }}</a>
+                </div>
+                <small class="text-muted">{{ sibling.get_type }}</small>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        {% endwith %}
+    </div>
+</div>
+{% endif %}

--- a/locations/templates/locations/core/location/form.html
+++ b/locations/templates/locations/core/location/form.html
@@ -13,6 +13,17 @@
             <div class="col-sm">{{ form.parent }}</div>
         </div>
     {% endblock parent %}
+    {% block physical_place %}
+        {% if form.physical_place %}
+        <div class="row">
+            <div class="col-sm">
+                <label for="id_physical_place">Physical Place</label>
+                {{ form.physical_place }}
+                <small class="text-muted">Link this to a real-world physical location for cross-gameline integration</small>
+            </div>
+        </div>
+        {% endif %}
+    {% endblock physical_place %}
     {% block gauntlets %}
         <div class="row">
             <div class="col-sm">Gauntlet</div>

--- a/locations/templates/locations/core/physical_place/detail.html
+++ b/locations/templates/locations/core/physical_place/detail.html
@@ -1,0 +1,114 @@
+{% extends "core/base.html" %}
+{% load sanitize_text %}
+{% block title %}{{ object.name }}{% endblock title %}
+{% block content %}
+<div class="container">
+    <!-- Page Header -->
+    <div class="tg-card header-card mb-4">
+        <div class="tg-card-header">
+            <h1 class="tg-card-title wod_heading">{{ object.name }}</h1>
+            <p class="tg-card-subtitle mb-0">
+                <span class="tg-badge badge-secondary">{{ object.get_place_type_display }}</span>
+                {% if object.city %}{{ object.city }}{% endif %}
+                {% if object.state %}, {{ object.state }}{% endif %}
+            </p>
+        </div>
+    </div>
+
+    <!-- Location Details -->
+    <div class="row">
+        <div class="col-md-6">
+            <div class="tg-card mb-4">
+                <div class="tg-card-header">
+                    <h3 class="tg-card-title">Location Details</h3>
+                </div>
+                <div class="tg-card-body">
+                    {% if object.description %}
+                        <div class="mb-3">
+                            <strong>Description:</strong>
+                            <p>{{ object.description|sanitize_html }}</p>
+                        </div>
+                    {% endif %}
+                    {% if object.get_full_address %}
+                        <div class="mb-2">
+                            <strong>Address:</strong> {{ object.get_full_address }}
+                        </div>
+                    {% endif %}
+                    {% if object.has_coordinates %}
+                        <div class="mb-2">
+                            <strong>Coordinates:</strong>
+                            {{ object.latitude }}, {{ object.longitude }}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="tg-card mb-4">
+                <div class="tg-card-header">
+                    <h3 class="tg-card-title">Quick Stats</h3>
+                </div>
+                <div class="tg-card-body">
+                    <div class="row text-center">
+                        <div class="col">
+                            <h2>{{ total_locations }}</h2>
+                            <small class="text-muted">Supernatural Locations</small>
+                        </div>
+                        <div class="col">
+                            <h2>{{ gameline_locations|length }}</h2>
+                            <small class="text-muted">Gamelines</small>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Supernatural Locations by Gameline -->
+    {% if gameline_locations %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-header">
+            <h3 class="tg-card-title">Supernatural Locations</h3>
+            <p class="tg-card-subtitle">All supernatural aspects of this physical location, grouped by game line</p>
+        </div>
+        <div class="tg-card-body">
+            {% for gameline in gameline_locations %}
+            <div class="mb-4">
+                <h4 class="{{ gameline.code }}_heading mb-3">{{ gameline.name }}</h4>
+                <div class="row">
+                    {% for loc in gameline.locations %}
+                    <div class="col-sm-6 col-md-4 mb-3">
+                        <div class="tg-card h-100">
+                            <div class="tg-card-body" style="padding: 16px;">
+                                <a href="{{ loc.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">
+                                    {{ loc.name }}
+                                </a>
+                                <br>
+                                <small class="text-muted">{{ loc.get_type }}</small>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% else %}
+    <div class="tg-card mb-4">
+        <div class="tg-card-body text-center">
+            <p class="text-muted mb-0">No supernatural locations are linked to this physical place yet.</p>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Actions -->
+    <div class="tg-card mb-4">
+        <div class="tg-card-body">
+            <a href="{{ object.get_update_url }}" class="tg-btn tg-btn-primary">Edit Physical Place</a>
+            <a href="{% url 'locations:list:physical_place' %}" class="tg-btn tg-btn-secondary">Back to List</a>
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/locations/templates/locations/core/physical_place/form.html
+++ b/locations/templates/locations/core/physical_place/form.html
@@ -1,0 +1,84 @@
+{% extends "core/form.html" %}
+{% block creation_title %}
+    {% if object.pk %}Edit{% else %}Create{% endif %} Physical Place
+{% endblock creation_title %}
+{% block contents %}
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="id_name" class="form-label">Name</label>
+            {{ form.name }}
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="id_place_type" class="form-label">Place Type</label>
+            {{ form.place_type }}
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="id_description" class="form-label">Description</label>
+            {{ form.description }}
+        </div>
+    </div>
+
+    <h4 class="mt-4 mb-3">Address</h4>
+
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="id_address" class="form-label">Street Address</label>
+            {{ form.address }}
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <label for="id_city" class="form-label">City</label>
+            {{ form.city }}
+        </div>
+        <div class="col-md-3">
+            <label for="id_state" class="form-label">State/Province</label>
+            {{ form.state }}
+        </div>
+        <div class="col-md-3">
+            <label for="id_postal_code" class="form-label">Postal Code</label>
+            {{ form.postal_code }}
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <div class="col-12">
+            <label for="id_country" class="form-label">Country</label>
+            {{ form.country }}
+        </div>
+    </div>
+
+    <h4 class="mt-4 mb-3">Coordinates (Optional)</h4>
+
+    <div class="row mb-3">
+        <div class="col-md-6">
+            <label for="id_latitude" class="form-label">Latitude</label>
+            {{ form.latitude }}
+            <small class="text-muted">Range: -90 to 90</small>
+        </div>
+        <div class="col-md-6">
+            <label for="id_longitude" class="form-label">Longitude</label>
+            {{ form.longitude }}
+            <small class="text-muted">Range: -180 to 180</small>
+        </div>
+    </div>
+
+    {% if form.display %}
+    <h4 class="mt-4 mb-3">Visibility</h4>
+    <div class="row mb-3">
+        <div class="col-12">
+            <div class="form-check">
+                {{ form.display }}
+                <label class="form-check-label" for="id_display">Display this place</label>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+{% endblock contents %}

--- a/locations/templates/locations/core/physical_place/list.html
+++ b/locations/templates/locations/core/physical_place/list.html
@@ -1,0 +1,72 @@
+{% extends "core/base.html" %}
+{% block title %}Physical Places{% endblock title %}
+{% block content %}
+<div class="container">
+    <div class="tg-card mb-4">
+        <div class="tg-card-header d-flex justify-content-between align-items-center">
+            <div>
+                <h3 class="tg-card-title wod_heading">Physical Places</h3>
+                <p class="tg-card-subtitle mb-0">Real-world locations that may host supernatural sites</p>
+            </div>
+            <a href="{% url 'locations:create:physical_place' %}" class="tg-btn tg-btn-primary">Create New</a>
+        </div>
+        <div class="tg-card-body" style="padding: 24px;">
+            <div class="row">
+                {% for place in physical_places %}
+                    <div class="col-sm-6 col-md-4 mb-3">
+                        <div class="tg-card h-100">
+                            <div class="tg-card-body" style="padding: 16px;">
+                                <a href="{{ place.get_absolute_url }}" style="font-weight: 600; color: var(--theme-text-primary);">
+                                    {{ place.name }}
+                                </a>
+                                <br>
+                                <small class="text-muted">
+                                    {{ place.get_place_type_display }}
+                                    {% if place.city %} - {{ place.city }}{% endif %}
+                                </small>
+                                <br>
+                                <small class="text-muted">
+                                    {{ place.locations.count }} supernatural location{{ place.locations.count|pluralize }}
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                {% empty %}
+                    <div class="col-12 text-center">
+                        <p class="text-muted">No physical places found.</p>
+                        <a href="{% url 'locations:create:physical_place' %}" class="tg-btn tg-btn-primary">Create the first one</a>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+
+    {% if is_paginated %}
+    <nav aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+                <li class="page-item">
+                    <a class="page-link" href="?page=1">&laquo; First</a>
+                </li>
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                </li>
+            {% endif %}
+
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+            </li>
+
+            {% if page_obj.has_next %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                </li>
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.paginator.num_pages }}">Last &raquo;</a>
+                </li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
+</div>
+{% endblock content %}

--- a/locations/tests/models/core/test_physical_place.py
+++ b/locations/tests/models/core/test_physical_place.py
@@ -1,0 +1,285 @@
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from game.models import Chronicle
+from locations.models import LocationModel, PhysicalPlace
+from locations.models.mage.node import Node
+from locations.models.vampire.elysium import Elysium
+from locations.models.wraith.haunt import Haunt
+
+
+class TestPhysicalPlaceModel(TestCase):
+    """Tests for the PhysicalPlace model."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        self.place = PhysicalPlace.objects.create(
+            name="Pike Place Market",
+            description="Historic public market in Seattle",
+            address="85 Pike Street",
+            city="Seattle",
+            state="WA",
+            country="USA",
+            postal_code="98101",
+            owner=self.user,
+            chronicle=self.chronicle,
+        )
+
+    def test_physical_place_creation(self):
+        """Test basic PhysicalPlace creation."""
+        self.assertEqual(self.place.name, "Pike Place Market")
+        self.assertEqual(self.place.city, "Seattle")
+        self.assertEqual(self.place.state, "WA")
+
+    def test_physical_place_str(self):
+        """Test string representation."""
+        self.assertEqual(str(self.place), "Pike Place Market")
+
+    def test_get_full_address(self):
+        """Test full address formatting."""
+        address = self.place.get_full_address()
+        self.assertIn("85 Pike Street", address)
+        self.assertIn("Seattle", address)
+        self.assertIn("WA", address)
+        self.assertIn("98101", address)
+        self.assertIn("USA", address)
+
+    def test_get_full_address_partial(self):
+        """Test full address with missing components."""
+        place = PhysicalPlace.objects.create(
+            name="Simple Place",
+            city="Portland",
+        )
+        address = place.get_full_address()
+        self.assertEqual(address, "Portland")
+
+    def test_has_coordinates_false(self):
+        """Test has_coordinates returns False when not set."""
+        self.assertFalse(self.place.has_coordinates())
+
+    def test_has_coordinates_true(self):
+        """Test has_coordinates returns True when set."""
+        self.place.latitude = Decimal("47.6097")
+        self.place.longitude = Decimal("-122.3331")
+        self.place.save()
+        self.assertTrue(self.place.has_coordinates())
+
+    def test_place_type_default(self):
+        """Test default place type."""
+        self.assertEqual(self.place.place_type, "building")
+
+    def test_display_default(self):
+        """Test default display value."""
+        self.assertTrue(self.place.display)
+
+
+class TestPhysicalPlaceValidation(TestCase):
+    """Tests for PhysicalPlace validation."""
+
+    def test_name_required(self):
+        """Test that name is required."""
+        place = PhysicalPlace(name="")
+        with self.assertRaises(ValidationError) as context:
+            place.full_clean()
+        self.assertIn("name", context.exception.message_dict)
+
+    def test_coordinates_must_be_paired(self):
+        """Test that both latitude and longitude must be set together."""
+        place = PhysicalPlace(
+            name="Test Place",
+            latitude=Decimal("47.6097"),
+        )
+        with self.assertRaises(ValidationError) as context:
+            place.full_clean()
+        self.assertIn("latitude", context.exception.message_dict)
+
+    def test_latitude_range_validation(self):
+        """Test latitude must be between -90 and 90."""
+        place = PhysicalPlace(
+            name="Test Place",
+            latitude=Decimal("91.0"),
+            longitude=Decimal("0.0"),
+        )
+        with self.assertRaises(ValidationError) as context:
+            place.full_clean()
+        self.assertIn("latitude", context.exception.message_dict)
+
+    def test_longitude_range_validation(self):
+        """Test longitude must be between -180 and 180."""
+        place = PhysicalPlace(
+            name="Test Place",
+            latitude=Decimal("0.0"),
+            longitude=Decimal("181.0"),
+        )
+        with self.assertRaises(ValidationError) as context:
+            place.full_clean()
+        self.assertIn("longitude", context.exception.message_dict)
+
+    def test_valid_coordinates(self):
+        """Test valid coordinate values pass validation."""
+        place = PhysicalPlace(
+            name="Test Place",
+            latitude=Decimal("47.6097"),
+            longitude=Decimal("-122.3331"),
+        )
+        place.full_clean()  # Should not raise
+
+
+class TestPhysicalPlaceLocationRelationship(TestCase):
+    """Tests for PhysicalPlace relationships with LocationModel."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.place = PhysicalPlace.objects.create(
+            name="St. Mark's Cathedral",
+            address="1245 10th Ave E",
+            city="Seattle",
+            state="WA",
+        )
+
+    def test_link_location_to_physical_place(self):
+        """Test linking a LocationModel to a PhysicalPlace."""
+        location = LocationModel.objects.create(
+            name="St. Mark's Cathedral",
+            physical_place=self.place,
+        )
+        self.assertEqual(location.physical_place, self.place)
+        self.assertIn(location, self.place.locations.all())
+
+    def test_multiple_locations_same_place(self):
+        """Test multiple supernatural locations at the same physical place."""
+        # A Mage Node at St. Mark's
+        node = Node.objects.create(
+            name="Faith Nexus",
+            physical_place=self.place,
+            rank=3,
+        )
+
+        # A Vampire Elysium at St. Mark's
+        elysium = Elysium.objects.create(
+            name="The Cathedral Elysium",
+            physical_place=self.place,
+            prestige=4,
+        )
+
+        # A Wraith Haunt at St. Mark's
+        haunt = Haunt.objects.create(
+            name="The Whispering Choir",
+            physical_place=self.place,
+            rank=2,
+            faith_resonance="Echoes of prayer",
+        )
+
+        # All three should be linked
+        locations = self.place.get_supernatural_locations()
+        self.assertEqual(locations.count(), 3)
+        self.assertIn(node, locations)
+        self.assertIn(elysium, locations)
+        self.assertIn(haunt, locations)
+
+    def test_get_supernatural_locations_by_gameline(self):
+        """Test grouping locations by gameline."""
+        # Create locations from different gamelines
+        node = Node.objects.create(
+            name="Faith Nexus",
+            physical_place=self.place,
+            rank=3,
+        )
+        elysium = Elysium.objects.create(
+            name="The Cathedral Elysium",
+            physical_place=self.place,
+            prestige=4,
+        )
+        haunt = Haunt.objects.create(
+            name="The Whispering Choir",
+            physical_place=self.place,
+            rank=2,
+            faith_resonance="Echoes of prayer",
+        )
+
+        by_gameline = self.place.get_supernatural_locations_by_gameline()
+
+        self.assertIn("mta", by_gameline)
+        self.assertIn("vtm", by_gameline)
+        self.assertIn("wto", by_gameline)
+        self.assertIn(node, by_gameline["mta"])
+        self.assertIn(elysium, by_gameline["vtm"])
+        self.assertIn(haunt, by_gameline["wto"])
+
+
+class TestLocationModelSiblings(TestCase):
+    """Tests for LocationModel sibling methods."""
+
+    def setUp(self):
+        self.place = PhysicalPlace.objects.create(
+            name="The Waterfront",
+            city="Seattle",
+        )
+        self.node = Node.objects.create(
+            name="Tidal Node",
+            physical_place=self.place,
+            rank=2,
+        )
+        self.elysium = Elysium.objects.create(
+            name="Harbor Elysium",
+            physical_place=self.place,
+            prestige=3,
+        )
+        self.haunt = Haunt.objects.create(
+            name="Drowned Whispers",
+            physical_place=self.place,
+            rank=1,
+            faith_resonance="The call of the deep",
+        )
+
+    def test_get_sibling_locations(self):
+        """Test getting sibling locations at the same physical place."""
+        siblings = self.node.get_sibling_locations()
+
+        # Should include the elysium and haunt but not the node itself
+        self.assertEqual(siblings.count(), 2)
+        self.assertIn(self.elysium, siblings)
+        self.assertIn(self.haunt, siblings)
+        self.assertNotIn(self.node, siblings)
+
+    def test_get_sibling_locations_no_physical_place(self):
+        """Test sibling locations when no physical place is set."""
+        orphan = LocationModel.objects.create(name="Unplaced Location")
+        siblings = orphan.get_sibling_locations()
+        self.assertEqual(siblings.count(), 0)
+
+    def test_get_sibling_locations_single_location(self):
+        """Test sibling locations when only one location at a place."""
+        solo_place = PhysicalPlace.objects.create(name="Solo Place")
+        solo_location = Node.objects.create(
+            name="Solo Node",
+            physical_place=solo_place,
+            rank=1,
+        )
+        siblings = solo_location.get_sibling_locations()
+        self.assertEqual(siblings.count(), 0)
+
+
+class TestPhysicalPlaceUrls(TestCase):
+    """Tests for PhysicalPlace URL methods."""
+
+    def setUp(self):
+        self.place = PhysicalPlace.objects.create(name="Test Place")
+
+    def test_get_absolute_url(self):
+        """Test get_absolute_url method."""
+        url = self.place.get_absolute_url()
+        self.assertEqual(url, f"/locations/physical-place/{self.place.id}/")
+
+    def test_get_update_url(self):
+        """Test get_update_url method."""
+        url = self.place.get_update_url()
+        self.assertEqual(url, f"/locations/update/physical-place/{self.place.id}/")
+
+    def test_get_creation_url(self):
+        """Test get_creation_url class method."""
+        url = PhysicalPlace.get_creation_url()
+        self.assertEqual(url, "/locations/create/physical-place/")

--- a/locations/urls/core/create.py
+++ b/locations/urls/core/create.py
@@ -13,4 +13,9 @@ urls = [
         views.core.CityCreateView.as_view(),
         name="city",
     ),
+    path(
+        "physical-place/",
+        views.core.PhysicalPlaceCreateView.as_view(),
+        name="physical_place",
+    ),
 ]

--- a/locations/urls/core/detail.py
+++ b/locations/urls/core/detail.py
@@ -4,5 +4,10 @@ from locations import views
 app_name = "locations:detail"
 urls = [
     path("city/<pk>/", views.core.CityDetailView.as_view(), name="city"),
+    path(
+        "physical-place/<pk>/",
+        views.core.PhysicalPlaceDetailView.as_view(),
+        name="physical_place",
+    ),
     path("<pk>/", views.core.GenericLocationDetailView.as_view(), name="location"),
 ]

--- a/locations/urls/core/index.py
+++ b/locations/urls/core/index.py
@@ -4,4 +4,5 @@ from locations import views
 app_name = "locations:detail"
 urls = [
     path("city/", views.core.CityListView.as_view(), name="city"),
+    path("physical-place/", views.core.PhysicalPlaceListView.as_view(), name="physical_place"),
 ]

--- a/locations/urls/core/update.py
+++ b/locations/urls/core/update.py
@@ -13,4 +13,9 @@ urls = [
         views.core.CityUpdateView.as_view(),
         name="city",
     ),
+    path(
+        "physical-place/<pk>/",
+        views.core.PhysicalPlaceUpdateView.as_view(),
+        name="physical_place",
+    ),
 ]

--- a/locations/views/core/__init__.py
+++ b/locations/views/core/__init__.py
@@ -62,6 +62,12 @@ from locations.views import mage, werewolf
 
 from .city import CityCreateView, CityDetailView, CityListView, CityUpdateView
 from .location import LocationCreateView, LocationDetailView, LocationUpdateView
+from .physical_place import (
+    PhysicalPlaceCreateView,
+    PhysicalPlaceDetailView,
+    PhysicalPlaceListView,
+    PhysicalPlaceUpdateView,
+)
 
 
 class GenericLocationDetailView(DictView):

--- a/locations/views/core/location.py
+++ b/locations/views/core/location.py
@@ -16,6 +16,7 @@ class LocationCreateView(LoginRequiredMixin, CreateView):
     fields = [
         "name",
         "parent",
+        "physical_place",
         "gauntlet",
         "shroud",
         "dimension_barrier",
@@ -44,6 +45,7 @@ class LocationUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     fields = [
         "name",
         "parent",
+        "physical_place",
         "gauntlet",
         "shroud",
         "dimension_barrier",

--- a/locations/views/core/physical_place.py
+++ b/locations/views/core/physical_place.py
@@ -1,0 +1,123 @@
+from django.conf import settings
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+from locations.models import PhysicalPlace
+
+
+class PhysicalPlaceDetailView(LoginRequiredMixin, DetailView):
+    """Detail view showing a physical place and all its supernatural locations."""
+
+    model = PhysicalPlace
+    template_name = "locations/core/physical_place/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Get supernatural locations grouped by gameline
+        by_gameline = self.object.get_supernatural_locations_by_gameline()
+
+        # Add gameline display names
+        gameline_locations = []
+        for gameline_code, locations in by_gameline.items():
+            gameline_name = settings.GAMELINES.get(gameline_code, {}).get(
+                "name", gameline_code.upper()
+            )
+            gameline_locations.append({
+                "code": gameline_code,
+                "name": gameline_name,
+                "locations": locations,
+            })
+
+        # Sort by gameline name
+        gameline_locations.sort(key=lambda x: x["name"])
+
+        context["gameline_locations"] = gameline_locations
+        context["total_locations"] = self.object.get_supernatural_locations().count()
+        return context
+
+
+class PhysicalPlaceListView(LoginRequiredMixin, ListView):
+    """List view for all physical places."""
+
+    model = PhysicalPlace
+    template_name = "locations/core/physical_place/list.html"
+    context_object_name = "physical_places"
+    paginate_by = 25
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        # Filter by chronicle if user has one selected
+        # and filter by visibility
+        return queryset.filter(display=True).prefetch_related("locations")
+
+
+class PhysicalPlaceCreateView(LoginRequiredMixin, CreateView):
+    """Create view for physical places."""
+
+    model = PhysicalPlace
+    template_name = "locations/core/physical_place/form.html"
+    fields = [
+        "name",
+        "description",
+        "address",
+        "city",
+        "state",
+        "country",
+        "postal_code",
+        "latitude",
+        "longitude",
+        "place_type",
+    ]
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["name"].widget.attrs.update({"placeholder": "Enter name"})
+        form.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description", "rows": 4}
+        )
+        form.fields["address"].widget.attrs.update({"placeholder": "Street address"})
+        form.fields["city"].widget.attrs.update({"placeholder": "City"})
+        form.fields["state"].widget.attrs.update({"placeholder": "State/Province"})
+        form.fields["country"].widget.attrs.update({"placeholder": "Country"})
+        form.fields["postal_code"].widget.attrs.update({"placeholder": "Postal code"})
+        form.fields["latitude"].widget.attrs.update({"placeholder": "e.g., 47.6097"})
+        form.fields["longitude"].widget.attrs.update({"placeholder": "e.g., -122.3331"})
+        return form
+
+    def form_valid(self, form):
+        form.instance.owner = self.request.user
+        return super().form_valid(form)
+
+
+class PhysicalPlaceUpdateView(LoginRequiredMixin, UpdateView):
+    """Update view for physical places."""
+
+    model = PhysicalPlace
+    template_name = "locations/core/physical_place/form.html"
+    fields = [
+        "name",
+        "description",
+        "address",
+        "city",
+        "state",
+        "country",
+        "postal_code",
+        "latitude",
+        "longitude",
+        "place_type",
+        "display",
+    ]
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["name"].widget.attrs.update({"placeholder": "Enter name"})
+        form.fields["description"].widget.attrs.update(
+            {"placeholder": "Enter description", "rows": 4}
+        )
+        form.fields["address"].widget.attrs.update({"placeholder": "Street address"})
+        form.fields["city"].widget.attrs.update({"placeholder": "City"})
+        form.fields["state"].widget.attrs.update({"placeholder": "State/Province"})
+        form.fields["country"].widget.attrs.update({"placeholder": "Country"})
+        form.fields["postal_code"].widget.attrs.update({"placeholder": "Postal code"})
+        form.fields["latitude"].widget.attrs.update({"placeholder": "e.g., 47.6097"})
+        form.fields["longitude"].widget.attrs.update({"placeholder": "e.g., -122.3331"})
+        return form


### PR DESCRIPTION
## Summary
- Creates new `PhysicalPlace` model to represent mundane real-world locations (addresses, coordinates, place types)
- Adds `physical_place` ForeignKey to `LocationModel` enabling multiple supernatural locations to reference the same physical space
- Implements `get_sibling_locations()` method to find other supernatural locations at the same physical place
- Creates complete CRUD views and templates for PhysicalPlace management
- Shows linked supernatural locations grouped by gameline on PhysicalPlace detail pages
- Displays sibling locations on existing location detail pages when linked to a physical place

## Test plan
- [x] Run PhysicalPlace model tests: `python manage.py test locations.tests.models.core.test_physical_place`
- [x] Run all core location tests: `python manage.py test locations.tests.models.core`
- [x] Verify URL patterns resolve correctly
- [x] Verify view imports work correctly

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)