### PR TITLE
Fix core infrastructure test failures

### DIFF
--- a/core/decorators.py
+++ b/core/decorators.py
@@ -33,9 +33,9 @@ def require_permission(permission: Permission, lookup="pk", raise_404=True):
             obj_id = kwargs.get(lookup)
 
             # Try to get model class from view's attributes or module
-            # This is a simplified approach - in practice you might want
-            # to pass the model class as a parameter
-            model_class = getattr(view_func, "model", None)
+            # Check both the wrapper (for when .model is set after decoration)
+            # and the original view_func
+            model_class = getattr(wrapper, "model", None) or getattr(view_func, "model", None)
 
             if model_class is None:
                 # Try to infer from URL pattern or raise error

--- a/core/tests/test_cache.py
+++ b/core/tests/test_cache.py
@@ -125,7 +125,8 @@ class CacheInvalidatorTest(TestCase):
         cache.set("tg:queryset:FakeModel:status=App", "value1")
         cache.set("tg:queryset:FakeModel:status=Un", "value2")
 
-        with patch.object(cache, "delete_pattern") as mock_delete_pattern:
+        # Use create=True to allow patching non-existent attribute
+        with patch.object(cache, "delete_pattern", create=True) as mock_delete_pattern:
             CacheInvalidator.invalidate_model_cache(FakeModel)
             mock_delete_pattern.assert_called_once_with("tg:queryset:FakeModel:*")
 
@@ -140,8 +141,8 @@ class CacheInvalidatorTest(TestCase):
         cache_key = CacheKeyGenerator.make_model_key(FakeModel)
         cache.set(cache_key, "test_value")
 
-        # Mock delete_pattern to raise AttributeError
-        with patch.object(cache, "delete_pattern", side_effect=AttributeError):
+        # Mock delete_pattern to raise AttributeError (create=True for non-existent attribute)
+        with patch.object(cache, "delete_pattern", side_effect=AttributeError, create=True):
             with patch.object(cache, "delete") as mock_delete:
                 CacheInvalidator.invalidate_model_cache(FakeModel)
                 mock_delete.assert_called_once_with(cache_key)


### PR DESCRIPTION
fixes #1267

- Cache tests: Add create=True to patch.object calls for delete_pattern since LocMemCache backend doesn't have this method
- Decorator tests: Check wrapper.model in addition to view_func.model to support setting .model attribute after decoration