### PR TITLE
Fix accounts test failure for XP spend request notifications

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -228,7 +228,7 @@ class Profile(models.Model):
         return reverse("profile", kwargs={"pk": self.pk})
 
     def get_updated_journals(self):
-        return Journal.objects.filter(journalentry__st_message="").distinct()
+        return Journal.objects.filter(entries__st_message="").distinct()
 
     def get_unfulfilled_weekly_xp_requests(self):
         """Get character/week pairs that need XP requests created.
@@ -305,5 +305,5 @@ class Profile(models.Model):
 
     def unread_scenes(self):
         return Scene.objects.filter(
-            userscenereadstatus__user=self.user, userscenereadstatus__read=False
+            user_read_statuses__user=self.user, user_read_statuses__read=False
         ).distinct()

--- a/accounts/tests/context_processors/test_context_processors.py
+++ b/accounts/tests/context_processors/test_context_processors.py
@@ -318,8 +318,10 @@ class TestNotificationCountContextProcessor(TestCase):
         )
         XPSpendingRequest.objects.create(
             character=char,
-            trait="strength",
-            xp_cost=5,
+            trait_name="Strength",
+            trait_type="attribute",
+            trait_value=3,
+            cost=5,
             approved="Pending",
         )
         request = self.factory.get("/")

--- a/core/models.py
+++ b/core/models.py
@@ -1003,6 +1003,11 @@ class BasePracticeRating(models.Model):
         "characters.Practice",
         on_delete=models.SET_NULL,
         null=True,
+    )
+
+    class Meta:
+        abstract = True
+
 
 class BaseResonanceRating(models.Model):
     """


### PR DESCRIPTION
This commit fixes three issues that were causing the test_st_sees_xp_spend_requests test to fail:

1. Fixed syntax error in core/models.py where BasePracticeRating class was missing closing parenthesis and Meta class (lost during a merge)

2. Fixed Profile.unread_scenes() to use correct related_name 'user_read_statuses' instead of 'userscenereadstatus'

3. Fixed Profile.get_updated_journals() to use correct related_name 'entries' instead of 'journalentry'

4. Updated test to use correct XPSpendingRequest field names:
   - trait → trait_name
   - xp_cost → cost
   - Added required fields: trait_type, trait_value

Fixes #1268