### PR TITLE
Fix Werewolf/Fera character test failures by adding blank=True to cho…

### DIFF
--- a/characters/models/werewolf/ajaba.py
+++ b/characters/models/werewolf/ajaba.py
@@ -29,7 +29,7 @@ class Ajaba(Fera):
         ("full_moon", "Full Moon"),  # Warriors
     ]
 
-    auspice = models.CharField(default="", max_length=100, choices=AUSPICES)
+    auspice = models.CharField(default="", max_length=100, choices=AUSPICES, blank=True)
 
     # Ajaba renown
     ferocity = models.IntegerField(default=0)  # Savage strength

--- a/characters/models/werewolf/ananasi.py
+++ b/characters/models/werewolf/ananasi.py
@@ -27,7 +27,7 @@ class Ananasi(Fera):
         ("hatar", "Hatar"),  # Web-weavers and mystics
     ]
 
-    aspect = models.CharField(default="", max_length=100, choices=ASPECTS)
+    aspect = models.CharField(default="", max_length=100, choices=ASPECTS, blank=True)
 
     # Ananasi renown
     cunning = models.IntegerField(default=0)  # Cleverness and deceit

--- a/characters/models/werewolf/bastet.py
+++ b/characters/models/werewolf/bastet.py
@@ -40,8 +40,8 @@ class Bastet(Fera):
         ("midnight", "Midnight"),  # Mystics and seers
     ]
 
-    tribe = models.CharField(default="", max_length=100, choices=TRIBES)
-    pryio = models.CharField(default="", max_length=100, choices=PRYIO)
+    tribe = models.CharField(default="", max_length=100, choices=TRIBES, blank=True)
+    pryio = models.CharField(default="", max_length=100, choices=PRYIO, blank=True)
 
     # Bastet use a simplified renown system
     ferocity = models.IntegerField(default=0)  # Like Glory

--- a/characters/models/werewolf/drone.py
+++ b/characters/models/werewolf/drone.py
@@ -14,8 +14,8 @@ class Drone(WtAHuman):
     type = "drone"
 
     # Bane name/type
-    bane_name = models.CharField(default="", max_length=100)
-    bane_type = models.CharField(default="", max_length=100)
+    bane_name = models.CharField(default="", max_length=100, blank=True)
+    bane_type = models.CharField(default="", max_length=100, blank=True)
 
     # Spiritual stats
     rage = models.IntegerField(default=0)

--- a/characters/models/werewolf/grondr.py
+++ b/characters/models/werewolf/grondr.py
@@ -29,7 +29,7 @@ class Grondr(Fera):
         ("winter", "Winter"),  # Mystics and seers
     ]
 
-    auspice = models.CharField(default="", max_length=100, choices=AUSPICES)
+    auspice = models.CharField(default="", max_length=100, choices=AUSPICES, blank=True)
 
     # Grondr renown
     glory = models.IntegerField(default=0)  # Martial prowess

--- a/characters/models/werewolf/gurahl.py
+++ b/characters/models/werewolf/gurahl.py
@@ -28,7 +28,7 @@ class Gurahl(Fera):
         ("kieh", "Kieh"),  # Spring - Healers
     ]
 
-    auspice = models.CharField(default="", max_length=100, choices=AUSPICES)
+    auspice = models.CharField(default="", max_length=100, choices=AUSPICES, blank=True)
 
     # Gurahl renown
     honor = models.IntegerField(default=0)

--- a/characters/models/werewolf/kitsune.py
+++ b/characters/models/werewolf/kitsune.py
@@ -27,7 +27,7 @@ class Kitsune(Fera):
         ("gukutsushi", "Gukutsushi"),  # Trickster puppeteers
     ]
 
-    path = models.CharField(default="", max_length=100, choices=PATHS)
+    path = models.CharField(default="", max_length=100, choices=PATHS, blank=True)
 
     # Kitsune renown (Japanese-themed)
     chie = models.IntegerField(default=0)  # Wisdom

--- a/characters/models/werewolf/mokole.py
+++ b/characters/models/werewolf/mokole.py
@@ -40,8 +40,8 @@ class Mokole(Fera):
         ("solar_eclipse", "Solar Eclipse"),  # Rare - Chosen
     ]
 
-    stream = models.CharField(default="", max_length=100, choices=STREAMS)
-    auspice = models.CharField(default="", max_length=100, choices=AUSPICES)
+    stream = models.CharField(default="", max_length=100, choices=STREAMS, blank=True)
+    auspice = models.CharField(default="", max_length=100, choices=AUSPICES, blank=True)
 
     # Mokole renown
     valor = models.IntegerField(default=0)  # Courage

--- a/characters/models/werewolf/nagah.py
+++ b/characters/models/werewolf/nagah.py
@@ -28,7 +28,7 @@ class Nagah(Fera):
         ("kali", "Kali"),  # Assassins
     ]
 
-    auspice = models.CharField(default="", max_length=100, choices=AUSPICES)
+    auspice = models.CharField(default="", max_length=100, choices=AUSPICES, blank=True)
 
     # Nagah renown
     obligation = models.IntegerField(default=0)  # Duty to Gaia

--- a/characters/models/werewolf/ratkin.py
+++ b/characters/models/werewolf/ratkin.py
@@ -32,7 +32,7 @@ class Ratkin(Fera):
         ("twitchers", "Twitchers"),  # Psychics
     ]
 
-    aspect = models.CharField(default="", max_length=100, choices=ASPECTS)
+    aspect = models.CharField(default="", max_length=100, choices=ASPECTS, blank=True)
 
     # Ratkin renown
     infamy = models.IntegerField(default=0)  # Like Glory

--- a/characters/models/werewolf/rokea.py
+++ b/characters/models/werewolf/rokea.py
@@ -25,7 +25,7 @@ class Rokea(Fera):
         ("darkwater", "Darkwater"),  # Born at night - mystics
     ]
 
-    auspice = models.CharField(default="", max_length=100, choices=AUSPICES)
+    auspice = models.CharField(default="", max_length=100, choices=AUSPICES, blank=True)
 
     # Rokea renown
     valor = models.IntegerField(default=0)  # Courage and ferocity

--- a/core/models.py
+++ b/core/models.py
@@ -1003,6 +1003,11 @@ class BasePracticeRating(models.Model):
         "characters.Practice",
         on_delete=models.SET_NULL,
         null=True,
+    )
+
+    class Meta:
+        abstract = True
+
 
 class BaseResonanceRating(models.Model):
     """


### PR DESCRIPTION
…ice fields

Added blank=True to CharField fields with choices in Fera models to allow empty string defaults without triggering validation errors. This matches the pattern used by the Garou model.

Models fixed:
- Ajaba: auspice
- Mokole: stream, auspice
- Nagah: auspice
- Gurahl: auspice
- Rokea: auspice
- Grondr: auspice
- Ananasi: aspect
- Ratkin: aspect
- Bastet: tribe, pryio
- Kitsune: path
- Drone: bane_name, bane_type

Also fixed syntax error in core/models.py where BasePracticeRating was missing a closing parenthesis and Meta class.

Fixes #1270