### PR TITLE
Fix Wraith views missing get_object() method

### DIFF
--- a/characters/views/wraith/wraith_chargen.py
+++ b/characters/views/wraith/wraith_chargen.py
@@ -181,6 +181,12 @@ class WraithPassionsView(EditPermissionMixin, FormView):
     form_class = PassionForm
     template_name = "characters/wraith/wraith/chargen.html"
 
+    def get_object(self):
+        """Return the Wraith object for permission checking."""
+        if not hasattr(self, "object") or self.object is None:
+            self.object = get_object_or_404(Wraith, pk=self.kwargs.get("pk"))
+        return self.object
+
     def dispatch(self, request, *args, **kwargs):
         obj = get_object_or_404(Wraith, pk=kwargs.get("pk"))
         # If they already have the right number of passion points, skip this
@@ -253,6 +259,12 @@ class WraithPassionsView(EditPermissionMixin, FormView):
 class WraithFettersView(EditPermissionMixin, FormView):
     form_class = FetterForm
     template_name = "characters/wraith/wraith/chargen.html"
+
+    def get_object(self):
+        """Return the Wraith object for permission checking."""
+        if not hasattr(self, "object") or self.object is None:
+            self.object = get_object_or_404(Wraith, pk=self.kwargs.get("pk"))
+        return self.object
 
     def dispatch(self, request, *args, **kwargs):
         obj = get_object_or_404(Wraith, pk=kwargs.get("pk"))
@@ -455,6 +467,12 @@ class WraithLanguagesView(EditPermissionMixin, FormView):
     form_class = HumanLanguageForm
     template_name = "characters/wraith/wraith/chargen.html"
 
+    def get_object(self):
+        """Return the Human object for permission checking."""
+        if not hasattr(self, "object") or self.object is None:
+            self.object = get_object_or_404(Human, pk=self.kwargs.get("pk"))
+        return self.object
+
     def dispatch(self, request, *args, **kwargs):
         obj = get_object_or_404(Human, pk=kwargs.get("pk"))
         if "Language" not in obj.merits_and_flaws.values_list("name", flat=True):
@@ -522,9 +540,15 @@ class WraithSpecialtiesView(EditPermissionMixin, FormView):
     form_class = SpecialtiesForm
     template_name = "characters/wraith/wraith/chargen.html"
 
+    def get_object(self):
+        """Return the Wraith object for permission checking."""
+        if not hasattr(self, "object") or self.object is None:
+            self.object = Wraith.objects.get(id=self.kwargs["pk"])
+        return self.object
+
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["object"] = Wraith.objects.get(id=self.kwargs["pk"])
+        context["object"] = self.get_object()
         context["is_approved_user"] = self.check_if_special_user(
             context["object"], self.request.user
         )

--- a/characters/views/wraith/wtohuman.py
+++ b/characters/views/wraith/wtohuman.py
@@ -392,6 +392,12 @@ class WtOHumanLanguagesView(EditPermissionMixin, FormView):
     form_class = HumanLanguageForm
     template_name = "characters/wraith/wtohuman/chargen.html"
 
+    def get_object(self):
+        """Return the Human object for permission checking."""
+        if not hasattr(self, "object") or self.object is None:
+            self.object = get_object_or_404(Human, pk=self.kwargs.get("pk"))
+        return self.object
+
     def dispatch(self, request, *args, **kwargs):
         obj = get_object_or_404(Human, pk=kwargs.get("pk"))
         if "Language" not in obj.merits_and_flaws.values_list("name", flat=True):
@@ -448,9 +454,15 @@ class WtOHumanSpecialtiesView(EditPermissionMixin, FormView):
     form_class = SpecialtiesForm
     template_name = "characters/wraith/wtohuman/chargen.html"
 
+    def get_object(self):
+        """Return the WtOHuman object for permission checking."""
+        if not hasattr(self, "object") or self.object is None:
+            self.object = WtOHuman.objects.get(id=self.kwargs["pk"])
+        return self.object
+
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
-        context["object"] = WtOHuman.objects.get(id=self.kwargs["pk"])
+        context["object"] = self.get_object()
         context["is_approved_user"] = self.check_if_special_user(
             context["object"], self.request.user
         )


### PR DESCRIPTION
Added get_object() method to 6 FormView-based views that use EditPermissionMixin. The mixin's has_permission() method requires get_object() to check permissions, but FormView doesn't provide this method like UpdateView or DetailView do.

Fixed views:
- WraithPassionsView
- WraithFettersView
- WraithLanguagesView
- WraithSpecialtiesView
- WtOHumanLanguagesView
- WtOHumanSpecialtiesView

Fixes #1277