### PR TITLE
Fix wraith items URL configuration and add missing get_absolute_url m…

### DIFF
--- a/items/models/wraith/artifact.py
+++ b/items/models/wraith/artifact.py
@@ -40,6 +40,9 @@ class WraithArtifact(ItemModel):
         verbose_name = "Artifact"
         verbose_name_plural = "Artifacts"
 
+    def get_absolute_url(self):
+        return reverse("items:wraith:artifact", kwargs={"pk": self.pk})
+
     def get_update_url(self):
         return reverse("items:wraith:update:artifact", args=[str(self.id)])
 

--- a/items/models/wraith/relic.py
+++ b/items/models/wraith/relic.py
@@ -27,6 +27,9 @@ class WraithRelic(ItemModel):
         verbose_name = "Relic"
         verbose_name_plural = "Relics"
 
+    def get_absolute_url(self):
+        return reverse("items:wraith:relic", kwargs={"pk": self.pk})
+
     def get_update_url(self):
         return reverse("items:wraith:update:relic", args=[str(self.id)])
 

--- a/items/urls/wraith/__init__.py
+++ b/items/urls/wraith/__init__.py
@@ -2,10 +2,9 @@ from django.urls import include, path
 
 from . import create, detail, index, update
 
-app_name = "wraith"
-urlpatterns = [
-    path("", include((index.urls, index.app_name))),
-    path("detail/", include((detail.urls, detail.app_name))),
-    path("create/", include((create.urls, create.app_name))),
-    path("update/", include((update.urls, update.app_name))),
+urls = [
+    path("create/", include((create.urls, "wraith_create"), namespace="create")),
+    path("update/", include((update.urls, "wraith_update"), namespace="update")),
+    path("list/", include((index.urls, "wraith_list"), namespace="list")),
+    path("", include(detail.urls)),
 ]


### PR DESCRIPTION
…ethods

The wraith items module had two issues causing 14 test failures:

1. items/urls/wraith/__init__.py used `urlpatterns` instead of `urls`, causing it to be silently skipped by the main URL config which looks for `gameline_module.urls` attribute

2. WraithArtifact and WraithRelic models were missing `get_absolute_url()` methods, causing NoReverseMatch errors when tests called this method

Changes:
- Renamed `urlpatterns` to `urls` in items/urls/wraith/__init__.py
- Aligned URL structure with other gamelines (vampire, mage, demon)
- Added `get_absolute_url()` to WraithArtifact returning items:wraith:artifact
- Added `get_absolute_url()` to WraithRelic returning items:wraith:relic

Fixes #1280