### PR TITLE
Fix 19 Mummy items test failures

### DIFF
--- a/items/models/mummy/relic.py
+++ b/items/models/mummy/relic.py
@@ -169,9 +169,8 @@ class MummyRelic(ItemModel):
         return True
 
     def save(self, *args, **kwargs):
-        """Auto-set background_cost to rank if not specified"""
-        if not self.background_cost:
-            self.background_cost = self.rank
+        """Auto-set background_cost to rank"""
+        self.background_cost = self.rank
         super().save(*args, **kwargs)
 
     # ========================================

--- a/items/tests/models/mummy/test_relic.py
+++ b/items/tests/models/mummy/test_relic.py
@@ -1,4 +1,5 @@
 """Tests for MummyRelic model."""
+from django.contrib.auth.models import User
 from django.test import TestCase
 from items.models.mummy.relic import MummyRelic, RelicResonanceRating
 
@@ -108,16 +109,19 @@ class TestMummyRelicDetailView(TestCase):
     """Test MummyRelic detail view."""
 
     def setUp(self):
-        self.relic = MummyRelic.objects.create(name="Test Relic")
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.relic = MummyRelic.objects.create(name="Test Relic", owner=self.user)
         self.url = self.relic.get_absolute_url()
 
     def test_detail_view_status_code(self):
         """Test detail view returns 200."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_detail_view_template(self):
         """Test detail view uses correct template."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/relic/detail.html")
 
@@ -126,15 +130,18 @@ class TestMummyRelicCreateView(TestCase):
     """Test MummyRelic create view."""
 
     def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="testpass")
         self.url = MummyRelic.get_creation_url()
 
     def test_create_view_status_code(self):
         """Test create view returns 200."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_create_view_template(self):
         """Test create view uses correct template."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/relic/form.html")
 
@@ -143,16 +150,21 @@ class TestMummyRelicUpdateView(TestCase):
     """Test MummyRelic update view."""
 
     def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="admin", password="adminpass", email="admin@test.com"
+        )
         self.relic = MummyRelic.objects.create(name="Test Relic", description="Test")
         self.url = self.relic.get_update_url()
 
     def test_update_view_status_code(self):
         """Test update view returns 200."""
+        self.client.login(username="admin", password="adminpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_update_view_template(self):
         """Test update view uses correct template."""
+        self.client.login(username="admin", password="adminpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/relic/form.html")
 

--- a/items/tests/models/mummy/test_ushabti.py
+++ b/items/tests/models/mummy/test_ushabti.py
@@ -1,4 +1,5 @@
 """Tests for Ushabti model."""
+from django.contrib.auth.models import User
 from django.test import TestCase
 from items.models.mummy.ushabti import Ushabti
 
@@ -122,16 +123,19 @@ class TestUshabtiDetailView(TestCase):
     """Test Ushabti detail view."""
 
     def setUp(self):
-        self.ushabti = Ushabti.objects.create(name="Test Ushabti")
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.ushabti = Ushabti.objects.create(name="Test Ushabti", owner=self.user)
         self.url = self.ushabti.get_absolute_url()
 
     def test_detail_view_status_code(self):
         """Test detail view returns 200."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_detail_view_template(self):
         """Test detail view uses correct template."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/ushabti/detail.html")
 
@@ -140,15 +144,18 @@ class TestUshabtiCreateView(TestCase):
     """Test Ushabti create view."""
 
     def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="testpass")
         self.url = Ushabti.get_creation_url()
 
     def test_create_view_status_code(self):
         """Test create view returns 200."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_create_view_template(self):
         """Test create view uses correct template."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/ushabti/form.html")
 
@@ -157,16 +164,21 @@ class TestUshabtiUpdateView(TestCase):
     """Test Ushabti update view."""
 
     def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="admin", password="adminpass", email="admin@test.com"
+        )
         self.ushabti = Ushabti.objects.create(name="Test Ushabti", description="Test")
         self.url = self.ushabti.get_update_url()
 
     def test_update_view_status_code(self):
         """Test update view returns 200."""
+        self.client.login(username="admin", password="adminpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_update_view_template(self):
         """Test update view uses correct template."""
+        self.client.login(username="admin", password="adminpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/ushabti/form.html")
 

--- a/items/tests/models/mummy/test_vessel.py
+++ b/items/tests/models/mummy/test_vessel.py
@@ -1,4 +1,5 @@
 """Tests for Vessel model."""
+from django.contrib.auth.models import User
 from django.test import TestCase
 from items.models.mummy.vessel import Vessel
 
@@ -191,16 +192,19 @@ class TestVesselDetailView(TestCase):
     """Test Vessel detail view."""
 
     def setUp(self):
-        self.vessel = Vessel.objects.create(name="Test Vessel")
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.vessel = Vessel.objects.create(name="Test Vessel", owner=self.user)
         self.url = self.vessel.get_absolute_url()
 
     def test_detail_view_status_code(self):
         """Test detail view returns 200."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_detail_view_template(self):
         """Test detail view uses correct template."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/vessel/detail.html")
 
@@ -209,15 +213,18 @@ class TestVesselCreateView(TestCase):
     """Test Vessel create view."""
 
     def setUp(self):
+        self.user = User.objects.create_user(username="testuser", password="testpass")
         self.url = Vessel.get_creation_url()
 
     def test_create_view_status_code(self):
         """Test create view returns 200."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_create_view_template(self):
         """Test create view uses correct template."""
+        self.client.login(username="testuser", password="testpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/vessel/form.html")
 
@@ -226,16 +233,21 @@ class TestVesselUpdateView(TestCase):
     """Test Vessel update view."""
 
     def setUp(self):
+        self.user = User.objects.create_superuser(
+            username="admin", password="adminpass", email="admin@test.com"
+        )
         self.vessel = Vessel.objects.create(name="Test Vessel", description="Test")
         self.url = self.vessel.get_update_url()
 
     def test_update_view_status_code(self):
         """Test update view returns 200."""
+        self.client.login(username="admin", password="adminpass")
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
     def test_update_view_template(self):
         """Test update view uses correct template."""
+        self.client.login(username="admin", password="adminpass")
         response = self.client.get(self.url)
         self.assertTemplateUsed(response, "items/mummy/vessel/form.html")
 


### PR DESCRIPTION
- Fix MummyRelic.save() to always set background_cost = rank (previously, the condition `if not self.background_cost` was never true because background_cost defaults to 1)
- Add proper authentication to view tests for MummyRelic, Ushabti, and Vessel:
  - Detail views now create a user and set owner for VIEW_FULL permission
  - Create views now log in the user (LoginRequiredMixin)
  - Update views now use a superuser for EDIT_FULL permission

Fixes #1281