### PR TITLE
Add list view URL routes for Hunter locations

### DIFF
--- a/locations/urls/hunter/detail.py
+++ b/locations/urls/hunter/detail.py
@@ -4,9 +4,19 @@ from locations import views
 app_name = "hunter:detail"
 urls = [
     path(
+        "safehouse/",
+        views.hunter.SafehouseListView.as_view(),
+        name="safehouse-list",
+    ),
+    path(
         "safehouse/<pk>/",
         views.hunter.SafehouseDetailView.as_view(),
         name="safehouse",
+    ),
+    path(
+        "hunting-ground/",
+        views.hunter.HuntingGroundListView.as_view(),
+        name="hunting-ground-list",
     ),
     path(
         "hunting-ground/<pk>/",


### PR DESCRIPTION
Add direct URL routes for Safehouse and HuntingGround list views to hunter/detail.py so they're accessible without the /list/ prefix.

This fixes the test_safehouse_list_view test that expects /locations/hunter/safehouse/ to return the list view.

Fixes #1285