### PR TITLE
Fix 18 Vampire character test failures (#1276)

### DIFF
--- a/characters/models/vampire/ghoul.py
+++ b/characters/models/vampire/ghoul.py
@@ -53,6 +53,11 @@ class Ghoul(VtMHuman):
     # Years as ghoul (affects aging)
     years_as_ghoul = models.IntegerField(default=0)
 
+    # Virtues (ghouls have standard mortal virtues)
+    conscience = models.IntegerField(default=1)
+    self_control = models.IntegerField(default=1)
+    courage = models.IntegerField(default=1)
+
     class Meta:
         verbose_name = "Ghoul"
         verbose_name_plural = "Ghouls"

--- a/characters/views/vampire/ghoul_chargen.py
+++ b/characters/views/vampire/ghoul_chargen.py
@@ -54,8 +54,8 @@ class GhoulBasicsView(LoginRequiredMixin, FormView):
         self.object = form.save()
         # Ghouls start with Potence 1 (already set as default in model)
         # Set initial willpower to courage (default 1)
-        self.object.willpower = self.object.courage
-        self.object.save()
+        # Use set_willpower() to properly adjust temporary_willpower and avoid constraint violations
+        self.object.set_willpower(self.object.courage)
         return super().form_valid(form)
 
     def get_success_url(self):


### PR DESCRIPTION
- Add virtue fields (conscience, self_control, courage) to Ghoul model Ghouls are mortals with vampire blood and have standard virtues in VtM

- Fix willpower constraint violations in chargen views Use set_willpower() method instead of direct assignment to properly adjust temporary_willpower and avoid the database constraint violation (temporary_willpower cannot exceed permanent willpower)

This resolves:
1. AttributeError: Ghoul has no 'courage' attribute
2. ValidationError: Willpower constraint violations during character creation

Note: Run `python manage.py makemigrations` to create migration for Ghoul virtues

Fixes #1276 