### PR TITLE
Fix incomplete view_mapping in HumanCharacterCreationView

### DIFF
--- a/characters/views/core/human.py
+++ b/characters/views/core/human.py
@@ -8,6 +8,7 @@ from characters.models.core.attribute_block import Attribute
 from characters.models.core.background_block import Background, BackgroundRating
 from characters.models.core.merit_flaw_block import MeritFlaw
 from characters.models.core.specialty import Specialty
+from characters.views.core.backgrounds import HumanBackgroundsView
 from characters.views.core.character import CharacterDetailView
 from core.forms.language import HumanLanguageForm
 from core.mixins import (
@@ -545,7 +546,15 @@ class HumanSpecialtiesView(SpendFreebiesPermissionMixin, FormView):
 
 
 class HumanCharacterCreationView(DictView):
-    view_mapping = {1: HumanAttributeView, 2: HumanBiographicalInformation}
+    view_mapping = {
+        1: HumanAttributeView,
+        2: HumanAbilityView,
+        3: HumanBackgroundsView,
+        4: HumanBiographicalInformation,
+        5: HumanFreebiesView,
+        6: HumanLanguagesView,
+        7: HumanSpecialtiesView,
+    }
     model_class = Human
     key_property = "creation_status"
     default_redirect = HumanDetailView


### PR DESCRIPTION
The HumanCharacterCreationView.view_mapping was missing steps 3-7 of the character creation process, causing tests to fail with KeyError: 'form' when accessing the backgrounds view (creation_status=3).

Added the complete character creation workflow:
- Step 1: HumanAttributeView (attributes)
- Step 2: HumanAbilityView (abilities)
- Step 3: HumanBackgroundsView (backgrounds)
- Step 4: HumanBiographicalInformation (biographical details)
- Step 5: HumanFreebiesView (freebies)
- Step 6: HumanLanguagesView (languages)
- Step 7: HumanSpecialtiesView (specialties)

This aligns with the character creation flow used in other gamelines (VtMHuman, WtOHuman, MtAHuman, etc.) which all have backgrounds at step 3.

Fixes #1278