### PR TITLE
Fix Haunt model validation by adding blank=True to faith_resonance

### DIFF
--- a/locations/models/wraith/haunt.py
+++ b/locations/models/wraith/haunt.py
@@ -38,7 +38,7 @@ class Haunt(LocationModel):
     haunt_size = models.CharField(max_length=20, choices=HAUNT_SIZE_CHOICES, default="single_room")
 
     # Faith resonance
-    faith_resonance = models.TextField(default="")
+    faith_resonance = models.TextField(default="", blank=True)
 
     # Whether ghosts are attracted
     attracts_ghosts = models.BooleanField(default=True)


### PR DESCRIPTION
## Summary
- Fixed 31 test failures in Wraith location test suite (Haunt model)
- Added `blank=True` to `faith_resonance` field to allow empty strings during validation
- Root cause: The field had `default=""` but was missing `blank=True`, causing Django validation to fail when `full_clean()` is called during save

## Test plan
- [ ] Run `python manage.py test locations.tests.models.wraith.test_haunt`
- [ ] Verify all 31 tests pass

Fixes #1283