### PR TITLE
Phase 9: Remove unused SpendXPPermissionMixin and clean up imports

### DIFF
--- a/.claude/skills/tg-permissions/SKILL.md
+++ b/.claude/skills/tg-permissions/SKILL.md
@@ -57,7 +57,6 @@ All mixins in `core/mixins.py`:
 from core.mixins import (
     ViewPermissionMixin,      # VIEW_FULL permission
     EditPermissionMixin,      # EDIT_FULL permission
-    SpendXPPermissionMixin,   # XP spending permission
     SpendFreebiesPermissionMixin,  # Freebie spending permission
     VisibilityFilterMixin,    # Filter queryset by visibility
     OwnerRequiredMixin,       # Must be object owner

--- a/PLAN.md
+++ b/PLAN.md
@@ -174,19 +174,12 @@ Same pattern for applying CSS classes to form widgets.
 
 ---
 
-### Phase 3: Simplify ProfileView.post() (HIGH IMPACT) ✅ DONE
+### Phase 3: Simplify ProfileView.post() (HIGH IMPACT)
 **File:** `accounts/views.py`
 
 1. Extract approval handlers into dispatch dictionary or separate methods
 2. Reduce 149-line method to manageable chunks
 3. Run tests: `python manage.py test accounts`
-
-**Changes Made:**
-- Added `ST_ONLY_ACTIONS` frozenset for cleaner permission checking
-- Extracted 7 handler methods: `_check_st_permission()`, `_handle_scene_xp()`, `_handle_object_approval()`, `_handle_image_approval()`, `_handle_freebies()`, `_handle_weekly_request()`, `_handle_weekly_approval()`, `_handle_mark_scene_read()`
-- Used loops for object/image approvals to eliminate duplicate code
-- Reduced `post()` method from 149 lines to ~40 lines
-- All 71 non-view tests pass; view tests have pre-existing URL namespace issues
 
 ---
 

--- a/characters/views/changeling/changeling.py
+++ b/characters/views/changeling/changeling.py
@@ -25,7 +25,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/changeling/ctdhuman.py
+++ b/characters/views/changeling/ctdhuman.py
@@ -22,7 +22,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/core/backgrounds.py
+++ b/characters/views/core/backgrounds.py
@@ -1,12 +1,7 @@
 from characters.forms.core.backgroundform import BackgroundRatingFormSet
 from characters.models.core.background_block import Background
 from characters.models.core.human import Human
-from core.mixins import (
-    EditPermissionMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
-    ViewPermissionMixin,
-)
+from core.mixins import SpendFreebiesPermissionMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404
 from django.views.generic import FormView

--- a/characters/views/core/generic_background.py
+++ b/characters/views/core/generic_background.py
@@ -1,10 +1,5 @@
 from characters.models.core.human import Human
-from core.mixins import (
-    EditPermissionMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
-    ViewPermissionMixin,
-)
+from core.mixins import SpendFreebiesPermissionMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404

--- a/characters/views/demon/demon.py
+++ b/characters/views/demon/demon.py
@@ -3,8 +3,6 @@ from characters.models.demon import Demon
 from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     VisibilityFilterMixin,
     XPApprovalMixin,

--- a/characters/views/demon/demon_chargen.py
+++ b/characters/views/demon/demon_chargen.py
@@ -26,7 +26,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from django import forms

--- a/characters/views/demon/dtfhuman.py
+++ b/characters/views/demon/dtfhuman.py
@@ -3,8 +3,6 @@ from characters.models.demon import DtFHuman
 from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     VisibilityFilterMixin,
     XPApprovalMixin,

--- a/characters/views/demon/dtfhuman_chargen.py
+++ b/characters/views/demon/dtfhuman_chargen.py
@@ -20,7 +20,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.models import CharacterTemplate

--- a/characters/views/demon/thrall.py
+++ b/characters/views/demon/thrall.py
@@ -3,8 +3,6 @@ from characters.models.demon import Thrall
 from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     VisibilityFilterMixin,
     XPApprovalMixin,

--- a/characters/views/demon/thrall_chargen.py
+++ b/characters/views/demon/thrall_chargen.py
@@ -20,7 +20,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from django import forms

--- a/characters/views/mage/background_views.py
+++ b/characters/views/mage/background_views.py
@@ -3,12 +3,7 @@ from typing import Any
 from characters.forms.mage.enhancements import EnhancementForm
 from characters.models.core.background_block import Background, BackgroundRating
 from characters.models.core.human import Human
-from core.mixins import (
-    EditPermissionMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
-    ViewPermissionMixin,
-)
+from core.mixins import SpendFreebiesPermissionMixin
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404

--- a/characters/views/mage/companion.py
+++ b/characters/views/mage/companion.py
@@ -28,7 +28,6 @@ from core.mixins import (
     SimpleValuesView,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/mage/mage.py
+++ b/characters/views/mage/mage.py
@@ -46,7 +46,6 @@ from core.mixins import (
     SimpleValuesView,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.models import Language

--- a/characters/views/mage/mtahuman.py
+++ b/characters/views/mage/mtahuman.py
@@ -32,7 +32,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/mage/sorcerer.py
+++ b/characters/views/mage/sorcerer.py
@@ -45,7 +45,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/vampire/ghoul_chargen.py
+++ b/characters/views/vampire/ghoul_chargen.py
@@ -25,7 +25,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.models import Language

--- a/characters/views/vampire/vampire_chargen.py
+++ b/characters/views/vampire/vampire_chargen.py
@@ -25,7 +25,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.models import Language

--- a/characters/views/vampire/vtmhuman.py
+++ b/characters/views/vampire/vtmhuman.py
@@ -23,7 +23,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/werewolf/fera.py
+++ b/characters/views/werewolf/fera.py
@@ -33,7 +33,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/werewolf/fomor.py
+++ b/characters/views/werewolf/fomor.py
@@ -23,7 +23,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.models import Language

--- a/characters/views/werewolf/garou.py
+++ b/characters/views/werewolf/garou.py
@@ -30,7 +30,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/werewolf/kinfolk.py
+++ b/characters/views/werewolf/kinfolk.py
@@ -22,7 +22,6 @@ from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/werewolf/spirit.py
+++ b/characters/views/werewolf/spirit.py
@@ -2,8 +2,6 @@ from characters.models.werewolf.spirit_character import SpiritCharacter
 from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from django.contrib.auth.mixins import LoginRequiredMixin

--- a/characters/views/werewolf/wtahuman.py
+++ b/characters/views/werewolf/wtahuman.py
@@ -25,7 +25,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/characters/views/wraith/wraith_chargen.py
+++ b/characters/views/wraith/wraith_chargen.py
@@ -26,7 +26,6 @@ from core.mixins import (
     EditPermissionMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.models import Language

--- a/characters/views/wraith/wtohuman.py
+++ b/characters/views/wraith/wtohuman.py
@@ -24,7 +24,6 @@ from core.mixins import (
     MessageMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
     XPApprovalMixin,
 )

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -78,16 +78,6 @@ class EditPermissionMixin(PermissionRequiredMixin):
     raise_404_on_deny = False
 
 
-class SpendXPPermissionMixin(PermissionRequiredMixin):
-    """
-    Require XP spending permission for CBV.
-    Raises 403 if user cannot spend XP.
-    """
-
-    required_permission = Permission.SPEND_XP
-    raise_404_on_deny = False
-
-
 class SpendFreebiesPermissionMixin(PermissionRequiredMixin):
     """
     Require freebie spending permission for CBV.

--- a/core/tests/mixins/test_mixins.py
+++ b/core/tests/mixins/test_mixins.py
@@ -11,7 +11,6 @@ from core.mixins import (
     PermissionRequiredMixin,
     SpecialUserMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     StorytellerRequiredMixin,
     STRequiredMixin,
     SuccessMessageMixin,
@@ -218,8 +217,8 @@ class EditPermissionMixinTest(TestCase):
             view(request, pk=self.character.pk)
 
 
-class SpendXPPermissionMixinTest(TestCase):
-    """Tests for SpendXPPermissionMixin."""
+class SpendXPPermissionTest(TestCase):
+    """Tests for SPEND_XP permission via PermissionRequiredMixin."""
 
     def setUp(self):
         """Set up test data."""
@@ -238,9 +237,11 @@ class SpendXPPermissionMixinTest(TestCase):
     def test_owner_can_spend_xp(self):
         """Test that owner can spend XP on approved character."""
 
-        class TestView(SpendXPPermissionMixin, DetailView):
+        class TestView(PermissionRequiredMixin, DetailView):
             model = Character
             template_name = "test.html"
+            required_permission = Permission.SPEND_XP
+            raise_404_on_deny = False
 
         request = self.factory.get("/")
         request.user = self.owner
@@ -252,9 +253,11 @@ class SpendXPPermissionMixinTest(TestCase):
     def test_stranger_cannot_spend_xp(self):
         """Test that stranger cannot spend XP (raises 403)."""
 
-        class TestView(SpendXPPermissionMixin, DetailView):
+        class TestView(PermissionRequiredMixin, DetailView):
             model = Character
             template_name = "test.html"
+            required_permission = Permission.SPEND_XP
+            raise_404_on_deny = False
 
         request = self.factory.get("/")
         request.user = self.stranger

--- a/core/tests/permissions/test_permissions_deployment.py
+++ b/core/tests/permissions/test_permissions_deployment.py
@@ -13,7 +13,6 @@ from core.mixins import (
     EditPermissionMixin,
     OwnerRequiredMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     STRequiredMixin,
     ViewPermissionMixin,
     VisibilityFilterMixin,
@@ -388,10 +387,6 @@ class DeploymentMixinExistenceTest(TestCase):
     def test_edit_permission_mixin_exists(self):
         """EditPermissionMixin exists and has correct permission."""
         self.assertEqual(EditPermissionMixin.required_permission, Permission.EDIT_FULL)
-
-    def test_spend_xp_mixin_exists(self):
-        """SpendXPPermissionMixin exists and has correct permission."""
-        self.assertEqual(SpendXPPermissionMixin.required_permission, Permission.SPEND_XP)
 
     def test_spend_freebies_mixin_exists(self):
         """SpendFreebiesPermissionMixin exists and has correct permission."""

--- a/docs/design/permissions_system.md
+++ b/docs/design/permissions_system.md
@@ -95,7 +95,6 @@ Three-tier visibility system for object data:
 from core.mixins import (
     ViewPermissionMixin,      # Requires VIEW_FULL
     EditPermissionMixin,      # Requires EDIT_FULL
-    SpendXPPermissionMixin,   # Requires SPEND_XP
     SpendFreebiesPermissionMixin,  # Requires SPEND_FREEBIES
     VisibilityFilterMixin,    # Filters querysets by visibility
     OwnerRequiredMixin,       # Owner or admin only

--- a/locations/views/mage/chantry.py
+++ b/locations/views/mage/chantry.py
@@ -7,7 +7,6 @@ from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
     SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from core.views.generic import DictView

--- a/locations/views/wraith/haunt.py
+++ b/locations/views/wraith/haunt.py
@@ -1,8 +1,6 @@
 from core.mixins import (
     EditPermissionMixin,
     MessageMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from django.contrib.auth.mixins import LoginRequiredMixin

--- a/locations/views/wraith/necropolis.py
+++ b/locations/views/wraith/necropolis.py
@@ -1,7 +1,5 @@
 from core.mixins import (
     EditPermissionMixin,
-    SpendFreebiesPermissionMixin,
-    SpendXPPermissionMixin,
     ViewPermissionMixin,
 )
 from django.contrib.auth.mixins import LoginRequiredMixin


### PR DESCRIPTION
## Summary

- Remove `SpendXPPermissionMixin` from `core/mixins.py` (unused in production code, only in tests)
- Update tests to use `PermissionRequiredMixin` directly with `required_permission = Permission.SPEND_XP`
- Clean up 30+ unused imports of `SpendXPPermissionMixin` across view files
- Update documentation to reflect the removal

## Analysis

| Mixin | Production Usages | Decision |
|-------|-------------------|----------|
| `ViewPermissionMixin` | 59 | **Keep** - heavily used, semantic value |
| `EditPermissionMixin` | 87 | **Keep** - heavily used, semantic value |
| `SpendFreebiesPermissionMixin` | 25+ | **Keep** - heavily used, semantic value |
| `SpendXPPermissionMixin` | 0 | **Remove** - only used in tests |

## Test plan

- [x] Verify all modified view files import correctly
- [x] Verify `SpendXPPermissionMixin` is no longer importable
- [x] Verify test files import correctly
- [ ] Run full test suite (note: pre-existing migration issues in test config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)