### PR TITLE
Remove unused code: reverse filter and trivial model methods

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -372,29 +372,11 @@ class Model(PermissionMixin, PolymorphicModel):
         self.name = name
         return True
 
-    def has_description(self):
-        return self.description != ""
-
-    def set_description(self, description):
-        self.description = description
-        return True
-
-    def has_owner(self):
-        return self.owner is not None
-
-    def set_owner(self, owner):
-        self.owner = owner
-        return True
-
     def owned_by_list(self):
         return []
 
     def update_status(self, status):
         self.status = status
-        return True
-
-    def toggle_display(self):
-        self.display = not self.display
         return True
 
     def has_source(self):

--- a/core/templatetags/reverse.py
+++ b/core/templatetags/reverse.py
@@ -1,9 +1,0 @@
-from django import template
-
-register = template.Library()
-
-
-@register.filter(name="reverse")
-def reverse(value):
-    """Reverses the given value."""
-    return value[::-1]

--- a/core/tests/views/test_home.py
+++ b/core/tests/views/test_home.py
@@ -182,37 +182,12 @@ class TestModel(TestCase):
         self.assertTrue(self.model.set_name("Test"))
         self.assertTrue(self.model.has_name())
 
-    def test_has_description(self):
-        self.assertFalse(self.model.has_description())
-        self.model.set_description("Test")
-        self.assertTrue(self.model.has_description())
-
-    def test_set_description(self):
-        self.assertFalse(self.model.has_description())
-        self.assertTrue(self.model.set_description("Test"))
-        self.assertTrue(self.model.has_description())
-
-    def test_has_owner(self):
-        self.assertFalse(self.model.has_owner())
-        self.model.set_owner(self.user)
-        self.assertTrue(self.model.has_owner())
-
-    def test_set_owner(self):
-        self.assertFalse(self.model.has_owner())
-        self.assertTrue(self.model.set_owner(self.user))
-        self.assertTrue(self.model.has_owner())
-
     def test_update_status(self):
         self.assertEqual(self.model.status, "Un")
         self.assertEqual(self.model.get_status_display(), "Unapproved")
         self.assertTrue(self.model.update_status("App"))
         self.assertEqual(self.model.status, "App")
         self.assertEqual(self.model.get_status_display(), "Approved")
-
-    def test_toggle_display(self):
-        self.assertTrue(self.model.display)
-        self.assertTrue(self.model.toggle_display())
-        self.assertFalse(self.model.display)
 
     def test_has_source(self):
         self.assertFalse(self.model.has_source())

--- a/locations/templates/locations/mage/reality_zone/display_includes/reality_zone.html
+++ b/locations/templates/locations/mage/reality_zone/display_includes/reality_zone.html
@@ -1,5 +1,4 @@
 {% load dots %}
-{% load reverse %}
 {% if object %}
     <div class="row mb-4">
         <div class="col-12">
@@ -37,7 +36,6 @@
                             <div class="table-responsive">
                                 <table class="tg-table node-table mb-0">
                                     <tbody>
-                                        {% load reverse %}
                                         {% for pr in object.get_negative_practices %}
                                             <tr>
                                                 <td>


### PR DESCRIPTION
## Summary
- Delete `core/templatetags/reverse.py` (filter was loaded but never used in templates)
- Remove `{% load reverse %}` from `reality_zone.html` template
- Delete unused trivial getters/setters from `core/models.py`: `has_description()`, `set_description()`, `has_owner()`, `set_owner()`, `toggle_display()`
- Remove corresponding tests from `test_home.py`

## Notes
The original plan suggested deleting additional items that were found to be in use:
- **Kept `lore_name` filter** - used in `lore_block.html`
- **Kept `get_item` filter** - used in `journal/list.html`
- **Kept `has_name`, `set_name`, `update_status`, `add_source`, `has_source`, `owned_by_list`** - all used in production code

## Test plan
- [x] Verified retained methods work via Django shell
- [x] Ran core and locations test suites (pre-existing URL config failures unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)