### PR TITLE
Remove permission delegation wrappers from PermissionMixin

### DIFF
--- a/.claude/skills/tg-permissions/references/implementation-guide.md
+++ b/.claude/skills/tg-permissions/references/implementation-guide.md
@@ -113,7 +113,7 @@ class PermissionManager:
 ```python
 # BAD - N+1 queries
 for character in Character.objects.all():
-    if character.user_can_view(request.user):  # Queries each time
+    if PermissionManager.user_can_view(request.user, character):  # Queries each time
         print(character.name)
 
 # GOOD - Prefetch related data
@@ -235,7 +235,7 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def visibility_tier(context, obj):
     user = context['request'].user
-    return obj.get_visibility_tier(user)
+    return PermissionManager.get_visibility_tier(user, obj)
 
 @register.filter
 def is_full(tier):

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,4 +1,4 @@
-from core.permissions import Permission, Role, VisibilityTier
+from core.permissions import Permission, PermissionManager, Role, VisibilityTier
 from game.models import Chronicle
 
 
@@ -32,10 +32,6 @@ def permissions(request):
         "VisibilityTier": VisibilityTier,
         "Permission": Permission,
         "Role": Role,
-        "user_can_view": lambda obj: (
-            obj.user_can_view(request.user) if hasattr(obj, "user_can_view") else False
-        ),
-        "user_can_edit": lambda obj: (
-            obj.user_can_edit(request.user) if hasattr(obj, "user_can_edit") else False
-        ),
+        "user_can_view": lambda obj: PermissionManager.user_can_view(request.user, obj),
+        "user_can_edit": lambda obj: PermissionManager.user_can_edit(request.user, obj),
     }

--- a/core/models.py
+++ b/core/models.py
@@ -271,42 +271,6 @@ class PermissionMixin(models.Model):
     class Meta:
         abstract = True
 
-    def get_user_roles(self, user):
-        """Get all roles user has for this object."""
-        from core.permissions import PermissionManager
-
-        return PermissionManager.get_user_roles(user, self)
-
-    def user_can_view(self, user):
-        """Check if user can view this object."""
-        from core.permissions import PermissionManager
-
-        return PermissionManager.user_can_view(user, self)
-
-    def user_can_edit(self, user):
-        """Check if user can edit this object (EDIT_FULL)."""
-        from core.permissions import PermissionManager
-
-        return PermissionManager.user_can_edit(user, self)
-
-    def user_can_spend_xp(self, user):
-        """Check if user can spend XP on this object."""
-        from core.permissions import PermissionManager
-
-        return PermissionManager.user_can_spend_xp(user, self)
-
-    def user_can_spend_freebies(self, user):
-        """Check if user can spend freebie points on this object."""
-        from core.permissions import PermissionManager
-
-        return PermissionManager.user_can_spend_freebies(user, self)
-
-    def get_visibility_tier(self, user):
-        """Get visibility tier for user."""
-        from core.permissions import PermissionManager
-
-        return PermissionManager.get_visibility_tier(user, self)
-
     def add_observer(self, user, granted_by):
         """Grant observer access to a user."""
         from django.contrib.contenttypes.models import ContentType

--- a/core/templatetags/permissions.py
+++ b/core/templatetags/permissions.py
@@ -26,28 +26,28 @@ register = template.Library()
 def user_can_view(context, obj):
     """Check if current user can view object."""
     user = context["request"].user
-    return obj.user_can_view(user)
+    return PermissionManager.user_can_view(user, obj)
 
 
 @register.simple_tag(takes_context=True)
 def user_can_edit(context, obj):
     """Check if current user can edit object (EDIT_FULL)."""
     user = context["request"].user
-    return obj.user_can_edit(user)
+    return PermissionManager.user_can_edit(user, obj)
 
 
 @register.simple_tag(takes_context=True)
 def user_can_spend_xp(context, obj):
     """Check if current user can spend XP on object."""
     user = context["request"].user
-    return obj.user_can_spend_xp(user)
+    return PermissionManager.user_can_spend_xp(user, obj)
 
 
 @register.simple_tag(takes_context=True)
 def user_can_spend_freebies(context, obj):
     """Check if current user can spend freebies on object."""
     user = context["request"].user
-    return obj.user_can_spend_freebies(user)
+    return PermissionManager.user_can_spend_freebies(user, obj)
 
 
 @register.simple_tag(takes_context=True)
@@ -81,7 +81,7 @@ def visibility_tier(context, obj):
         {% if tier|is_full %}...{% endif %}
     """
     user = context["request"].user
-    return obj.get_visibility_tier(user)
+    return PermissionManager.get_visibility_tier(user, obj)
 
 
 @register.simple_tag(takes_context=True)
@@ -96,7 +96,7 @@ def user_roles(context, obj):
         {% endfor %}
     """
     user = context["request"].user
-    return obj.get_user_roles(user)
+    return PermissionManager.get_user_roles(user, obj)
 
 
 @register.filter

--- a/core/tests/templatetags/test_permissions.py
+++ b/core/tests/templatetags/test_permissions.py
@@ -1,6 +1,8 @@
 """Tests for permissions template tags."""
 
-from core.permissions import Permission, VisibilityTier
+from unittest.mock import Mock, patch
+
+from core.permissions import Permission, Role, VisibilityTier
 from core.templatetags.permissions import (
     is_full,
     is_game_st,
@@ -88,29 +90,31 @@ class UserCanViewTagTest(TestCase):
             username="testuser", email="test@example.com", password="password"
         )
 
-    def test_returns_true_when_user_can_view(self):
-        """Test tag returns True when object allows viewing."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_view")
+    def test_returns_true_when_user_can_view(self, mock_perm):
+        """Test tag returns True when PermissionManager allows viewing."""
+        mock_perm.return_value = True
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_view = True
-
+        obj = Mock()
         result = user_can_view(context, obj)
         self.assertTrue(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_false_when_user_cannot_view(self):
-        """Test tag returns False when object denies viewing."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_view")
+    def test_returns_false_when_user_cannot_view(self, mock_perm):
+        """Test tag returns False when PermissionManager denies viewing."""
+        mock_perm.return_value = False
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_view = False
-
+        obj = Mock()
         result = user_can_view(context, obj)
         self.assertFalse(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
 
 class UserCanEditTagTest(TestCase):
@@ -122,29 +126,31 @@ class UserCanEditTagTest(TestCase):
             username="testuser", email="test@example.com", password="password"
         )
 
-    def test_returns_true_when_user_can_edit(self):
-        """Test tag returns True when object allows editing."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_edit")
+    def test_returns_true_when_user_can_edit(self, mock_perm):
+        """Test tag returns True when PermissionManager allows editing."""
+        mock_perm.return_value = True
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_edit = True
-
+        obj = Mock()
         result = user_can_edit(context, obj)
         self.assertTrue(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_false_when_user_cannot_edit(self):
-        """Test tag returns False when object denies editing."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_edit")
+    def test_returns_false_when_user_cannot_edit(self, mock_perm):
+        """Test tag returns False when PermissionManager denies editing."""
+        mock_perm.return_value = False
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_edit = False
-
+        obj = Mock()
         result = user_can_edit(context, obj)
         self.assertFalse(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
 
 class UserCanSpendXPTagTest(TestCase):
@@ -156,29 +162,31 @@ class UserCanSpendXPTagTest(TestCase):
             username="testuser", email="test@example.com", password="password"
         )
 
-    def test_returns_true_when_user_can_spend_xp(self):
-        """Test tag returns True when object allows XP spending."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_spend_xp")
+    def test_returns_true_when_user_can_spend_xp(self, mock_perm):
+        """Test tag returns True when PermissionManager allows XP spending."""
+        mock_perm.return_value = True
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_spend_xp = True
-
+        obj = Mock()
         result = user_can_spend_xp(context, obj)
         self.assertTrue(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_false_when_user_cannot_spend_xp(self):
-        """Test tag returns False when object denies XP spending."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_spend_xp")
+    def test_returns_false_when_user_cannot_spend_xp(self, mock_perm):
+        """Test tag returns False when PermissionManager denies XP spending."""
+        mock_perm.return_value = False
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_spend_xp = False
-
+        obj = Mock()
         result = user_can_spend_xp(context, obj)
         self.assertFalse(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
 
 class UserCanSpendFreebiesTagTest(TestCase):
@@ -190,29 +198,31 @@ class UserCanSpendFreebiesTagTest(TestCase):
             username="testuser", email="test@example.com", password="password"
         )
 
-    def test_returns_true_when_user_can_spend_freebies(self):
-        """Test tag returns True when object allows freebie spending."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_spend_freebies")
+    def test_returns_true_when_user_can_spend_freebies(self, mock_perm):
+        """Test tag returns True when PermissionManager allows freebie spending."""
+        mock_perm.return_value = True
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_spend_freebies = True
-
+        obj = Mock()
         result = user_can_spend_freebies(context, obj)
         self.assertTrue(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_false_when_user_cannot_spend_freebies(self):
-        """Test tag returns False when object denies freebie spending."""
+    @patch("core.templatetags.permissions.PermissionManager.user_can_spend_freebies")
+    def test_returns_false_when_user_cannot_spend_freebies(self, mock_perm):
+        """Test tag returns False when PermissionManager denies freebie spending."""
+        mock_perm.return_value = False
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._can_spend_freebies = False
-
+        obj = Mock()
         result = user_can_spend_freebies(context, obj)
         self.assertFalse(result)
+        mock_perm.assert_called_once_with(self.user, obj)
 
 
 class UserHasPermissionTagTest(TestCase):
@@ -284,41 +294,44 @@ class VisibilityTierTagTest(TestCase):
             username="testuser", email="test@example.com", password="password"
         )
 
-    def test_returns_full_visibility_tier(self):
+    @patch("core.templatetags.permissions.PermissionManager.get_visibility_tier")
+    def test_returns_full_visibility_tier(self, mock_perm):
         """Test tag returns FULL visibility tier."""
+        mock_perm.return_value = VisibilityTier.FULL
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._visibility_tier = VisibilityTier.FULL
-
+        obj = Mock()
         result = visibility_tier(context, obj)
         self.assertEqual(result, VisibilityTier.FULL)
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_partial_visibility_tier(self):
+    @patch("core.templatetags.permissions.PermissionManager.get_visibility_tier")
+    def test_returns_partial_visibility_tier(self, mock_perm):
         """Test tag returns PARTIAL visibility tier."""
+        mock_perm.return_value = VisibilityTier.PARTIAL
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._visibility_tier = VisibilityTier.PARTIAL
-
+        obj = Mock()
         result = visibility_tier(context, obj)
         self.assertEqual(result, VisibilityTier.PARTIAL)
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_none_visibility_tier(self):
+    @patch("core.templatetags.permissions.PermissionManager.get_visibility_tier")
+    def test_returns_none_visibility_tier(self, mock_perm):
         """Test tag returns NONE visibility tier."""
+        mock_perm.return_value = VisibilityTier.NONE
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._visibility_tier = VisibilityTier.NONE
-
+        obj = Mock()
         result = visibility_tier(context, obj)
         self.assertEqual(result, VisibilityTier.NONE)
+        mock_perm.assert_called_once_with(self.user, obj)
 
 
 class UserRolesTagTest(TestCase):
@@ -330,31 +343,31 @@ class UserRolesTagTest(TestCase):
             username="testuser", email="test@example.com", password="password"
         )
 
-    def test_returns_user_roles(self):
+    @patch("core.templatetags.permissions.PermissionManager.get_user_roles")
+    def test_returns_user_roles(self, mock_perm):
         """Test tag returns set of user roles."""
-        from core.permissions import Role
-
+        mock_perm.return_value = {Role.OWNER, Role.AUTHENTICATED}
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._roles = {Role.OWNER, Role.AUTHENTICATED}
-
+        obj = Mock()
         result = user_roles(context, obj)
         self.assertEqual(result, {Role.OWNER, Role.AUTHENTICATED})
+        mock_perm.assert_called_once_with(self.user, obj)
 
-    def test_returns_empty_set_when_no_roles(self):
+    @patch("core.templatetags.permissions.PermissionManager.get_user_roles")
+    def test_returns_empty_set_when_no_roles(self, mock_perm):
         """Test tag returns empty set when user has no roles."""
+        mock_perm.return_value = set()
         request = self.factory.get("/")
         request.user = self.user
         context = {"request": request}
 
-        obj = MockObject()
-        obj._roles = set()
-
+        obj = Mock()
         result = user_roles(context, obj)
         self.assertEqual(result, set())
+        mock_perm.assert_called_once_with(self.user, obj)
 
 
 class IsFullFilterTest(TestCase):

--- a/core/tests/test_context_processors.py
+++ b/core/tests/test_context_processors.py
@@ -149,83 +149,61 @@ class PermissionsContextProcessorTest(TestCase):
         self.assertIn("user_can_edit", result)
         self.assertTrue(callable(result["user_can_edit"]))
 
-    def test_user_can_view_returns_true_when_object_has_method_returning_true(self):
-        """Test that user_can_view returns True when object.user_can_view returns True."""
+    @patch("core.context_processors.PermissionManager.user_can_view")
+    def test_user_can_view_returns_true_when_permission_manager_returns_true(self, mock_perm):
+        """Test that user_can_view returns True when PermissionManager returns True."""
+        mock_perm.return_value = True
         request = self.factory.get("/")
         request.user = self.user
 
         result = permissions(request)
-
         mock_obj = Mock()
-        mock_obj.user_can_view = Mock(return_value=True)
 
         can_view = result["user_can_view"](mock_obj)
         self.assertTrue(can_view)
-        mock_obj.user_can_view.assert_called_once_with(self.user)
+        mock_perm.assert_called_once_with(self.user, mock_obj)
 
-    def test_user_can_view_returns_false_when_object_has_method_returning_false(self):
-        """Test that user_can_view returns False when object.user_can_view returns False."""
+    @patch("core.context_processors.PermissionManager.user_can_view")
+    def test_user_can_view_returns_false_when_permission_manager_returns_false(self, mock_perm):
+        """Test that user_can_view returns False when PermissionManager returns False."""
+        mock_perm.return_value = False
         request = self.factory.get("/")
         request.user = self.user
 
         result = permissions(request)
-
         mock_obj = Mock()
-        mock_obj.user_can_view = Mock(return_value=False)
 
         can_view = result["user_can_view"](mock_obj)
         self.assertFalse(can_view)
+        mock_perm.assert_called_once_with(self.user, mock_obj)
 
-    def test_user_can_view_returns_false_when_object_has_no_method(self):
-        """Test that user_can_view returns False when object has no user_can_view method."""
+    @patch("core.context_processors.PermissionManager.user_can_edit")
+    def test_user_can_edit_returns_true_when_permission_manager_returns_true(self, mock_perm):
+        """Test that user_can_edit returns True when PermissionManager returns True."""
+        mock_perm.return_value = True
         request = self.factory.get("/")
         request.user = self.user
 
         result = permissions(request)
-
-        mock_obj = object()  # Plain object with no user_can_view method
-
-        can_view = result["user_can_view"](mock_obj)
-        self.assertFalse(can_view)
-
-    def test_user_can_edit_returns_true_when_object_has_method_returning_true(self):
-        """Test that user_can_edit returns True when object.user_can_edit returns True."""
-        request = self.factory.get("/")
-        request.user = self.user
-
-        result = permissions(request)
-
         mock_obj = Mock()
-        mock_obj.user_can_edit = Mock(return_value=True)
 
         can_edit = result["user_can_edit"](mock_obj)
         self.assertTrue(can_edit)
-        mock_obj.user_can_edit.assert_called_once_with(self.user)
+        mock_perm.assert_called_once_with(self.user, mock_obj)
 
-    def test_user_can_edit_returns_false_when_object_has_method_returning_false(self):
-        """Test that user_can_edit returns False when object.user_can_edit returns False."""
+    @patch("core.context_processors.PermissionManager.user_can_edit")
+    def test_user_can_edit_returns_false_when_permission_manager_returns_false(self, mock_perm):
+        """Test that user_can_edit returns False when PermissionManager returns False."""
+        mock_perm.return_value = False
         request = self.factory.get("/")
         request.user = self.user
 
         result = permissions(request)
-
         mock_obj = Mock()
-        mock_obj.user_can_edit = Mock(return_value=False)
 
         can_edit = result["user_can_edit"](mock_obj)
         self.assertFalse(can_edit)
-
-    def test_user_can_edit_returns_false_when_object_has_no_method(self):
-        """Test that user_can_edit returns False when object has no user_can_edit method."""
-        request = self.factory.get("/")
-        request.user = self.user
-
-        result = permissions(request)
-
-        mock_obj = object()  # Plain object with no user_can_edit method
-
-        can_edit = result["user_can_edit"](mock_obj)
-        self.assertFalse(can_edit)
+        mock_perm.assert_called_once_with(self.user, mock_obj)
 
     def test_visibility_tier_enum_values_accessible(self):
         """Test that VisibilityTier enum values are accessible."""


### PR DESCRIPTION
## Summary

- Remove 6 redundant wrapper methods from `PermissionMixin` that just delegated to `PermissionManager`
- Update template tags and context processors to call `PermissionManager` directly
- Eliminates circular imports (each wrapper was importing `PermissionManager` inside the method)
- Removes ~50 lines of redundant code

## Changes

| File | Change |
|------|--------|
| `core/models.py` | Delete `get_user_roles`, `user_can_view`, `user_can_edit`, `user_can_spend_xp`, `user_can_spend_freebies`, `get_visibility_tier` |
| `core/templatetags/permissions.py` | Call `PermissionManager` directly instead of wrapper methods |
| `core/context_processors.py` | Call `PermissionManager` directly |
| `core/tests/*.py` | Update tests to use patching |
| `.claude/skills/tg-permissions/references/implementation-guide.md` | Update documentation examples |

## Test plan

- [x] All 150 permission-related tests pass
- [x] Core permission tests: 94 tests OK
- [x] Context processor tests: 18 tests OK
- [x] Template tag tests: 38 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)