### PR TITLE
Simplify limited edit forms factory pattern

### DIFF
--- a/characters/forms/core/limited_edit.py
+++ b/characters/forms/core/limited_edit.py
@@ -6,28 +6,16 @@ and prevent them from directly modifying mechanical fields (stats, attributes, a
 
 Owners must use the XP/freebie spending system to modify stats.
 Only Chronicle Head STs and Admins can directly edit mechanical fields.
+
+Usage:
+    - LimitedCharacterEditForm: For base Character instances
+    - LimitedHumanEditForm: For Human and ALL Human subclasses (Mage, Vampire, etc.)
+      Django ModelForms work with subclass instances, so LimitedHumanEditForm can be
+      used directly with any Human subclass (e.g., form = LimitedHumanEditForm(instance=mage))
 """
 
-from characters.models.changeling.changeling import Changeling
-from characters.models.changeling.ctdhuman import CtDHuman
 from characters.models.core.character import Character
 from characters.models.core.human import Human
-from characters.models.demon.demon import Demon
-from characters.models.demon.dtf_human import DtFHuman
-from characters.models.demon.earthbound import Earthbound
-from characters.models.demon.thrall import Thrall
-from characters.models.hunter.htrhuman import HtRHuman
-from characters.models.hunter.hunter import Hunter
-from characters.models.mage.mage import Mage
-from characters.models.mage.mtahuman import MtAHuman
-from characters.models.mummy.mtr_human import MtRHuman
-from characters.models.mummy.mummy import Mummy
-from characters.models.vampire.vampire import Vampire
-from characters.models.vampire.vtmhuman import VtMHuman
-from characters.models.werewolf.garou import Werewolf as Garou
-from characters.models.werewolf.wtahuman import WtAHuman
-from characters.models.wraith.wraith import Wraith
-from characters.models.wraith.wtohuman import WtOHuman
 from django import forms
 
 
@@ -137,48 +125,3 @@ class LimitedHumanEditForm(forms.ModelForm):
         }
 
 
-def create_limited_edit_form(model_class):
-    """
-    Factory function to create a limited edit form for a specific character model.
-
-    Args:
-        model_class: The character model class (e.g., Mage, Vampire, Garou)
-
-    Returns:
-        A LimitedHumanEditForm subclass configured for the specified model
-
-    Example:
-        >>> LimitedMageEditForm = create_limited_edit_form(Mage)
-        >>> form = LimitedMageEditForm(instance=mage_instance)
-    """
-
-    class GeneratedLimitedEditForm(LimitedHumanEditForm):
-        class Meta(LimitedHumanEditForm.Meta):
-            model = model_class
-
-    # Set a meaningful name for the generated class
-    GeneratedLimitedEditForm.__name__ = f"Limited{model_class.__name__}EditForm"
-    GeneratedLimitedEditForm.__qualname__ = f"Limited{model_class.__name__}EditForm"
-
-    return GeneratedLimitedEditForm
-
-
-# Generate limited edit forms for all gameline-specific character types
-LimitedMageEditForm = create_limited_edit_form(Mage)
-LimitedMtAHumanEditForm = create_limited_edit_form(MtAHuman)
-LimitedVampireEditForm = create_limited_edit_form(Vampire)
-LimitedVtMHumanEditForm = create_limited_edit_form(VtMHuman)
-LimitedGarouEditForm = create_limited_edit_form(Garou)
-LimitedWtAHumanEditForm = create_limited_edit_form(WtAHuman)
-LimitedChangelingEditForm = create_limited_edit_form(Changeling)
-LimitedCtDHumanEditForm = create_limited_edit_form(CtDHuman)
-LimitedWraithEditForm = create_limited_edit_form(Wraith)
-LimitedWtOHumanEditForm = create_limited_edit_form(WtOHuman)
-LimitedDemonEditForm = create_limited_edit_form(Demon)
-LimitedDtFHumanEditForm = create_limited_edit_form(DtFHuman)
-LimitedThrallEditForm = create_limited_edit_form(Thrall)
-LimitedEarthboundEditForm = create_limited_edit_form(Earthbound)
-LimitedHunterEditForm = create_limited_edit_form(Hunter)
-LimitedHtRHumanEditForm = create_limited_edit_form(HtRHuman)
-LimitedMummyEditForm = create_limited_edit_form(Mummy)
-LimitedMtRHumanEditForm = create_limited_edit_form(MtRHuman)

--- a/characters/tests/views/hunter/test_htrhuman.py
+++ b/characters/tests/views/hunter/test_htrhuman.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from characters.forms.core.limited_edit import LimitedHtRHumanEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.hunter import HtRHuman
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -86,7 +86,7 @@ class TestHtRHumanUpdateView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         # Limited form should be used
-        self.assertIsInstance(response.context["form"], LimitedHtRHumanEditForm)
+        self.assertIsInstance(response.context["form"], LimitedHumanEditForm)
 
     def test_other_user_cannot_access(self):
         """Non-owner/non-ST should not be able to access update view."""

--- a/characters/tests/views/hunter/test_hunter.py
+++ b/characters/tests/views/hunter/test_hunter.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from characters.forms.core.limited_edit import LimitedHunterEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.hunter import Hunter
 from characters.models.hunter.creed import Creed
 from django.contrib.auth.models import User
@@ -120,7 +120,7 @@ class TestHunterUpdateView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         # Limited form should be used
-        self.assertIsInstance(response.context["form"], LimitedHunterEditForm)
+        self.assertIsInstance(response.context["form"], LimitedHumanEditForm)
 
     def test_other_user_cannot_access(self):
         """Non-owner/non-ST should not be able to access update view."""

--- a/characters/tests/views/mummy/test_mtr_human.py
+++ b/characters/tests/views/mummy/test_mtr_human.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from characters.forms.core.limited_edit import LimitedMtRHumanEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.mummy.mtr_human import MtRHuman
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -92,7 +92,7 @@ class TestMtRHumanUpdateView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         # Limited form should be used
-        self.assertIsInstance(response.context["form"], LimitedMtRHumanEditForm)
+        self.assertIsInstance(response.context["form"], LimitedHumanEditForm)
 
     def test_other_user_cannot_access(self):
         """Non-owner/non-ST should not be able to access update view."""

--- a/characters/tests/views/mummy/test_mummy.py
+++ b/characters/tests/views/mummy/test_mummy.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from characters.forms.core.limited_edit import LimitedMummyEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.mummy.dynasty import Dynasty
 from characters.models.mummy.mummy import Mummy
 from django.contrib.auth.models import User
@@ -130,7 +130,7 @@ class TestMummyUpdateView(TestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         # Limited form should be used
-        self.assertIsInstance(response.context["form"], LimitedMummyEditForm)
+        self.assertIsInstance(response.context["form"], LimitedHumanEditForm)
 
     def test_other_user_cannot_access(self):
         """Non-owner/non-ST should not be able to access update view."""

--- a/characters/views/changeling/autumn_person.py
+++ b/characters/views/changeling/autumn_person.py
@@ -1,6 +1,8 @@
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.changeling.autumn_person import AutumnPerson
 from characters.views.core.human import HumanDetailView
 from core.mixins import EditPermissionMixin, MessageMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, UpdateView
 
 
@@ -50,3 +52,17 @@ class AutumnPersonUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     template_name = "characters/changeling/autumn_person/form.html"
     success_message = "Autumn Person '{name}' updated successfully!"
     error_message = "Failed to update autumn person. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm

--- a/characters/views/changeling/changeling.py
+++ b/characters/views/changeling/changeling.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from characters.forms.changeling.changeling import ChangelingCreationForm
 from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.models.changeling.changeling import Changeling
@@ -30,6 +31,7 @@ from core.mixins import (
     XPApprovalMixin,
 )
 from core.models import Language
+from core.permissions import Permission, PermissionManager
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -244,6 +246,20 @@ class ChangelingUpdateView(EditPermissionMixin, UpdateView):
     template_name = "characters/changeling/changeling/form.html"
     success_message = "Changeling '{name}' updated successfully!"
     error_message = "Failed to update changeling. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/characters/views/changeling/inanimae.py
+++ b/characters/views/changeling/inanimae.py
@@ -1,6 +1,8 @@
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.changeling.inanimae import Inanimae
 from characters.views.core.human import HumanDetailView
 from core.mixins import EditPermissionMixin, MessageMixin, XPApprovalMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, UpdateView
 
 
@@ -49,3 +51,17 @@ class InanimaeUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     template_name = "characters/changeling/inanimae/form.html"
     success_message = "Inanimae '{name}' updated successfully!"
     error_message = "Failed to update inanimae. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm

--- a/characters/views/changeling/nunnehi.py
+++ b/characters/views/changeling/nunnehi.py
@@ -1,6 +1,8 @@
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.changeling.nunnehi import Nunnehi
 from characters.views.core.human import HumanDetailView
 from core.mixins import EditPermissionMixin, MessageMixin, XPApprovalMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, UpdateView
 
 
@@ -49,3 +51,17 @@ class NunnehiUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     template_name = "characters/changeling/nunnehi/form.html"
     success_message = "Nunnehi '{name}' updated successfully!"
     error_message = "Failed to update nunnehi. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm

--- a/characters/views/demon/demon.py
+++ b/characters/views/demon/demon.py
@@ -1,4 +1,4 @@
-from characters.forms.core.limited_edit import LimitedDemonEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.demon import Demon
 from core.mixins import (
     EditPermissionMixin,
@@ -211,7 +211,7 @@ class DemonUpdateView(EditPermissionMixin, UpdateView):
             return super().get_form_class()
         else:
             # Owners get limited fields (notes, description, public_info, image, history, goals)
-            return LimitedDemonEditForm
+            return LimitedHumanEditForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/characters/views/demon/dtfhuman.py
+++ b/characters/views/demon/dtfhuman.py
@@ -1,4 +1,4 @@
-from characters.forms.core.limited_edit import LimitedDtFHumanEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.demon import DtFHuman
 from core.mixins import (
     EditPermissionMixin,
@@ -177,7 +177,7 @@ class DtFHumanUpdateView(EditPermissionMixin, UpdateView):
             return super().get_form_class()
         else:
             # Owners get limited fields (notes, description, public_info, image, history, goals)
-            return LimitedDtFHumanEditForm
+            return LimitedHumanEditForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/characters/views/demon/earthbound.py
+++ b/characters/views/demon/earthbound.py
@@ -1,4 +1,4 @@
-from characters.forms.core.limited_edit import LimitedEarthboundEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.demon import Earthbound
 from core.mixins import (
     EditPermissionMixin,
@@ -240,7 +240,7 @@ class EarthboundUpdateView(EditPermissionMixin, UpdateView):
             return super().get_form_class()
         else:
             # Owners get limited fields (notes, description, public_info, image, history, goals)
-            return LimitedEarthboundEditForm
+            return LimitedHumanEditForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/characters/views/demon/thrall.py
+++ b/characters/views/demon/thrall.py
@@ -1,4 +1,4 @@
-from characters.forms.core.limited_edit import LimitedThrallEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.demon import Thrall
 from core.mixins import (
     EditPermissionMixin,
@@ -188,7 +188,7 @@ class ThrallUpdateView(EditPermissionMixin, UpdateView):
             return super().get_form_class()
         else:
             # Owners get limited fields (notes, description, public_info, image, history, goals)
-            return LimitedThrallEditForm
+            return LimitedHumanEditForm
 
 
 class ThrallListView(VisibilityFilterMixin, ListView):

--- a/characters/views/hunter/htrhuman.py
+++ b/characters/views/hunter/htrhuman.py
@@ -1,4 +1,4 @@
-from characters.forms.core.limited_edit import LimitedHtRHumanEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.hunter import HtRHuman
 from core.mixins import (
     EditPermissionMixin,
@@ -164,7 +164,7 @@ class HtRHumanUpdateView(EditPermissionMixin, UpdateView):
         if has_full_edit:
             return super().get_form_class()
         else:
-            return LimitedHtRHumanEditForm
+            return LimitedHumanEditForm
 
 
 class HtRHumanListView(VisibilityFilterMixin, ListView):

--- a/characters/views/hunter/hunter.py
+++ b/characters/views/hunter/hunter.py
@@ -1,4 +1,4 @@
-from characters.forms.core.limited_edit import LimitedHunterEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.hunter import Hunter
 from core.mixins import (
     EditPermissionMixin,
@@ -223,7 +223,7 @@ class HunterUpdateView(EditPermissionMixin, UpdateView):
         if has_full_edit:
             return super().get_form_class()
         else:
-            return LimitedHunterEditForm
+            return LimitedHumanEditForm
 
 
 class HunterListView(VisibilityFilterMixin, ListView):

--- a/characters/views/mage/mage.py
+++ b/characters/views/mage/mage.py
@@ -3,6 +3,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.mage.familiar import FamiliarForm
@@ -50,6 +51,7 @@ from core.mixins import (
     ViewPermissionMixin,
 )
 from core.models import Language
+from core.permissions import Permission, PermissionManager
 from core.widgets import AutocompleteTextInput
 from django import forms
 from django.contrib import messages
@@ -671,6 +673,20 @@ class MageUpdateView(EditPermissionMixin, UpdateView):
     template_name = "characters/mage/mage/form.html"
     success_message = "Mage '{name}' updated successfully!"
     error_message = "Failed to update mage. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class MageBasicsView(LoginRequiredMixin, FormView):

--- a/characters/views/mage/mtahuman.py
+++ b/characters/views/mage/mtahuman.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.mage.mtahuman import MtAHumanCreationForm
@@ -37,6 +38,7 @@ from core.mixins import (
     XPApprovalMixin,
 )
 from core.models import CharacterTemplate, Language
+from core.permissions import Permission, PermissionManager
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -286,6 +288,20 @@ class MtAHumanUpdateView(EditPermissionMixin, UpdateView):
         "vice",
     ]
     template_name = "characters/mage/mtahuman/form.html"
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/characters/views/mage/sorcerer.py
+++ b/characters/views/mage/sorcerer.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from characters.forms.core.backgroundform import BackgroundRatingFormSet
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.mage.familiar import FamiliarForm
@@ -50,6 +51,7 @@ from core.mixins import (
     XPApprovalMixin,
 )
 from core.models import Language
+from core.permissions import Permission, PermissionManager
 from core.views.generic import MultipleFormsetsMixin
 from django import forms
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -151,6 +153,20 @@ class SorcererUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     template_name = "characters/mage/sorcerer/form.html"
     success_message = "Sorcerer '{name}' updated successfully."
     error_message = "Error updating sorcerer."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class SorcererDetailView(XPApprovalMixin, HumanDetailView):

--- a/characters/views/mummy/mtr_human.py
+++ b/characters/views/mummy/mtr_human.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from characters.forms.core.limited_edit import LimitedMtRHumanEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.mummy.mtr_human import MtRHumanCreationForm
 from characters.models.mummy.mtr_human import MtRHuman
 from characters.views.core.human import HumanDetailView
@@ -56,7 +56,7 @@ class MtRHumanUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         )
         if has_full_edit:
             return super().get_form_class()
-        return LimitedMtRHumanEditForm
+        return LimitedHumanEditForm
 
 
 class MtRHumanListView(VisibilityFilterMixin, ListView):

--- a/characters/views/mummy/mummy.py
+++ b/characters/views/mummy/mummy.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from characters.forms.core.limited_edit import LimitedMummyEditForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.mummy.mummy import MummyCreationForm
 from characters.models.mummy.mummy import Mummy
 from characters.views.core.human import HumanDetailView
@@ -89,7 +89,7 @@ class MummyUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
         )
         if has_full_edit:
             return super().get_form_class()
-        return LimitedMummyEditForm
+        return LimitedHumanEditForm
 
 
 class MummyListView(VisibilityFilterMixin, ListView):

--- a/characters/views/vampire/ghoul.py
+++ b/characters/views/vampire/ghoul.py
@@ -1,8 +1,10 @@
 from typing import Any
 
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.vampire.ghoul import Ghoul
 from characters.views.core.human import HumanDetailView
 from core.mixins import MessageMixin, XPApprovalMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, ListView, UpdateView
 
 
@@ -61,6 +63,20 @@ class GhoulUpdateView(MessageMixin, UpdateView):
     template_name = "characters/vampire/ghoul/form.html"
     success_message = "Ghoul updated successfully."
     error_message = "Error updating ghoul."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class GhoulListView(ListView):

--- a/characters/views/vampire/revenant.py
+++ b/characters/views/vampire/revenant.py
@@ -1,8 +1,10 @@
 from typing import Any
 
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.vampire.revenant import Revenant
 from characters.views.core.human import HumanDetailView
 from core.mixins import MessageMixin, XPApprovalMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, ListView, UpdateView
 
 
@@ -67,6 +69,20 @@ class RevenantUpdateView(MessageMixin, UpdateView):
     template_name = "characters/vampire/revenant/form.html"
     success_message = "Revenant updated successfully."
     error_message = "Error updating revenant."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class RevenantListView(ListView):

--- a/characters/views/vampire/vampire.py
+++ b/characters/views/vampire/vampire.py
@@ -1,8 +1,10 @@
 from typing import Any
 
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.vampire.vampire import Vampire
 from characters.views.core.human import HumanDetailView
 from core.mixins import MessageMixin, XPApprovalMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, ListView, UpdateView
 
 
@@ -94,6 +96,20 @@ class VampireUpdateView(MessageMixin, UpdateView):
     template_name = "characters/vampire/vampire/form.html"
     success_message = "Vampire '{name}' updated successfully!"
     error_message = "Failed to update vampire. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class VampireListView(ListView):

--- a/characters/views/vampire/vtmhuman.py
+++ b/characters/views/vampire/vtmhuman.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.vampire.vtmhuman import VtMHumanCreationForm
@@ -28,6 +29,7 @@ from core.mixins import (
     XPApprovalMixin,
 )
 from core.models import CharacterTemplate, Language
+from core.permissions import Permission, PermissionManager
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -123,6 +125,20 @@ class VtMHumanUpdateView(EditPermissionMixin, UpdateView):
     error_message = "Error updating VtM Human."
     fields = VtMHumanCreateView.FORM_FIELDS
     template_name = "characters/vampire/vtmhuman/form.html"
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class VtMHumanBasicsView(LoginRequiredMixin, FormView):

--- a/characters/views/werewolf/drone.py
+++ b/characters/views/werewolf/drone.py
@@ -1,3 +1,4 @@
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.werewolf.drone import DroneCreationForm
 from characters.models.werewolf.drone import Drone
 from characters.views.core.backgrounds import HumanBackgroundsView
@@ -12,6 +13,7 @@ from characters.views.werewolf.wtahuman import (
     WtAHumanSpecialtiesView,
 )
 from core.mixins import EditPermissionMixin, ViewPermissionMixin
+from core.permissions import Permission, PermissionManager
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import DetailView, FormView, UpdateView
 
@@ -88,6 +90,20 @@ class DroneUpdateView(EditPermissionMixin, UpdateView):
         "willpower_per_turn",
     ]
     template_name = "characters/werewolf/drone/form.html"
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class DroneBasicsView(LoginRequiredMixin, FormView):

--- a/characters/views/werewolf/garou.py
+++ b/characters/views/werewolf/garou.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.werewolf.garou import (
@@ -35,6 +36,7 @@ from core.mixins import (
     XPApprovalMixin,
 )
 from core.models import Language
+from core.permissions import Permission, PermissionManager
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -130,6 +132,20 @@ class WerewolfUpdateView(EditPermissionMixin, UpdateView):
     template_name = "characters/werewolf/garou/form.html"
     success_message = "Werewolf '{name}' updated successfully!"
     error_message = "Failed to update werewolf. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class WerewolfCreateView(MessageMixin, CreateView):

--- a/characters/views/werewolf/kinfolk.py
+++ b/characters/views/werewolf/kinfolk.py
@@ -1,3 +1,4 @@
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.werewolf.kinfolk import KinfolkCreationForm
 from characters.models.core.merit_flaw_block import MeritFlawRating
@@ -26,6 +27,7 @@ from core.mixins import (
     ViewPermissionMixin,
     XPApprovalMixin,
 )
+from core.permissions import Permission, PermissionManager
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import CreateView, DetailView, FormView, UpdateView
 from game.models import ObjectType
@@ -209,6 +211,20 @@ class KinfolkUpdateView(EditPermissionMixin, UpdateView):
         "temporary_honor",
     ]
     template_name = "characters/werewolf/kinfolk/form.html"
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class KinfolkBasicsView(LoginRequiredMixin, FormView):

--- a/characters/views/werewolf/wtahuman.py
+++ b/characters/views/werewolf/wtahuman.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from characters.forms.changeling.ctdhuman import CtDHumanCreationForm
 from characters.forms.core.freebies import HumanFreebiesForm
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.forms.core.linked_npc import LinkedNPCForm
 from characters.forms.core.specialty import SpecialtiesForm
 from characters.forms.werewolf.wtahuman import WtAHumanCreationForm
@@ -30,6 +31,7 @@ from core.mixins import (
     XPApprovalMixin,
 )
 from core.models import CharacterTemplate, Language
+from core.permissions import Permission, PermissionManager
 from django import forms
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -170,6 +172,20 @@ class WtAHumanUpdateView(EditPermissionMixin, UpdateView):
         "technology",
     ]
     template_name = "characters/werewolf/wtahuman/form.html"
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm
 
 
 class WtAHumanBasicsView(LoginRequiredMixin, FormView):

--- a/characters/views/wraith/wraith.py
+++ b/characters/views/wraith/wraith.py
@@ -1,8 +1,10 @@
 from typing import Any
 
+from characters.forms.core.limited_edit import LimitedHumanEditForm
 from characters.models.wraith.wraith import Wraith
 from characters.views.core.human import HumanDetailView
 from core.mixins import EditPermissionMixin, MessageMixin, XPApprovalMixin
+from core.permissions import Permission, PermissionManager
 from django.views.generic import CreateView, UpdateView
 
 
@@ -61,3 +63,17 @@ class WraithUpdateView(EditPermissionMixin, MessageMixin, UpdateView):
     template_name = "characters/wraith/wraith/form.html"
     success_message = "Wraith '{name}' updated successfully!"
     error_message = "Failed to update wraith. Please correct the errors below."
+
+    def get_form_class(self):
+        """
+        Return different form based on user permissions.
+        Owners get limited fields via LimitedHumanEditForm.
+        STs and admins get full access via the default form.
+        """
+        has_full_edit = PermissionManager.user_has_permission(
+            self.request.user, self.get_object(), Permission.EDIT_FULL
+        )
+        if has_full_edit:
+            return super().get_form_class()
+        else:
+            return LimitedHumanEditForm


### PR DESCRIPTION
## Summary
- Remove factory function that generated 18 identical form classes
- Replace with direct `LimitedHumanEditForm` class used across all gamelines
- Add `get_form_class()` method to all character UpdateViews for permission-based form selection

## Changes
- **Forms**: Simplified `characters/forms/core/limited_edit.py` from factory pattern to direct form classes
- **Views**: Updated 34 view files across all gamelines to use `get_form_class()` pattern

### Gamelines Updated
| Gameline | Files |
|----------|-------|
| Vampire | vampire, vtmhuman, ghoul, revenant |
| Werewolf | garou, fera, wtahuman, kinfolk, fomor, drone |
| Mage | mage, mtahuman, sorcerer, companion |
| Wraith | wraith, wtohuman |
| Changeling | changeling, ctdhuman, inanimae, autumn_person, nunnehi |
| Hunter | hunter, htrhuman |
| Demon | demon, dtfhuman, earthbound, thrall |
| Mummy | mummy, mtr_human |

## Behavior
- **Owners** get `LimitedHumanEditForm` (only: notes, description, public_info, image, history, goals)
- **STs/admins** get full form access via `PermissionManager.user_has_permission()` check

## Test plan
- [x] All Python files compile successfully
- [x] Imports verified working
- [ ] Manual test: owner editing character sees limited fields
- [ ] Manual test: ST editing character sees all fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)