### PR TITLE
Create widgets/ app and migrate chained_select functionality

### DIFF
--- a/chained_select/__init__.py
+++ b/chained_select/__init__.py
@@ -1,32 +1,39 @@
 """
-Django Chained Select - Self-Contained Cascading Dropdowns
+Django Chained Select - Backward Compatibility Layer
 
-Works like native Django form fields. Just render the field in your template.
-No {{ form.media }}, no URL configuration, no JavaScript setup.
+DEPRECATED: This module is deprecated and will be removed in a future version.
+Please update your imports to use the widgets app:
 
-Example:
-    from django import forms
+    # Old (deprecated):
     from chained_select import ChainedChoiceField, ChainedSelectMixin
 
-    class MyForm(ChainedSelectMixin, forms.Form):
-        parent = ChainedChoiceField(choices=[('a', 'A'), ('b', 'B')])
-        child = ChainedChoiceField(
-            parent_field='parent',
-            choices_map={'a': [('a1', 'A1')], 'b': [('b1', 'B1')]}
-        )
+    # New:
+    from widgets import ChainedChoiceField, ChainedSelectMixin
 
-Template:
-    {{ form.as_p }}
-
-That's it!
+All functionality has been migrated to the widgets app for better organization.
 """
 
-from .fields import ChainedChoiceField, ChainedModelChoiceField, ChainedSelectMixin
-from .views import ChainedSelectAjaxView, make_ajax_view
-from .widgets import ChainedSelect, ChainedSelectMultiple
+import warnings
 
-# Auto-register URL via AppConfig
-default_app_config = "chained_select.apps.ChainedSelectConfig"
+# Re-export everything from widgets for backward compatibility
+from widgets import (
+    ChainedChoiceField,
+    ChainedModelChoiceField,
+    ChainedSelect,
+    ChainedSelectAjaxView,
+    ChainedSelectMixin,
+    ChainedSelectMultiple,
+    make_ajax_view,
+)
+
+# Emit deprecation warning on import
+warnings.warn(
+    "The 'chained_select' module is deprecated. "
+    "Please update your imports to use 'widgets' instead. "
+    "Example: from widgets import ChainedChoiceField, ChainedSelectMixin",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "ChainedSelect",

--- a/chained_select/apps.py
+++ b/chained_select/apps.py
@@ -1,7 +1,7 @@
 """
-Django App Configuration for Chained Select
+Django App Configuration for Chained Select - Backward Compatibility
 
-Auto-registers the AJAX endpoint URL so users don't need to modify urls.py
+This app is deprecated. The widgets app now handles URL registration.
 """
 
 from django.apps import AppConfig
@@ -12,45 +12,5 @@ class ChainedSelectConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self):
-        """Auto-register the AJAX URL when Django starts."""
-        self._register_url()
-
-    def _register_url(self):
-        """Inject our AJAX endpoint into the root URLconf."""
-        import importlib
-
-        from django.conf import settings
-        from django.urls import path
-
-        try:
-            # Import the root URL configuration
-            urlconf_module = importlib.import_module(settings.ROOT_URLCONF)
-
-            # Import our view
-            from .views import auto_chained_ajax_view
-
-            # Check if we've already added it (happens during testing/reloads)
-            existing_names = [
-                getattr(p, "name", None) for p in getattr(urlconf_module, "urlpatterns", [])
-            ]
-
-            if "__chained_select_ajax__" not in existing_names:
-                # Add our URL pattern
-                urlconf_module.urlpatterns.insert(
-                    0,
-                    path(
-                        "__chained_select__/",
-                        auto_chained_ajax_view,
-                        name="__chained_select_ajax__",
-                    ),
-                )
-        except Exception as e:
-            # Don't crash the app if URL registration fails
-            # (might happen in some test scenarios)
-            import warnings
-
-            warnings.warn(
-                f"chained_select: Could not auto-register URL: {e}. "
-                "You may need to add the URL manually.",
-                RuntimeWarning,
-            )
+        """No longer registers URLs - widgets app handles this."""
+        pass

--- a/characters/forms/core/chained_freebies.py
+++ b/characters/forms/core/chained_freebies.py
@@ -6,7 +6,7 @@ without manual AJAX. Choices are computed at form initialization
 and embedded in the page JavaScript.
 """
 
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core.ability_block import Ability
 from characters.models.core.attribute_block import Attribute
 from characters.models.core.background_block import Background, BackgroundRating

--- a/characters/forms/core/character_creation.py
+++ b/characters/forms/core/character_creation.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from core.constants import GameLine
 from django import forms
 from game.models import ObjectType

--- a/characters/forms/core/xp.py
+++ b/characters/forms/core/xp.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core.ability_block import Ability
 from characters.models.core.attribute_block import Attribute
 from characters.models.core.background_block import Background, BackgroundRating

--- a/characters/forms/mage/freebies.py
+++ b/characters/forms/mage/freebies.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.forms.core.freebies import CATEGORY_CHOICES, HumanFreebiesForm
 from characters.models.core.ability_block import Ability
 from characters.models.core.attribute_block import Attribute

--- a/characters/forms/mage/mage.py
+++ b/characters/forms/mage/mage.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.mage.faction import MageFaction
 from characters.models.mage.mage import Mage
 from django import forms

--- a/characters/forms/mage/numina.py
+++ b/characters/forms/mage/numina.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core.ability_block import Ability
 from characters.models.mage.focus import Practice
 from characters.models.mage.sorcerer import (

--- a/characters/forms/mage/rote.py
+++ b/characters/forms/mage/rote.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core.ability_block import Ability
 from characters.models.core.attribute_block import Attribute
 from characters.models.mage.effect import Effect

--- a/characters/forms/mage/sorcerer.py
+++ b/characters/forms/mage/sorcerer.py
@@ -1,6 +1,6 @@
 """Forms for Sorcerer character type."""
 
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core.archetype import Archetype
 from characters.models.mage.fellowship import SorcererFellowship
 from characters.models.mage.sorcerer import LinearMagicPath, Sorcerer

--- a/game/forms.py
+++ b/game/forms.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core import CharacterModel
 from core.constants import GameLine, XPApprovalStatus
 from django import forms

--- a/items/forms/core/item_creation.py
+++ b/items/forms/core/item_creation.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from core.constants import GameLine
 from django import forms
 from game.models import ObjectType

--- a/locations/forms/core/location_creation.py
+++ b/locations/forms/core/location_creation.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from core.constants import GameLine
 from django import forms
 from game.models import ObjectType

--- a/locations/forms/mage/chantry.py
+++ b/locations/forms/mage/chantry.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.forms.mage.effect import EffectCreateOrSelectForm
 from characters.models.core.background_block import Background
 from characters.models.mage.effect import Effect

--- a/locations/forms/mage/node.py
+++ b/locations/forms/mage/node.py
@@ -1,4 +1,4 @@
-from chained_select import ChainedChoiceField, ChainedSelectMixin
+from widgets import ChainedChoiceField, ChainedSelectMixin
 from characters.models.core.merit_flaw_block import MeritFlaw
 from characters.models.mage.resonance import Resonance
 from core.models import Number

--- a/tg/settings/base.py
+++ b/tg/settings/base.py
@@ -33,7 +33,8 @@ INSTALLED_APPS = [
     "locations",
     "polymorphic",
     "core",
-    "chained_select",
+    "widgets",  # Reusable form widgets (replaces chained_select)
+    "chained_select",  # Deprecated - backward compatibility only
     "django.contrib.humanize",
     "crispy_forms",
     "crispy_bootstrap4",

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -1,0 +1,45 @@
+"""
+Django Widgets App - Reusable Form Components
+
+A centralized app for form widgets, fields, and mixins.
+Consolidates reusable form components from across the codebase.
+
+Chained Select Usage:
+    from django import forms
+    from widgets import ChainedChoiceField, ChainedSelectMixin
+
+    class MyForm(ChainedSelectMixin, forms.Form):
+        parent = ChainedChoiceField(choices=[('a', 'A'), ('b', 'B')])
+        child = ChainedChoiceField(
+            parent_field='parent',
+            choices_map={'a': [('a1', 'A1')], 'b': [('b1', 'B1')]}
+        )
+
+Template:
+    {{ form.as_p }}
+
+That's it!
+"""
+
+# Chained Select exports (primary widget functionality)
+from .fields.chained import ChainedChoiceField, ChainedModelChoiceField
+from .mixins.chained import ChainedSelectMixin
+from .views import ChainedSelectAjaxView, auto_chained_ajax_view, make_ajax_view
+from .widgets.chained import ChainedSelect, ChainedSelectMultiple
+
+__all__ = [
+    # Widgets
+    "ChainedSelect",
+    "ChainedSelectMultiple",
+    # Fields
+    "ChainedChoiceField",
+    "ChainedModelChoiceField",
+    # Mixins
+    "ChainedSelectMixin",
+    # Views
+    "ChainedSelectAjaxView",
+    "auto_chained_ajax_view",
+    "make_ajax_view",
+]
+
+__version__ = "1.0.0"

--- a/widgets/apps.py
+++ b/widgets/apps.py
@@ -1,0 +1,57 @@
+"""
+Django App Configuration for Widgets App
+
+Auto-registers the AJAX endpoint URL so users don't need to modify urls.py
+"""
+
+from django.apps import AppConfig
+
+
+class WidgetsConfig(AppConfig):
+    name = "widgets"
+    default_auto_field = "django.db.models.BigAutoField"
+    verbose_name = "Form Widgets"
+
+    def ready(self):
+        """Auto-register the AJAX URL when Django starts."""
+        self._register_url()
+
+    def _register_url(self):
+        """Inject our AJAX endpoint into the root URLconf."""
+        import importlib
+
+        from django.conf import settings
+        from django.urls import path
+
+        try:
+            # Import the root URL configuration
+            urlconf_module = importlib.import_module(settings.ROOT_URLCONF)
+
+            # Import our view
+            from .views import auto_chained_ajax_view
+
+            # Check if we've already added it (happens during testing/reloads)
+            existing_names = [
+                getattr(p, "name", None) for p in getattr(urlconf_module, "urlpatterns", [])
+            ]
+
+            if "__chained_select_ajax__" not in existing_names:
+                # Add our URL pattern
+                urlconf_module.urlpatterns.insert(
+                    0,
+                    path(
+                        "__chained_select__/",
+                        auto_chained_ajax_view,
+                        name="__chained_select_ajax__",
+                    ),
+                )
+        except Exception as e:
+            # Don't crash the app if URL registration fails
+            # (might happen in some test scenarios)
+            import warnings
+
+            warnings.warn(
+                f"widgets: Could not auto-register URL: {e}. "
+                "You may need to add the URL manually.",
+                RuntimeWarning,
+            )

--- a/widgets/fields/__init__.py
+++ b/widgets/fields/__init__.py
@@ -1,0 +1,10 @@
+"""
+Custom form fields for the widgets app.
+"""
+
+from .chained import ChainedChoiceField, ChainedModelChoiceField
+
+__all__ = [
+    "ChainedChoiceField",
+    "ChainedModelChoiceField",
+]

--- a/widgets/fields/chained.py
+++ b/widgets/fields/chained.py
@@ -1,0 +1,130 @@
+"""
+Chained Select Form Fields
+
+Provides ChainedChoiceField and ChainedModelChoiceField that automatically
+configure themselves. Just define the fields and add the mixin.
+"""
+
+from django import forms
+
+from ..widgets.chained import ChainedSelect
+
+
+class ChainedChoiceField(forms.ChoiceField):
+    """
+    A ChoiceField for use in cascading dropdown chains.
+
+    For root fields (no parent), provide choices directly.
+    For child fields, provide parent_field and either:
+      - choices_map: dict mapping parent values to choice lists
+      - choices_callback: function(parent_value) -> choice list
+
+    Example:
+        affiliation = ChainedChoiceField(
+            choices=[('traditions', 'Traditions'), ('technocracy', 'Technocracy')]
+        )
+
+        faction = ChainedChoiceField(
+            parent_field='affiliation',
+            choices_map={
+                'traditions': [('hermetic', 'Order of Hermes'), ...],
+                'technocracy': [('iteration_x', 'Iteration X'), ...],
+            }
+        )
+    """
+
+    widget = ChainedSelect
+
+    def __init__(
+        self,
+        *,
+        parent_field=None,
+        choices_map=None,
+        choices_callback=None,
+        empty_label="---------",
+        # Standard ChoiceField args
+        choices=(),
+        **kwargs,
+    ):
+        self.parent_field = parent_field
+        self.choices_map = choices_map
+        self.choices_callback = choices_callback
+        self.empty_label = empty_label
+        self._chain_name = None  # Set by mixin
+        self._chain_position = None  # Set by mixin
+
+        # For root field, use provided choices
+        # For child fields, start with empty (populated dynamically)
+        if parent_field and not choices:
+            choices = [("", empty_label)]
+        elif not any(c[0] == "" for c in choices):
+            # Prepend empty choice if not present
+            choices = [("", empty_label)] + list(choices)
+
+        super().__init__(choices=choices, **kwargs)
+
+    def valid_value(self, value):
+        """Allow values that will be validated at form level."""
+        if value == "":
+            return True
+        if not self.parent_field:
+            return super().valid_value(value)
+        # Child fields defer to form-level validation
+        return True
+
+    def get_choices_for_parent(self, parent_value):
+        """Get valid choices given a parent value."""
+        choices = [("", self.empty_label)]
+
+        if not parent_value:
+            return choices
+
+        if self.choices_map and parent_value in self.choices_map:
+            choices.extend(self.choices_map[parent_value])
+        elif self.choices_callback:
+            result = self.choices_callback(parent_value)
+            # Handle querysets
+            if hasattr(result, "__iter__") and not isinstance(result, (str, dict)):
+                choices.extend(result)
+
+        return choices
+
+    def get_full_choices_tree(self):
+        """
+        Get the complete choices tree for embedding in page.
+        Returns dict mapping parent values to child choices.
+        """
+        if self.choices_map:
+            return self.choices_map
+        return None
+
+
+class ChainedModelChoiceField(forms.ModelChoiceField):
+    """
+    A ModelChoiceField variant for chained selects with database-backed choices.
+
+    Example:
+        faction = ChainedModelChoiceField(
+            queryset=Faction.objects.none(),  # Start empty
+            parent_field='affiliation',
+            parent_fk='affiliation',  # FK field name on model
+        )
+    """
+
+    widget = ChainedSelect
+
+    def __init__(
+        self, queryset, *, parent_field=None, parent_fk=None, empty_label="---------", **kwargs
+    ):
+        self.parent_field = parent_field
+        self.parent_fk = parent_fk or parent_field
+        self._chain_name = None
+        self._chain_position = None
+
+        super().__init__(queryset=queryset, empty_label=empty_label, **kwargs)
+
+    def get_queryset_for_parent(self, parent_value):
+        """Get filtered queryset for a parent value."""
+        if not parent_value:
+            return self.queryset.none()
+        return self.queryset.filter(**{self.parent_fk: parent_value})

--- a/widgets/mixins/__init__.py
+++ b/widgets/mixins/__init__.py
@@ -1,0 +1,9 @@
+"""
+Reusable form and formset mixins for the widgets app.
+"""
+
+from .chained import ChainedSelectMixin
+
+__all__ = [
+    "ChainedSelectMixin",
+]

--- a/widgets/mixins/chained.py
+++ b/widgets/mixins/chained.py
@@ -1,0 +1,236 @@
+"""
+Chained Select Form Mixin
+
+Mixin for forms with chained select fields.
+"""
+
+from django.core.exceptions import ValidationError
+
+from ..fields.chained import ChainedChoiceField, ChainedModelChoiceField
+from ..widgets.chained import ChainedSelect
+
+
+class ChainedSelectMixin:
+    """
+    Mixin for forms with chained select fields.
+
+    Automatically:
+    - Detects ChainedChoiceFields and links them into chains
+    - Configures widgets with proper data attributes
+    - Builds and embeds choice trees for client-side operation
+    - Validates that selections are consistent
+
+    Usage:
+        class MyForm(ChainedSelectMixin, forms.Form):
+            affiliation = ChainedChoiceField(choices=[...])
+            faction = ChainedChoiceField(parent_field='affiliation', choices_map={...})
+            subfaction = ChainedChoiceField(parent_field='faction', choices_map={...})
+
+    That's it! Include {{ form.media }} in your template and it just works.
+    """
+
+    # Override to use a custom AJAX URL instead of the auto-registered one
+    chained_ajax_url = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._setup_chains()
+
+    def _get_form_path(self):
+        """Get the full import path for this form class."""
+        cls = self.__class__
+        return f"{cls.__module__}.{cls.__name__}"
+
+    def _setup_chains(self):
+        """Detect and configure all chained field relationships."""
+
+        # Find all chained fields and their relationships
+        chained_fields = {}
+        for name, field in self.fields.items():
+            if isinstance(field, (ChainedChoiceField, ChainedModelChoiceField)):
+                chained_fields[name] = {
+                    "field": field,
+                    "parent": getattr(field, "parent_field", None),
+                }
+
+        if not chained_fields:
+            return
+
+        # Build chains by following parent relationships
+        chains = self._build_chains(chained_fields)
+
+        # Configure each chain
+        for chain_name, field_names in chains.items():
+            self._configure_chain(chain_name, field_names)
+
+    def _build_chains(self, chained_fields):
+        """
+        Build chains from parent relationships.
+        Returns dict of chain_name -> [field_names in order]
+        """
+        chains = {}
+        chain_counter = 0
+
+        # Find root fields (no parent)
+        roots = [name for name, info in chained_fields.items() if not info["parent"]]
+
+        for root in roots:
+            chain_name = f"chain_{chain_counter}"
+            chain_counter += 1
+
+            # Follow the chain from root to leaves
+            chain = [root]
+            current = root
+
+            while True:
+                # Find child of current
+                child = None
+                for name, info in chained_fields.items():
+                    if info["parent"] == current:
+                        child = name
+                        break
+
+                if child:
+                    chain.append(child)
+                    current = child
+                else:
+                    break
+
+            chains[chain_name] = chain
+
+        return chains
+
+    def _configure_chain(self, chain_name, field_names):
+        """Configure widgets and build choice tree for a chain."""
+
+        # Build the complete choices tree for embedding
+        choices_tree = {}
+
+        # Determine AJAX URL - use auto-registered one if not specified
+        ajax_url = self.chained_ajax_url or "/__chained_select__/"
+        form_path = self._get_form_path()
+
+        # Check if any field needs AJAX (has choices_callback but no choices_map)
+        needs_ajax = any(
+            isinstance(self.fields[name], ChainedChoiceField)
+            and self.fields[name].choices_callback
+            and not self.fields[name].choices_map
+            for name in field_names
+        )
+
+        for position, field_name in enumerate(field_names):
+            field = self.fields[field_name]
+            parent_field = field_names[position - 1] if position > 0 else None
+
+            # Store chain info on field
+            field._chain_name = chain_name
+            field._chain_position = position
+
+            # Configure widget
+            widget = field.widget
+            if not isinstance(widget, ChainedSelect):
+                # Wrap in ChainedSelect
+                widget = ChainedSelect(
+                    choices=field.choices,
+                    attrs=widget.attrs if hasattr(widget, "attrs") else {},
+                )
+                field.widget = widget
+
+            widget.chain_name = chain_name
+            widget.chain_position = position
+            widget.parent_field = parent_field
+            widget.empty_label = getattr(field, "empty_label", "---------")
+
+            # Set AJAX URL and form path if this field needs AJAX
+            if needs_ajax and isinstance(field, ChainedChoiceField) and field.choices_callback:
+                widget.ajax_url = ajax_url
+                widget.form_path = form_path
+
+            # Build choices tree for this field
+            if isinstance(field, ChainedChoiceField):
+                if position == 0:
+                    # Root field - store its choices
+                    choices_tree["_root"] = [
+                        {"value": str(v), "label": str(l)} for v, l in field.choices if v != ""
+                    ]
+                    choices_tree["_root_field"] = field_name
+
+                # Get choices map for children to use (for embedded mode)
+                if field.choices_map:
+                    for parent_val, child_choices in field.choices_map.items():
+                        key = f"{field_name}:{parent_val}"
+                        choices_tree[key] = [
+                            {"value": str(v), "label": str(l)} for v, l in child_choices
+                        ]
+
+        # Attach tree to root widget for embedding
+        root_field = self.fields[field_names[0]]
+        root_field.widget.choices_tree = choices_tree
+
+        # Populate choices for bound forms / initial data
+        self._populate_initial_choices(field_names)
+
+    def _populate_initial_choices(self, field_names):
+        """Populate child fields based on initial/bound data."""
+        for position, field_name in enumerate(field_names):
+            if position == 0:
+                continue
+
+            field = self.fields[field_name]
+            parent_field_name = field_names[position - 1]
+
+            # Get parent value
+            parent_value = None
+            if self.is_bound:
+                parent_value = self.data.get(self.add_prefix(parent_field_name))
+            elif self.initial:
+                parent_value = self.initial.get(parent_field_name)
+
+            # Handle model instances - get the pk
+            if hasattr(parent_value, "pk"):
+                parent_value = parent_value.pk
+
+            if parent_value and isinstance(field, ChainedChoiceField):
+                choices = field.get_choices_for_parent(parent_value)
+                field.choices = choices
+                field.widget.choices = choices
+
+    def clean(self):
+        """Validate chained field consistency."""
+        cleaned_data = super().clean()
+
+        # Find all chains and validate
+        validated_chains = set()
+
+        for field_name, field in self.fields.items():
+            if not isinstance(field, (ChainedChoiceField, ChainedModelChoiceField)):
+                continue
+            if not field.parent_field:
+                continue
+
+            chain_name = getattr(field, "_chain_name", None)
+            if chain_name in validated_chains:
+                continue
+
+            # Validate this field against its parent
+            value = cleaned_data.get(field_name)
+            parent_value = cleaned_data.get(field.parent_field)
+
+            # Handle model instances - get the pk for comparison
+            if hasattr(parent_value, "pk"):
+                parent_value = parent_value.pk
+
+            if value and isinstance(field, ChainedChoiceField):
+                valid_choices = field.get_choices_for_parent(parent_value)
+                valid_values = [str(c[0]) for c in valid_choices]
+
+                if str(value) not in valid_values:
+                    self.add_error(
+                        field_name,
+                        ValidationError(
+                            f"Invalid selection for the chosen {field.parent_field}.",
+                            code="invalid_choice",
+                        ),
+                    )
+
+        return cleaned_data

--- a/widgets/tests/__init__.py
+++ b/widgets/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for the widgets app.
+"""

--- a/widgets/tests/test_chained_select.py
+++ b/widgets/tests/test_chained_select.py
@@ -1,0 +1,366 @@
+"""
+Tests for the widgets app chained select functionality.
+"""
+
+from django import forms
+from django.test import RequestFactory, TestCase
+
+from widgets import (
+    ChainedChoiceField,
+    ChainedModelChoiceField,
+    ChainedSelect,
+    ChainedSelectMixin,
+    ChainedSelectMultiple,
+)
+
+
+class TestChainedChoiceField(TestCase):
+    """Tests for ChainedChoiceField."""
+
+    def test_field_with_choices(self):
+        """Test basic field with direct choices."""
+        field = ChainedChoiceField(
+            choices=[("a", "Option A"), ("b", "Option B")],
+        )
+        # Empty choice is prepended
+        self.assertEqual(len(field.choices), 3)
+        self.assertEqual(field.choices[0][0], "")
+
+    def test_field_with_parent(self):
+        """Test child field with parent_field."""
+        field = ChainedChoiceField(
+            parent_field="parent",
+            choices_map={
+                "a": [("a1", "A1"), ("a2", "A2")],
+                "b": [("b1", "B1")],
+            },
+        )
+        self.assertEqual(field.parent_field, "parent")
+        self.assertEqual(len(field.choices_map["a"]), 2)
+
+    def test_get_choices_for_parent(self):
+        """Test getting choices based on parent value."""
+        field = ChainedChoiceField(
+            parent_field="parent",
+            choices_map={
+                "a": [("a1", "A1"), ("a2", "A2")],
+                "b": [("b1", "B1")],
+            },
+        )
+        choices = field.get_choices_for_parent("a")
+        # Should include empty choice plus mapped choices
+        self.assertEqual(len(choices), 3)
+        self.assertEqual(choices[1][0], "a1")
+
+    def test_get_choices_for_parent_empty(self):
+        """Test getting choices with no parent value."""
+        field = ChainedChoiceField(
+            parent_field="parent",
+            choices_map={"a": [("a1", "A1")]},
+        )
+        choices = field.get_choices_for_parent("")
+        # Only empty choice
+        self.assertEqual(len(choices), 1)
+
+    def test_valid_value_root_field(self):
+        """Test validation for root field."""
+        field = ChainedChoiceField(
+            choices=[("a", "Option A"), ("b", "Option B")],
+        )
+        self.assertTrue(field.valid_value("a"))
+        self.assertTrue(field.valid_value(""))
+        self.assertFalse(field.valid_value("invalid"))
+
+    def test_valid_value_child_field(self):
+        """Test validation for child field defers to form level."""
+        field = ChainedChoiceField(
+            parent_field="parent",
+            choices_map={"a": [("a1", "A1")]},
+        )
+        # Child fields always return True for non-empty values
+        self.assertTrue(field.valid_value("any_value"))
+
+    def test_choices_callback(self):
+        """Test field with choices_callback."""
+
+        def get_choices(parent_value):
+            if parent_value == "x":
+                return [("x1", "X1")]
+            return []
+
+        field = ChainedChoiceField(
+            parent_field="parent",
+            choices_callback=get_choices,
+        )
+        choices = field.get_choices_for_parent("x")
+        self.assertEqual(len(choices), 2)  # empty + x1
+
+
+class TestChainedSelect(TestCase):
+    """Tests for ChainedSelect widget."""
+
+    def test_widget_attributes(self):
+        """Test widget adds correct data attributes."""
+        widget = ChainedSelect(
+            chain_name="test_chain",
+            chain_position=1,
+            parent_field="parent",
+        )
+        attrs = widget.build_attrs({})
+        self.assertEqual(attrs["data-chained-select"], "true")
+        self.assertEqual(attrs["data-chain-name"], "test_chain")
+        self.assertEqual(attrs["data-chain-position"], "1")
+        self.assertEqual(attrs["data-parent-field"], "parent")
+
+    def test_widget_css_class(self):
+        """Test widget adds CSS class."""
+        widget = ChainedSelect()
+        attrs = widget.build_attrs({})
+        self.assertIn("chained-select", attrs["class"])
+
+    def test_widget_render_includes_script(self):
+        """Test widget renders JavaScript."""
+        ChainedSelect.reset_js_rendered()
+        widget = ChainedSelect(
+            chain_name="test",
+            chain_position=0,
+            choices=[("a", "A")],
+        )
+        html = widget.render("test_field", "a")
+        self.assertIn("data-chained-select-js", html)
+        self.assertIn("ChainedSelectManager", html)
+
+    def test_widget_render_choices_tree(self):
+        """Test widget embeds choices tree for root position."""
+        ChainedSelect.reset_js_rendered()
+        widget = ChainedSelect(
+            chain_name="test",
+            chain_position=0,
+            choices_tree={"key": [{"value": "1", "label": "One"}]},
+            choices=[("a", "A")],
+        )
+        html = widget.render("test_field", "a")
+        self.assertIn("data-chain-tree", html)
+
+    def test_widget_js_rendered_once(self):
+        """Test JavaScript is only rendered once."""
+        ChainedSelect.reset_js_rendered()
+        widget1 = ChainedSelect(chain_name="test1", chain_position=0, choices=[])
+        widget2 = ChainedSelect(chain_name="test2", chain_position=0, choices=[])
+
+        html1 = widget1.render("field1", "")
+        html2 = widget2.render("field2", "")
+
+        # JS should be in first render only
+        self.assertIn("data-chained-select-js", html1)
+        self.assertNotIn("data-chained-select-js", html2)
+
+
+class TestChainedSelectMultiple(TestCase):
+    """Tests for ChainedSelectMultiple widget."""
+
+    def test_multiple_select_inherits_chained_select(self):
+        """Test ChainedSelectMultiple inherits from ChainedSelect."""
+        widget = ChainedSelectMultiple()
+        self.assertIsInstance(widget, ChainedSelect)
+
+
+class TestChainedSelectMixin(TestCase):
+    """Tests for ChainedSelectMixin form mixin."""
+
+    def test_simple_chain_setup(self):
+        """Test mixin sets up simple parent-child chain."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            parent = ChainedChoiceField(
+                choices=[("a", "A"), ("b", "B")],
+            )
+            child = ChainedChoiceField(
+                parent_field="parent",
+                choices_map={
+                    "a": [("a1", "A1")],
+                    "b": [("b1", "B1")],
+                },
+            )
+
+        form = TestForm()
+        # Check chain is configured
+        self.assertIsNotNone(form.fields["parent"]._chain_name)
+        self.assertEqual(form.fields["parent"]._chain_position, 0)
+        self.assertEqual(form.fields["child"]._chain_position, 1)
+
+    def test_three_level_chain(self):
+        """Test mixin handles three-level chain."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            level1 = ChainedChoiceField(choices=[("x", "X")])
+            level2 = ChainedChoiceField(
+                parent_field="level1",
+                choices_map={"x": [("x1", "X1")]},
+            )
+            level3 = ChainedChoiceField(
+                parent_field="level2",
+                choices_map={"x1": [("x1a", "X1A")]},
+            )
+
+        form = TestForm()
+        self.assertEqual(form.fields["level1"]._chain_position, 0)
+        self.assertEqual(form.fields["level2"]._chain_position, 1)
+        self.assertEqual(form.fields["level3"]._chain_position, 2)
+
+    def test_bound_form_populates_choices(self):
+        """Test bound form populates child choices from parent value."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            parent = ChainedChoiceField(
+                choices=[("a", "A"), ("b", "B")],
+            )
+            child = ChainedChoiceField(
+                parent_field="parent",
+                choices_map={
+                    "a": [("a1", "A1"), ("a2", "A2")],
+                    "b": [("b1", "B1")],
+                },
+            )
+
+        form = TestForm(data={"parent": "a", "child": "a1"})
+        # Child should have parent "a" choices
+        child_values = [c[0] for c in form.fields["child"].choices]
+        self.assertIn("a1", child_values)
+        self.assertIn("a2", child_values)
+
+    def test_form_validation_valid_selection(self):
+        """Test form validates consistent selections."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            parent = ChainedChoiceField(
+                choices=[("a", "A"), ("b", "B")],
+            )
+            child = ChainedChoiceField(
+                parent_field="parent",
+                choices_map={
+                    "a": [("a1", "A1")],
+                    "b": [("b1", "B1")],
+                },
+            )
+
+        form = TestForm(data={"parent": "a", "child": "a1"})
+        self.assertTrue(form.is_valid())
+
+    def test_form_validation_invalid_selection(self):
+        """Test form rejects inconsistent selections."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            parent = ChainedChoiceField(
+                choices=[("a", "A"), ("b", "B")],
+            )
+            child = ChainedChoiceField(
+                parent_field="parent",
+                choices_map={
+                    "a": [("a1", "A1")],
+                    "b": [("b1", "B1")],
+                },
+            )
+
+        form = TestForm(data={"parent": "a", "child": "b1"})
+        self.assertFalse(form.is_valid())
+        self.assertIn("child", form.errors)
+
+    def test_initial_data_populates_choices(self):
+        """Test form with initial data populates child choices."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            parent = ChainedChoiceField(
+                choices=[("a", "A"), ("b", "B")],
+            )
+            child = ChainedChoiceField(
+                parent_field="parent",
+                choices_map={
+                    "a": [("a1", "A1")],
+                    "b": [("b1", "B1")],
+                },
+            )
+
+        form = TestForm(initial={"parent": "b"})
+        child_values = [c[0] for c in form.fields["child"].choices]
+        self.assertIn("b1", child_values)
+
+    def test_multiple_independent_chains(self):
+        """Test form with multiple independent chains."""
+
+        class TestForm(ChainedSelectMixin, forms.Form):
+            # First chain
+            color = ChainedChoiceField(choices=[("red", "Red")])
+            shade = ChainedChoiceField(
+                parent_field="color",
+                choices_map={"red": [("dark", "Dark")]},
+            )
+            # Second chain
+            size = ChainedChoiceField(choices=[("small", "Small")])
+            detail = ChainedChoiceField(
+                parent_field="size",
+                choices_map={"small": [("tiny", "Tiny")]},
+            )
+
+        form = TestForm()
+        # Should have two separate chains
+        self.assertNotEqual(
+            form.fields["color"]._chain_name,
+            form.fields["size"]._chain_name,
+        )
+
+
+class TestWidgetsImports(TestCase):
+    """Tests that the widgets package exports correctly."""
+
+    def test_all_exports_available(self):
+        """Test all expected exports are available from widgets package."""
+        from widgets import (
+            ChainedChoiceField,
+            ChainedModelChoiceField,
+            ChainedSelect,
+            ChainedSelectAjaxView,
+            ChainedSelectMixin,
+            ChainedSelectMultiple,
+            auto_chained_ajax_view,
+            make_ajax_view,
+        )
+
+        # Just verify imports work
+        self.assertIsNotNone(ChainedChoiceField)
+        self.assertIsNotNone(ChainedModelChoiceField)
+        self.assertIsNotNone(ChainedSelect)
+        self.assertIsNotNone(ChainedSelectMultiple)
+        self.assertIsNotNone(ChainedSelectMixin)
+        self.assertIsNotNone(ChainedSelectAjaxView)
+        self.assertIsNotNone(auto_chained_ajax_view)
+        self.assertIsNotNone(make_ajax_view)
+
+
+class TestBackwardCompatibility(TestCase):
+    """Tests for backward compatibility with chained_select package."""
+
+    def test_chained_select_import_works(self):
+        """Test importing from chained_select still works (with deprecation warning)."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # This should work but emit a deprecation warning
+            from chained_select import ChainedChoiceField as OldField
+
+            self.assertIsNotNone(OldField)
+            # Should have warning
+            self.assertTrue(any("deprecated" in str(warning.message).lower() for warning in w))
+
+    def test_both_imports_return_same_class(self):
+        """Test old and new imports return the same class."""
+        import warnings
+
+        from widgets import ChainedChoiceField as NewField
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            from chained_select import ChainedChoiceField as OldField
+
+        self.assertIs(NewField, OldField)

--- a/widgets/utils.py
+++ b/widgets/utils.py
@@ -1,0 +1,28 @@
+"""
+Utility functions for the widgets app.
+
+Shared helpers for response handling and choice normalization.
+"""
+
+
+def normalize_choices(choices):
+    """
+    Normalize choices to a list of {value, label} dicts.
+
+    Args:
+        choices: An iterable of choices. Can be:
+            - List of (value, label) tuples
+            - QuerySet of model instances
+            - List of model instances
+
+    Returns:
+        List of dicts with 'value' and 'label' keys
+    """
+    choices_list = []
+    for item in choices:
+        if isinstance(item, (list, tuple)) and len(item) >= 2:
+            choices_list.append({"value": str(item[0]), "label": str(item[1])})
+        elif hasattr(item, "pk"):
+            # Model instance
+            choices_list.append({"value": str(item.pk), "label": str(item)})
+    return choices_list

--- a/widgets/views.py
+++ b/widgets/views.py
@@ -1,0 +1,154 @@
+"""
+Views for Widgets AJAX endpoints.
+
+Includes an auto-discovery view that dynamically imports form classes,
+so no manual URL configuration is needed.
+"""
+
+import importlib
+
+from django.http import JsonResponse
+from django.views import View
+
+from .utils import normalize_choices
+
+
+def auto_chained_ajax_view(request):
+    """
+    Auto-discovery AJAX view that dynamically imports the form class.
+
+    This is automatically registered at /__chained_select__/
+
+    Query parameters:
+        - form: Full path to form class (e.g., 'myapp.forms.MageFactionForm')
+        - field: Name of the field to get choices for
+        - parent_value: Value of the parent field
+    """
+    form_path = request.GET.get("form")
+    field_name = request.GET.get("field")
+    parent_value = request.GET.get("parent_value")
+
+    if not form_path or not field_name:
+        return JsonResponse({"error": "Missing required parameters: form, field"}, status=400)
+
+    try:
+        # Parse form path: 'myapp.forms.MageFactionForm'
+        module_path, class_name = form_path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        form_class = getattr(module, class_name)
+
+        # Instantiate form to access field configuration
+        form = form_class()
+        field = form.fields.get(field_name)
+
+        if not field:
+            return JsonResponse({"error": f'Field "{field_name}" not found on form'}, status=400)
+
+        # Get the choices callback
+        choices_callback = getattr(field, "choices_callback", None)
+
+        if not choices_callback:
+            return JsonResponse(
+                {"error": f'Field "{field_name}" has no choices_callback'}, status=400
+            )
+
+        # Call the callback to get choices
+        choices = choices_callback(parent_value)
+
+        # Normalize to list of {value, label} dicts
+        choices_list = normalize_choices(choices)
+
+        return JsonResponse({"choices": choices_list})
+
+    except (ValueError, ImportError, AttributeError) as e:
+        return JsonResponse({"error": f"Could not load form: {e}"}, status=400)
+    except Exception as e:
+        return JsonResponse({"error": str(e)}, status=500)
+
+
+class ChainedSelectAjaxView(View):
+    """
+    Generic AJAX view for chained select choices.
+
+    Override get_choices() to provide choices based on the field and parent value.
+
+    Example:
+        class MyAjaxView(ChainedSelectAjaxView):
+            def get_choices(self, field_name, parent_value, request):
+                if field_name == 'faction':
+                    return Faction.objects.filter(
+                        affiliation_id=parent_value
+                    ).values_list('id', 'name')
+                return []
+    """
+
+    def get(self, request):
+        field_name = request.GET.get("field")
+        parent_value = request.GET.get("parent_value")
+
+        if not field_name:
+            return JsonResponse({"error": "field parameter required"}, status=400)
+
+        try:
+            choices = self.get_choices(field_name, parent_value, request)
+
+            # Normalize to list of {value, label} dicts
+            choices_list = normalize_choices(choices)
+
+            return JsonResponse({"choices": choices_list})
+
+        except Exception as e:
+            return JsonResponse({"error": str(e)}, status=500)
+
+    def get_choices(self, field_name, parent_value, request):
+        """Override this to return choices for the given field and parent."""
+        return []
+
+
+def make_ajax_view(choices_config):
+    """
+    Factory function to create an AJAX view from a config dict.
+
+    Args:
+        choices_config: Dict mapping field names to:
+            - A callable(parent_value) that returns choices
+            - A dict with 'model', 'parent_field' for simple FK lookups
+
+    Example:
+        ajax_view = make_ajax_view({
+            'faction': lambda parent: Faction.objects.filter(affiliation=parent),
+            'subfaction': {
+                'model': Subfaction,
+                'parent_field': 'faction_id',
+            },
+        })
+
+        # urls.py
+        path('ajax/chained/', ajax_view, name='chained_ajax'),
+    """
+
+    class ConfiguredAjaxView(ChainedSelectAjaxView):
+        def get_choices(self, field_name, parent_value, request):
+            if field_name not in choices_config:
+                return []
+
+            config = choices_config[field_name]
+
+            if callable(config):
+                result = config(parent_value)
+            elif isinstance(config, dict):
+                model = config["model"]
+                parent_field = config.get("parent_field", "parent_id")
+                qs = model.objects.filter(**{parent_field: parent_value})
+                return [(obj.pk, str(obj)) for obj in qs]
+            else:
+                return []
+
+            # Handle querysets
+            if hasattr(result, "values_list"):
+                return list(result.values_list("pk", flat=False))
+            if hasattr(result, "__iter__"):
+                return list(result)
+            return []
+
+    return ConfiguredAjaxView.as_view()

--- a/widgets/widgets/__init__.py
+++ b/widgets/widgets/__init__.py
@@ -1,0 +1,10 @@
+"""
+Custom widget classes for the widgets app.
+"""
+
+from .chained import ChainedSelect, ChainedSelectMultiple
+
+__all__ = [
+    "ChainedSelect",
+    "ChainedSelectMultiple",
+]

--- a/widgets/widgets/chained.py
+++ b/widgets/widgets/chained.py
@@ -1,0 +1,323 @@
+"""
+Chained Select Widget for Django
+
+A widget that renders dependent/cascading dropdowns with zero configuration.
+Just render the field in your template - no {{ form.media }} needed.
+"""
+
+import json
+
+from django import forms
+from django.utils.safestring import mark_safe
+
+# The JavaScript code, embedded directly so no static files or {{ form.media }} needed
+CHAINED_SELECT_JS = """
+(function() {
+    'use strict';
+
+    // Prevent double-initialization
+    if (window.ChainedSelect) return;
+
+    class ChainedSelectManager {
+        constructor() {
+            this.chains = {};
+            this.choiceTrees = {};
+            this.initialized = new WeakSet();
+        }
+
+        init() {
+            this.loadEmbeddedTrees();
+            document.querySelectorAll('[data-chained-select]').forEach(select => {
+                if (!this.initialized.has(select)) {
+                    this.registerSelect(select);
+                    this.initialized.add(select);
+                }
+            });
+        }
+
+        loadEmbeddedTrees() {
+            document.querySelectorAll('script[data-chain-tree]').forEach(script => {
+                const chainName = script.dataset.chainTree;
+                try {
+                    this.choiceTrees[chainName] = JSON.parse(script.textContent);
+                } catch (e) {
+                    console.error(`ChainedSelect: Failed to parse tree for ${chainName}:`, e);
+                }
+            });
+        }
+
+        registerSelect(select) {
+            const chainName = select.dataset.chainName;
+            const position = parseInt(select.dataset.chainPosition, 10);
+            const parentFieldName = select.dataset.parentField;
+            const ajaxUrl = select.dataset.ajaxUrl;
+            const formPath = select.dataset.formPath;
+            const emptyLabel = select.dataset.emptyLabel || '---------';
+
+            if (!chainName) return;
+
+            if (!this.chains[chainName]) {
+                this.chains[chainName] = { selects: {}, order: [], formPath: formPath };
+            }
+
+            const chain = this.chains[chainName];
+            const fieldName = this.getFieldName(select);
+
+            if (formPath) chain.formPath = formPath;
+
+            chain.selects[fieldName] = {
+                element: select,
+                position: position,
+                parentFieldName: parentFieldName,
+                ajaxUrl: ajaxUrl,
+                formPath: formPath,
+                emptyLabel: emptyLabel
+            };
+
+            chain.order = Object.keys(chain.selects).sort((a, b) =>
+                chain.selects[a].position - chain.selects[b].position
+            );
+
+            select.addEventListener('change', () => this.handleChange(chainName, fieldName));
+        }
+
+        getFieldName(select) {
+            const name = select.name || select.id;
+            const parts = name.split('-');
+            return parts[parts.length - 1];
+        }
+
+        handleChange(chainName, fieldName) {
+            const chain = this.chains[chainName];
+            const changedInfo = chain.selects[fieldName];
+            const changedPosition = changedInfo.position;
+            const newValue = changedInfo.element.value;
+
+            const children = chain.order.filter(name =>
+                chain.selects[name].position > changedPosition
+            );
+
+            if (children.length === 0) return;
+
+            this.updateChildSelect(chainName, children[0], fieldName, newValue);
+            children.slice(1).forEach(childName => this.resetSelect(chainName, childName));
+        }
+
+        async updateChildSelect(chainName, childFieldName, parentFieldName, parentValue) {
+            const chain = this.chains[chainName];
+            const childInfo = chain.selects[childFieldName];
+            const select = childInfo.element;
+            const tree = this.choiceTrees[chainName];
+
+            if (tree && !childInfo.ajaxUrl) {
+                const key = `${parentFieldName}:${parentValue}`;
+                const choices = tree[key] || [];
+                this.setOptions(select, childInfo.emptyLabel, choices);
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+                return;
+            }
+
+            if (!childInfo.ajaxUrl) {
+                this.resetSelect(chainName, childFieldName);
+                return;
+            }
+
+            select.disabled = true;
+            this.setOptions(select, 'Loading...', []);
+
+            if (!parentValue) {
+                this.resetSelect(chainName, childFieldName);
+                return;
+            }
+
+            try {
+                const url = new URL(childInfo.ajaxUrl, window.location.origin);
+                url.searchParams.set('field', childFieldName);
+                url.searchParams.set('parent_value', parentValue);
+
+                const formPath = childInfo.formPath || chain.formPath;
+                if (formPath) url.searchParams.set('form', formPath);
+
+                const response = await fetch(url, {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+                });
+
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+                const data = await response.json();
+                if (data.error) throw new Error(data.error);
+
+                this.setOptions(select, childInfo.emptyLabel, data.choices || []);
+                select.disabled = false;
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+
+            } catch (error) {
+                console.error('ChainedSelect error:', error);
+                this.setOptions(select, 'Error loading', []);
+                select.disabled = false;
+            }
+        }
+
+        resetSelect(chainName, fieldName) {
+            const chain = this.chains[chainName];
+            const info = chain.selects[fieldName];
+            const select = info.element;
+            this.setOptions(select, info.emptyLabel, []);
+            select.disabled = false;
+            select.value = '';
+        }
+
+        setOptions(select, emptyLabel, choices) {
+            select.innerHTML = '';
+            const emptyOpt = document.createElement('option');
+            emptyOpt.value = '';
+            emptyOpt.textContent = emptyLabel;
+            select.appendChild(emptyOpt);
+
+            choices.forEach(choice => {
+                const option = document.createElement('option');
+                option.value = choice.value;
+                option.textContent = choice.label;
+                select.appendChild(option);
+            });
+        }
+
+        setValue(chainName, fieldName, value) {
+            const chain = this.chains[chainName];
+            if (!chain || !chain.selects[fieldName]) return;
+            const select = chain.selects[fieldName].element;
+            select.value = value;
+            this.handleChange(chainName, fieldName);
+        }
+
+        getValues(chainName) {
+            const chain = this.chains[chainName];
+            if (!chain) return {};
+            const values = {};
+            chain.order.forEach(fieldName => {
+                values[fieldName] = chain.selects[fieldName].element.value;
+            });
+            return values;
+        }
+    }
+
+    window.ChainedSelect = new ChainedSelectManager();
+
+    const init = () => window.ChainedSelect.init();
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // Re-init for htmx/Turbo
+    document.addEventListener('htmx:afterSwap', init);
+    document.addEventListener('turbo:render', init);
+    document.addEventListener('turbo:frame-load', init);
+})();
+"""
+
+
+class ChainedSelect(forms.Select):
+    """
+    A Select widget for cascading/dependent dropdowns.
+
+    Self-contained: automatically injects JavaScript when rendered.
+    No {{ form.media }} or static file configuration needed.
+    """
+
+    # Track if JS has been rendered in this request
+    _js_rendered = False
+
+    def __init__(
+        self,
+        chain_name=None,
+        chain_position=0,
+        parent_field=None,
+        choices_tree=None,
+        ajax_url=None,
+        form_path=None,
+        empty_label="---------",
+        attrs=None,
+        choices=(),
+    ):
+        self.chain_name = chain_name
+        self.chain_position = chain_position
+        self.parent_field = parent_field
+        self.choices_tree = choices_tree
+        self.ajax_url = ajax_url
+        self.form_path = form_path
+        self.empty_label = empty_label
+
+        super().__init__(attrs=attrs, choices=choices)
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+
+        attrs["data-chained-select"] = "true"
+
+        if self.chain_name:
+            attrs["data-chain-name"] = self.chain_name
+        attrs["data-chain-position"] = str(self.chain_position)
+
+        if self.parent_field:
+            attrs["data-parent-field"] = self.parent_field
+
+        if self.ajax_url:
+            attrs["data-ajax-url"] = self.ajax_url
+
+        if self.form_path:
+            attrs["data-form-path"] = self.form_path
+
+        attrs["data-empty-label"] = self.empty_label
+
+        existing = attrs.get("class", "")
+        attrs["class"] = f"{existing} chained-select".strip()
+
+        return attrs
+
+    def render(self, name, value, attrs=None, renderer=None):
+        # Render the standard select
+        select_html = super().render(name, value, attrs, renderer)
+
+        parts = [select_html]
+
+        # Inject JavaScript (only once per page)
+        # We use a simple marker comment to detect if already injected
+        if not ChainedSelect._js_rendered:
+            ChainedSelect._js_rendered = True
+            parts.append(f"<script data-chained-select-js>{CHAINED_SELECT_JS}</script>")
+
+        # If we have a choices tree and this is the root, embed it
+        if self.choices_tree and self.chain_position == 0 and self.chain_name:
+            tree_json = json.dumps(self.choices_tree)
+            parts.append(
+                f'<script type="application/json" data-chain-tree="{self.chain_name}">'
+                f"{tree_json}</script>"
+            )
+
+        # Add a micro-script to re-initialize (handles dynamic/AJAX-loaded forms)
+        parts.append("<script>" "if(window.ChainedSelect)window.ChainedSelect.init();" "</script>")
+
+        return mark_safe("".join(parts))
+
+    @classmethod
+    def reset_js_rendered(cls):
+        """Reset the JS rendered flag. Called automatically between requests."""
+        cls._js_rendered = False
+
+
+class ChainedSelectMultiple(ChainedSelect, forms.SelectMultiple):
+    """Multiple-select variant of ChainedSelect."""
+
+    pass
+
+
+# Reset flag between requests using Django's request_finished signal
+try:
+    from django.core.signals import request_finished
+
+    request_finished.connect(lambda sender, **kwargs: ChainedSelect.reset_js_rendered())
+except ImportError:
+    pass


### PR DESCRIPTION
Addresses issue #1327: Create a centralized widgets app for reusable form components.

Changes:
- Create new widgets/ app with organized structure:
  - fields/ for custom form fields (ChainedChoiceField, ChainedModelChoiceField)
  - widgets/ for widget classes (ChainedSelect, ChainedSelectMultiple)
  - mixins/ for form mixins (ChainedSelectMixin)
  - views.py for AJAX endpoints
  - utils.py for shared helpers
- Add comprehensive test suite for chained select functionality
- Update chained_select as backward compatibility layer with deprecation warning
- Update all imports across codebase to use new widgets package
- Register widgets app in INSTALLED_APPS (before chained_select)

The chained_select package is now deprecated but continues to work for existing code. Developers should migrate to:
  from widgets import ChainedChoiceField, ChainedSelectMixin

Closes #1327