### PR TITLE
Add ConditionalFieldsMixin for declarative form field visibility

### DIFF
--- a/locations/forms/mage/chantry.py
+++ b/locations/forms/mage/chantry.py
@@ -7,12 +7,13 @@ from locations.models.mage.chantry import ChantryBackgroundRating
 from widgets import (
     ChainedChoiceField,
     ChainedSelectMixin,
+    ConditionalFieldsMixin,
     CreateOrSelectField,
     CreateOrSelectMixin,
 )
 
 
-class ChantryPointForm(ChainedSelectMixin, forms.Form):
+class ChantryPointForm(ChainedSelectMixin, ConditionalFieldsMixin, forms.Form):
     INTEGRATED_EFFECTS_NUMBERS = {
         0: 0,
         1: 4,
@@ -31,6 +32,15 @@ class ChantryPointForm(ChainedSelectMixin, forms.Form):
     example = ChainedChoiceField(parent_field="category", choices_map={}, required=False)
     note = forms.CharField(max_length=300, required=False)
     display_alt_name = forms.BooleanField(required=False)
+
+    # Conditional field visibility rules
+    conditional_fields = {
+        "category": {
+            "example": {"exclude": ["-----", "Integrated Effects"]},
+            "note": {"values": ["New Background"]},
+            "display_alt_name": {"values": ["New Background"]},
+        }
+    }
 
     def __init__(self, *args, **kwargs):
         pk = kwargs.pop("pk")

--- a/locations/templates/locations/mage/chantry/point_spend_form.html
+++ b/locations/templates/locations/mage/chantry/point_spend_form.html
@@ -26,37 +26,6 @@
     <div class="col-sm">{{ form.category }}</div>
     <div class="col-sm d-none" id="example_wrap">{{ form.example }}</div>
     <div class="col-sm d-none" id="note_wrap">{{ form.note }}</div>
-    <div class="col-sm d-none" id="alt_name_wrap">Alternate Name? {{ form.display_alt_name }}</div>
+    <div class="col-sm d-none" id="display_alt_name_wrap">Alternate Name? {{ form.display_alt_name }}</div>
 </div>
-<script>
-    document.addEventListener("DOMContentLoaded", function() {
-        const categorySelectMenu = document.getElementById("id_category");
-        const exampleElement = document.getElementById("example_wrap");
-        const noteElement = document.getElementById("note_wrap");
-        const altNameElement = document.getElementById("alt_name_wrap");
-
-        function updateVisibility() {
-            const value = categorySelectMenu.value;
-
-            // Reset all to hidden
-            exampleElement.classList.add("d-none");
-            noteElement.classList.add("d-none");
-            altNameElement.classList.add("d-none");
-
-            // Show fields based on category
-            if (!["-----", "Integrated Effects"].includes(value)) {
-                exampleElement.classList.remove("d-none");
-            }
-
-            if (value === "New Background") {
-                noteElement.classList.remove("d-none");
-                altNameElement.classList.remove("d-none");
-            }
-        }
-
-        categorySelectMenu.addEventListener("change", updateVisibility);
-
-        // Initial visibility on page load
-        updateVisibility();
-    });
-</script>
+{{ form.conditional_fields_script }}

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -55,6 +55,7 @@ JavaScript is auto-injected. No {{ form.media }} needed!
 from .fields.chained import ChainedChoiceField, ChainedModelChoiceField
 from .fields.create_or_select import CreateOrSelectField, CreateOrSelectModelChoiceField
 from .mixins.chained import ChainedSelectMixin
+from .mixins.conditional import ConditionalFieldsMixin
 from .mixins.create_or_select import CreateOrSelectMixin
 from .views import ChainedSelectAjaxView, auto_chained_ajax_view, make_ajax_view
 from .widgets.chained import ChainedSelect, ChainedSelectMultiple
@@ -72,6 +73,7 @@ __all__ = [
     "CreateOrSelectModelChoiceField",
     # Mixins
     "ChainedSelectMixin",
+    "ConditionalFieldsMixin",
     "CreateOrSelectMixin",
     # Views
     "ChainedSelectAjaxView",

--- a/widgets/mixins/__init__.py
+++ b/widgets/mixins/__init__.py
@@ -3,7 +3,9 @@ Reusable form and formset mixins for the widgets app.
 """
 
 from .chained import ChainedSelectMixin
+from .conditional import ConditionalFieldsMixin
 
 __all__ = [
     "ChainedSelectMixin",
+    "ConditionalFieldsMixin",
 ]

--- a/widgets/mixins/conditional.py
+++ b/widgets/mixins/conditional.py
@@ -1,0 +1,301 @@
+"""
+Conditional Fields Form Mixin
+
+Mixin for forms with conditional field visibility based on other field values.
+"""
+
+import json
+
+from django.utils.safestring import mark_safe
+
+# JavaScript for conditional field visibility - embedded directly
+CONDITIONAL_FIELDS_JS = """
+(function() {
+    'use strict';
+
+    // Prevent double-initialization
+    if (window.ConditionalFields) return;
+
+    class ConditionalFieldsManager {
+        constructor() {
+            this.initialized = new WeakSet();
+        }
+
+        init() {
+            // Find all elements with conditional rules
+            document.querySelectorAll('[data-conditional-rules]').forEach(rulesElement => {
+                if (!this.initialized.has(rulesElement)) {
+                    this.setupConditionalFields(rulesElement);
+                    this.initialized.add(rulesElement);
+                }
+            });
+        }
+
+        setupConditionalFields(rulesElement) {
+            const rules = JSON.parse(rulesElement.dataset.conditionalRules);
+            const prefix = rulesElement.dataset.formPrefix || '';
+
+            // Find the search context: closest form, parent with data-conditional-rules, or document
+            let searchContext = rulesElement.closest('form');
+            if (!searchContext) {
+                searchContext = rulesElement.parentElement || document;
+            }
+
+            // Set up each controller
+            Object.keys(rules).forEach(controllerName => {
+                const controllerRules = rules[controllerName];
+                const controller = this.findField(searchContext, controllerName, prefix);
+
+                if (!controller) {
+                    console.warn(`ConditionalFields: Controller '${controllerName}' not found`);
+                    return;
+                }
+
+                // Initial visibility update
+                this.updateVisibility(controller, controllerRules, searchContext, prefix);
+
+                // Add change listener
+                controller.addEventListener('change', () => {
+                    this.updateVisibility(controller, controllerRules, searchContext, prefix);
+                });
+            });
+        }
+
+        findField(context, fieldName, prefix) {
+            // Handle formset prefixes
+            const fullName = prefix ? `${prefix}-${fieldName}` : fieldName;
+            const root = context === document ? document : context;
+
+            // Try by ID first (Django convention: id_fieldname)
+            let field = root.querySelector(`#id_${fullName}`);
+            if (field) return field;
+
+            // Try by name
+            field = root.querySelector(`[name="${fullName}"]`);
+            if (field) return field;
+
+            // Try without prefix
+            field = root.querySelector(`#id_${fieldName}`);
+            if (field) return field;
+
+            return root.querySelector(`[name="${fieldName}"]`);
+        }
+
+        findWrapper(context, fieldName, prefix) {
+            const fullName = prefix ? `${prefix}-${fieldName}` : fieldName;
+            const root = context === document ? document : context;
+
+            // Try multiple wrapper ID patterns
+            let wrapper = root.querySelector(`#${fullName}_wrap`);
+            if (wrapper) return wrapper;
+
+            wrapper = root.querySelector(`#id_${fullName}_wrap`);
+            if (wrapper) return wrapper;
+
+            wrapper = root.querySelector(`#${fieldName}_wrap`);
+            if (wrapper) return wrapper;
+
+            wrapper = root.querySelector(`#id_${fieldName}_wrap`);
+            if (wrapper) return wrapper;
+
+            // Try data attribute
+            wrapper = root.querySelector(`[data-conditional-field="${fieldName}"]`);
+            if (wrapper) return wrapper;
+
+            return root.querySelector(`[data-conditional-field="${fullName}"]`);
+        }
+
+        updateVisibility(controller, rules, context, prefix) {
+            const value = this.getControllerValue(controller);
+
+            Object.keys(rules).forEach(targetName => {
+                const rule = rules[targetName];
+                const wrapper = this.findWrapper(context, targetName, prefix);
+
+                if (!wrapper) {
+                    console.warn(`ConditionalFields: Wrapper for '${targetName}' not found`);
+                    return;
+                }
+
+                const shouldShow = this.evaluateRule(value, rule);
+                this.setVisibility(wrapper, shouldShow);
+            });
+        }
+
+        getControllerValue(controller) {
+            if (controller.type === 'checkbox') {
+                return controller.checked;
+            }
+            return controller.value;
+        }
+
+        evaluateRule(value, rule) {
+            // Handle checkbox boolean
+            if (typeof value === 'boolean') {
+                if (rule.checked !== undefined) {
+                    return value === rule.checked;
+                }
+                return value;
+            }
+
+            // String value rules
+            const strValue = String(value);
+
+            // Exact match with 'values' array
+            if (rule.values !== undefined) {
+                return rule.values.includes(strValue);
+            }
+
+            // Exclude certain values
+            if (rule.exclude !== undefined) {
+                return !rule.exclude.includes(strValue);
+            }
+
+            // Show when not empty
+            if (rule.not_empty !== undefined) {
+                return strValue !== '' && strValue !== rule.not_empty;
+            }
+
+            // Default: show when controller has a value
+            return strValue !== '';
+        }
+
+        setVisibility(element, visible) {
+            if (visible) {
+                element.classList.remove('d-none');
+            } else {
+                element.classList.add('d-none');
+            }
+        }
+    }
+
+    window.ConditionalFields = new ConditionalFieldsManager();
+
+    const init = () => window.ConditionalFields.init();
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // Re-init for htmx/Turbo/dynamic content
+    document.addEventListener('htmx:afterSwap', init);
+    document.addEventListener('turbo:render', init);
+    document.addEventListener('turbo:frame-load', init);
+})();
+"""
+
+
+class ConditionalFieldsMixin:
+    """
+    Mixin for forms with conditional field visibility.
+
+    Automatically shows/hides fields based on another field's value.
+    Define rules in the `conditional_fields` class attribute.
+
+    Usage:
+        class MyForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[...])
+            example = forms.ChoiceField(choices=[...])
+            note = forms.CharField()
+            value = forms.IntegerField()
+
+            conditional_fields = {
+                'category': {  # The controller field
+                    'example': {'exclude': ['-----', 'Willpower']},  # Show except for these
+                    'note': {'values': ['Background']},  # Show only for these values
+                    'value': {'values': ['MeritFlaw']},
+                }
+            }
+
+    Rule types:
+        - {'values': ['A', 'B']}: Show when controller value is 'A' or 'B'
+        - {'exclude': ['X', 'Y']}: Show when controller value is NOT 'X' or 'Y'
+        - {'not_empty': ''}: Show when controller has any non-empty value
+        - {'checked': True}: For checkboxes, show when checked
+        - {'checked': False}: For checkboxes, show when unchecked
+
+    Template:
+        The mixin provides a `conditional_fields_script` property that renders
+        the necessary JavaScript. Wrap your dependent fields in divs with
+        id="fieldname_wrap" and include `d-none` class for initial hidden state.
+
+        Example template:
+            {{ form.category }}
+            <div class="d-none" id="example_wrap">{{ form.example }}</div>
+            <div class="d-none" id="note_wrap">{{ form.note }}</div>
+            {{ form.conditional_fields_script }}
+    """
+
+    # Override in subclasses to define visibility rules
+    conditional_fields = {}
+
+    # Track if JS has been rendered in this request
+    _conditional_js_rendered = False
+
+    def get_conditional_fields(self):
+        """
+        Return the conditional field rules.
+        Override this method for dynamic rules based on form instance.
+        """
+        return self.conditional_fields
+
+    @property
+    def conditional_fields_script(self):
+        """
+        Render the JavaScript for conditional field visibility.
+        Include this in your template after the form fields.
+        """
+        rules = self.get_conditional_fields()
+        if not rules:
+            return ""
+
+        parts = []
+
+        # Inject JS library only once per request
+        if not ConditionalFieldsMixin._conditional_js_rendered:
+            ConditionalFieldsMixin._conditional_js_rendered = True
+            parts.append(f"<script data-conditional-fields-js>{CONDITIONAL_FIELDS_JS}</script>")
+
+        # Get form prefix for formset support
+        prefix = getattr(self, "prefix", "") or ""
+
+        # Create a wrapper div with data attributes
+        rules_json = json.dumps(rules)
+        parts.append(
+            f"<div data-conditional-rules='{rules_json}' "
+            f'data-form-prefix="{prefix}" style="display:none;"></div>'
+        )
+
+        # Add init trigger
+        parts.append(
+            "<script>if(window.ConditionalFields)window.ConditionalFields.init();</script>"
+        )
+
+        return mark_safe("".join(parts))
+
+    def render_conditional_wrapper(self, field_name, content, extra_classes=""):
+        """
+        Helper method to render a field wrapped in a conditional div.
+
+        Usage in template tags or custom form rendering:
+            {{ form.render_conditional_wrapper('example', form.example) }}
+        """
+        classes = f"d-none {extra_classes}".strip()
+        return mark_safe(
+            f'<div id="{field_name}_wrap" class="{classes}" '
+            f'data-conditional-field="{field_name}">{content}</div>'
+        )
+
+
+# Reset flag between requests using Django's request_finished signal
+try:
+    from django.core.signals import request_finished
+
+    def _reset_conditional_js_flag(sender, **kwargs):
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+    request_finished.connect(_reset_conditional_js_flag)
+except ImportError:
+    pass

--- a/widgets/tests/test_conditional_fields.py
+++ b/widgets/tests/test_conditional_fields.py
@@ -1,0 +1,340 @@
+"""
+Tests for the widgets app conditional fields functionality.
+"""
+
+from django import forms
+from django.test import TestCase
+from widgets import ConditionalFieldsMixin
+from widgets.mixins.conditional import CONDITIONAL_FIELDS_JS, ConditionalFieldsMixin
+
+
+class TestConditionalFieldsMixin(TestCase):
+    """Tests for ConditionalFieldsMixin form mixin."""
+
+    def test_mixin_provides_script_property(self):
+        """Test mixin provides conditional_fields_script property."""
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A"), ("b", "B")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"values": ["a"]},
+                }
+            }
+
+        form = TestForm()
+        self.assertTrue(hasattr(form, "conditional_fields_script"))
+
+    def test_script_includes_javascript(self):
+        """Test script output includes JavaScript library."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"values": ["a"]},
+                }
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn("ConditionalFieldsManager", script)
+        self.assertIn("data-conditional-fields-js", script)
+
+    def test_script_includes_rules_json(self):
+        """Test script output includes rules as JSON."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"values": ["a", "b"]},
+                }
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn("data-conditional-rules", script)
+        self.assertIn('"category"', script)
+        self.assertIn('"example"', script)
+        self.assertIn('"values"', script)
+
+    def test_script_js_rendered_once(self):
+        """Test JavaScript library is only rendered once."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"values": ["a"]},
+                }
+            }
+
+        form1 = TestForm()
+        form2 = TestForm()
+
+        script1 = form1.conditional_fields_script
+        script2 = form2.conditional_fields_script
+
+        # JS library should be in first render only
+        self.assertIn("data-conditional-fields-js", script1)
+        self.assertNotIn("data-conditional-fields-js", script2)
+
+        # But both should have rules
+        self.assertIn("data-conditional-rules", script1)
+        self.assertIn("data-conditional-rules", script2)
+
+    def test_empty_rules_returns_empty_string(self):
+        """Test empty conditional_fields returns empty script."""
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            example = forms.CharField()
+
+            conditional_fields = {}
+
+        form = TestForm()
+        self.assertEqual(form.conditional_fields_script, "")
+
+    def test_get_conditional_fields_override(self):
+        """Test get_conditional_fields can be overridden for dynamic rules."""
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            example = forms.CharField()
+            note = forms.CharField()
+
+            def __init__(self, *args, show_note=False, **kwargs):
+                self.show_note = show_note
+                super().__init__(*args, **kwargs)
+
+            def get_conditional_fields(self):
+                rules = {
+                    "category": {
+                        "example": {"values": ["a"]},
+                    }
+                }
+                if self.show_note:
+                    rules["category"]["note"] = {"values": ["a"]}
+                return rules
+
+        ConditionalFieldsMixin._conditional_js_rendered = False
+        form_without_note = TestForm(show_note=False)
+        script1 = form_without_note.conditional_fields_script
+        self.assertIn('"example"', script1)
+        self.assertNotIn('"note"', script1)
+
+        ConditionalFieldsMixin._conditional_js_rendered = False
+        form_with_note = TestForm(show_note=True)
+        script2 = form_with_note.conditional_fields_script
+        self.assertIn('"example"', script2)
+        self.assertIn('"note"', script2)
+
+    def test_formset_prefix_included(self):
+        """Test form prefix is included in data attributes."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"values": ["a"]},
+                }
+            }
+
+        form = TestForm(prefix="items-0")
+        script = form.conditional_fields_script
+        self.assertIn('data-form-prefix="items-0"', script)
+
+    def test_render_conditional_wrapper(self):
+        """Test render_conditional_wrapper helper method."""
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            example = forms.CharField()
+
+        form = TestForm()
+        wrapper = form.render_conditional_wrapper("example", "<input>", "extra-class")
+
+        self.assertIn('id="example_wrap"', wrapper)
+        self.assertIn('class="d-none extra-class"', wrapper)
+        self.assertIn('data-conditional-field="example"', wrapper)
+        self.assertIn("<input>", wrapper)
+
+
+class TestConditionalFieldsRuleTypes(TestCase):
+    """Tests for different rule types in conditional fields."""
+
+    def test_values_rule(self):
+        """Test 'values' rule for exact match."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A"), ("b", "B")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"values": ["a"]},
+                }
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn('"values":["a"]', script.replace(" ", "").replace("'", '"'))
+
+    def test_exclude_rule(self):
+        """Test 'exclude' rule for negative match."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A"), ("b", "B")])
+            example = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"exclude": ["-----", "none"]},
+                }
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn("exclude", script)
+        self.assertIn("-----", script)
+
+    def test_checked_rule(self):
+        """Test 'checked' rule for checkbox fields."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            create_new = forms.BooleanField(required=False)
+            new_name = forms.CharField()
+
+            conditional_fields = {
+                "create_new": {
+                    "new_name": {"checked": True},
+                }
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn('"checked":true', script.replace(" ", "").replace("'", '"'))
+
+    def test_multiple_targets(self):
+        """Test multiple target fields for one controller."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A"), ("b", "B")])
+            example = forms.CharField()
+            note = forms.CharField()
+            value = forms.IntegerField()
+
+            conditional_fields = {
+                "category": {
+                    "example": {"exclude": ["-----"]},
+                    "note": {"values": ["b"]},
+                    "value": {"values": ["a"]},
+                }
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn('"example"', script)
+        self.assertIn('"note"', script)
+        self.assertIn('"value"', script)
+
+    def test_multiple_controllers(self):
+        """Test form with multiple controller fields."""
+        ConditionalFieldsMixin._conditional_js_rendered = False
+
+        class TestForm(ConditionalFieldsMixin, forms.Form):
+            category = forms.ChoiceField(choices=[("a", "A")])
+            type = forms.ChoiceField(choices=[("x", "X")])
+            for_category = forms.CharField()
+            for_type = forms.CharField()
+
+            conditional_fields = {
+                "category": {
+                    "for_category": {"values": ["a"]},
+                },
+                "type": {
+                    "for_type": {"values": ["x"]},
+                },
+            }
+
+        form = TestForm()
+        script = form.conditional_fields_script
+        self.assertIn('"category"', script)
+        self.assertIn('"type"', script)
+        self.assertIn('"for_category"', script)
+        self.assertIn('"for_type"', script)
+
+
+class TestConditionalFieldsJavaScript(TestCase):
+    """Tests for the embedded JavaScript."""
+
+    def test_js_contains_manager_class(self):
+        """Test JavaScript contains the manager class."""
+        self.assertIn("class ConditionalFieldsManager", CONDITIONAL_FIELDS_JS)
+
+    def test_js_contains_init_function(self):
+        """Test JavaScript contains init function."""
+        self.assertIn("init()", CONDITIONAL_FIELDS_JS)
+
+    def test_js_handles_htmx(self):
+        """Test JavaScript handles htmx:afterSwap event."""
+        self.assertIn("htmx:afterSwap", CONDITIONAL_FIELDS_JS)
+
+    def test_js_handles_turbo(self):
+        """Test JavaScript handles Turbo events."""
+        self.assertIn("turbo:render", CONDITIONAL_FIELDS_JS)
+        self.assertIn("turbo:frame-load", CONDITIONAL_FIELDS_JS)
+
+    def test_js_uses_d_none_class(self):
+        """Test JavaScript uses Bootstrap d-none class."""
+        self.assertIn("d-none", CONDITIONAL_FIELDS_JS)
+
+    def test_js_handles_checkbox(self):
+        """Test JavaScript handles checkbox type."""
+        self.assertIn("checkbox", CONDITIONAL_FIELDS_JS)
+
+    def test_js_evaluates_values_rule(self):
+        """Test JavaScript evaluates 'values' rule."""
+        self.assertIn("rule.values", CONDITIONAL_FIELDS_JS)
+
+    def test_js_evaluates_exclude_rule(self):
+        """Test JavaScript evaluates 'exclude' rule."""
+        self.assertIn("rule.exclude", CONDITIONAL_FIELDS_JS)
+
+    def test_js_evaluates_checked_rule(self):
+        """Test JavaScript evaluates 'checked' rule."""
+        self.assertIn("rule.checked", CONDITIONAL_FIELDS_JS)
+
+
+class TestWidgetsConditionalImports(TestCase):
+    """Tests that conditional fields are exported correctly."""
+
+    def test_conditional_fields_mixin_importable(self):
+        """Test ConditionalFieldsMixin is importable from widgets package."""
+        from widgets import ConditionalFieldsMixin
+
+        self.assertIsNotNone(ConditionalFieldsMixin)
+
+    def test_conditional_fields_mixin_in_all(self):
+        """Test ConditionalFieldsMixin is in __all__."""
+        import widgets
+
+        self.assertIn("ConditionalFieldsMixin", widgets.__all__)


### PR DESCRIPTION
Implements issue #1329: Create a reusable mixin that handles conditional
field visibility through declarative Python configuration instead of
duplicated JavaScript code.

Features:
- ConditionalFieldsMixin for forms to declare visibility rules
- Self-contained JavaScript that's auto-injected (no {{ form.media }} needed)
- Supports multiple rule types: values, exclude, checked, not_empty
- Compatible with Django formsets (handles field prefixes)
- Works with htmx and Turbo page loads

Example usage:
    class MyForm(ConditionalFieldsMixin, forms.Form):
        category = forms.ChoiceField(choices=[...])
        example = forms.CharField()

        conditional_fields = {
            'category': {
                'example': {'values': ['A', 'B']},  # Show only for A or B
            }
        }

Template:
    <div class="d-none" id="example_wrap">{{ form.example }}</div>
    {{ form.conditional_fields_script }}

Includes:
- widgets/mixins/conditional.py - Main mixin implementation
- widgets/tests/test_conditional_fields.py - Comprehensive test suite
- Example migration of ChantryPointForm template as proof of concept