### PR TITLE
Fix N+1 query performance issue in journal list view

### DIFF
--- a/game/templates/game/journal/list.html
+++ b/game/templates/game/journal/list.html
@@ -1,5 +1,4 @@
 {% extends "core/base.html" %}
-{% load json_filters %}
 {% block title %}
     Journals
 {% endblock title %}
@@ -46,18 +45,16 @@
                                     <div class="row text-center" style="font-size: 0.85rem;">
                                         <div class="col-6">
                                             <div style="color: var(--theme-text-secondary);">Entries</div>
-                                            <div style="font-weight: 600;">{{ journal_stats|get_item:obj.pk|get_item:"entry_count"|default:"0" }}</div>
+                                            <div style="font-weight: 600;">{{ obj.entry_count|default:"0" }}</div>
                                         </div>
                                         <div class="col-6">
                                             <div style="color: var(--theme-text-secondary);">Latest</div>
                                             <div style="font-weight: 600;">
-                                                {% with latest=journal_stats|get_item:obj.pk|get_item:"latest_entry" %}
-                                                    {% if latest %}
-                                                        {{ latest|date:"M j" }}
-                                                    {% else %}
-                                                        -
-                                                    {% endif %}
-                                                {% endwith %}
+                                                {% if obj.latest_entry %}
+                                                    {{ obj.latest_entry|date:"M j" }}
+                                                {% else %}
+                                                    -
+                                                {% endif %}
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
Replace per-journal database queries with QuerySet annotations to fetch entry counts and latest dates in a single query. This eliminates ~40 queries per page when displaying 20 journals.

Changes:
- Add Count and Max annotations to JournalListView.get_queryset()
- Update template to access annotations directly on journal objects
- Remove json_filters dependency from template
- Add tests for entry_count, latest_entry annotations and query count

Fixes #1349