### PR TITLE
Fix form validation anti-patterns across codebase

### DIFF
--- a/characters/forms/core/chained_freebies.py
+++ b/characters/forms/core/chained_freebies.py
@@ -268,20 +268,20 @@ class ChainedHumanFreebiesForm(ConditionalFieldsMixin, ChainedSelectMixin, forms
 
     def clean(self):
         cleaned_data = super().clean()
-        category = self.data.get("category")
+        category = cleaned_data.get("category")
 
         if category == "-----":
             raise forms.ValidationError("Must Choose Freebie Expenditure Type")
         elif category == "MeritFlaw" and (
-            self.data.get("example", "") == "" or self.data.get("value", "") == ""
+            not cleaned_data.get("example") or not cleaned_data.get("value")
         ):
             raise forms.ValidationError("Must Choose Merit/Flaw and rating")
         elif (
             category in ["Attribute", "Ability", "Background", "Sphere", "Tenet", "Practice"]
-            and self.data.get("example", "") == ""
+            and not cleaned_data.get("example")
         ):
             raise forms.ValidationError("Must Choose Trait")
-        elif category == "Resonance" and self.data.get("resonance", "") == "":
+        elif category == "Resonance" and not cleaned_data.get("resonance"):
             raise forms.ValidationError("Must Choose Resonance")
 
         return cleaned_data

--- a/characters/forms/core/freebies.py
+++ b/characters/forms/core/freebies.py
@@ -67,11 +67,11 @@ class HumanFreebiesForm(forms.Form):
 
     def clean(self):
         cleaned_data = super().clean()
-        category = self.data.get("category")
+        category = cleaned_data.get("category")
         if category == "-----":
             raise forms.ValidationError("Must Choose Freebie Expenditure Type")
         elif category == "MeritFlaw" and (
-            self.data.get("example", "") == "" or self.data.get("value", "") == ""
+            not cleaned_data.get("example") or not cleaned_data.get("value")
         ):
             raise forms.ValidationError("Must Choose Merit/Flaw and rating")
         elif (
@@ -84,9 +84,9 @@ class HumanFreebiesForm(forms.Form):
                 "Tenet",
                 "Practice",
             ]
-            and self.data.get("example", "") == ""
+            and not cleaned_data.get("example")
         ):
             raise forms.ValidationError("Must Choose Trait")
-        elif category == "Resonance" and self.data.get("resonance", "") == "":
+        elif category == "Resonance" and not cleaned_data.get("resonance"):
             raise forms.ValidationError("Must Choose Resonance")
         return cleaned_data

--- a/characters/forms/mage/chained_freebies.py
+++ b/characters/forms/mage/chained_freebies.py
@@ -119,9 +119,9 @@ class ChainedMageFreebiesForm(ChainedHumanFreebiesForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        category = self.data.get("category")
+        category = cleaned_data.get("category")
 
-        if category == "Resonance" and self.data.get("resonance", "") == "":
+        if category == "Resonance" and not cleaned_data.get("resonance"):
             raise forms.ValidationError("Must Choose Resonance")
 
         return cleaned_data

--- a/characters/forms/mage/rote.py
+++ b/characters/forms/mage/rote.py
@@ -133,11 +133,11 @@ class RoteCreationForm(ChainedSelectMixin, forms.Form):
         if self.cleaned_data["select_or_create_rote"]:
             # Create Rote
             name = self.cleaned_data.get("name")
-            # practice and ability are now string PKs from ChainedChoiceField
-            practice_pk = self.data.get("practice")
+            # practice and ability are string PKs from ChainedChoiceField
+            practice_pk = self.cleaned_data.get("practice")
             practice = Practice.objects.get(pk=practice_pk) if practice_pk else None
             attribute = self.cleaned_data.get("attribute")
-            ability_pk = self.data.get("ability")
+            ability_pk = self.cleaned_data.get("ability")
             ability = Ability.objects.get(pk=ability_pk) if ability_pk else None
             description = self.cleaned_data.get("description")
             if self.cleaned_data["select_or_create_effect"]:

--- a/game/tests/forms/test_forms.py
+++ b/game/tests/forms/test_forms.py
@@ -241,6 +241,63 @@ class TestPostForm(TestCase):
             scene=self.scene,
         )
         self.assertFalse(form.is_valid())
+        self.assertIn("message", form.errors)
+
+    def test_form_character_not_required_when_single_character(self):
+        """Test form accepts no character when user has only one character in scene."""
+        # User has only one character in the scene, so character is optional
+        form = PostForm(
+            data={
+                "character": "",
+                "display_name": "",
+                "message": "Hello!",
+            },
+            user=self.user,
+            scene=self.scene,
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_form_character_required_when_multiple_characters(self):
+        """Test form requires character when user has multiple characters in scene."""
+        # Add a second character for this user
+        second_char = Human.objects.create(
+            name="Second Character",
+            owner=self.user,
+            chronicle=self.chronicle,
+        )
+        self.scene.characters.add(second_char)
+
+        form = PostForm(
+            data={
+                "character": "",
+                "display_name": "",
+                "message": "Hello!",
+            },
+            user=self.user,
+            scene=self.scene,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("character", form.errors)
+
+    def test_form_valid_with_character_when_multiple(self):
+        """Test form accepts character selection when user has multiple in scene."""
+        second_char = Human.objects.create(
+            name="Second Character",
+            owner=self.user,
+            chronicle=self.chronicle,
+        )
+        self.scene.characters.add(second_char)
+
+        form = PostForm(
+            data={
+                "character": self.character.pk,
+                "display_name": "",
+                "message": "Hello!",
+            },
+            user=self.user,
+            scene=self.scene,
+        )
+        self.assertTrue(form.is_valid())
 
 
 class TestStoryForm(TestCase):

--- a/game/views.py
+++ b/game/views.py
@@ -755,16 +755,8 @@ class WeeklyXPRequestBatchApproveView(StorytellerRequiredMixin, View):
         # Use atomic transaction to ensure all approvals succeed or all fail
         with transaction.atomic():
             for xp_request in pending_requests:
-                # Approve the request as-is (using submitted XP categories)
-                xp_request.approved = True
-
-                # Calculate and award XP
-                xp_increase = xp_request.total_xp()
-                # Get the real Character instance (xp is on Character, not CharacterModel)
-                character = xp_request.character.get_real_instance()
-                character.xp += xp_increase
-                character.save()
-                xp_request.save()
+                # Approve the request using model method
+                xp_increase = xp_request.approve()
 
                 approved_count += 1
                 total_xp += xp_increase


### PR DESCRIPTION
- Replace self.data with cleaned_data in clean() methods:
  - freebies.py: Use cleaned_data.get() instead of self.data.get()
  - chained_freebies.py: Use cleaned_data.get() instead of self.data.get()
  - mage/chained_freebies.py: Use cleaned_data.get() instead of self.data.get()
  - mage/rote.py: Use cleaned_data.get() in save() method

- Refactor PostForm.clean() to avoid direct error dict manipulation:
  - Make character field not required by default
  - Validate character required only when multiple characters in scene
  - Use add_error() instead of del self.errors["character"]

- Move XP business logic from form to model:
  - Add WeeklyXPRequest.approve() method with @transaction.atomic
  - Simplify WeeklyXPRequestForm.st_save() to delegate to model
  - Update batch approval view to use model method

- Add comprehensive tests for new approve() method and PostForm validation

Fixes #1104