### PR TITLE
Fix issue 1353

### DIFF
--- a/game/views.py
+++ b/game/views.py
@@ -89,26 +89,35 @@ class ChronicleDetailView(LoginRequiredMixin, DetailView):
         locations_by_gameline = ChronicleDataService.group_locations_by_gameline(top_locations)
 
         # --- Characters by status ---
+        # Use select_related to prevent N+1 queries when accessing owner.username
+        # and owner.profile in templates
         active_characters = (
             Character.objects.active()
             .player_characters()
             .with_group_ordering()
             .filter(chronicle=chronicle)
+            .select_related("owner", "owner__profile")
         )
         retired_characters = (
             Character.objects.retired()
             .player_characters()
             .with_group_ordering()
             .filter(chronicle=chronicle)
+            .select_related("owner", "owner__profile")
         )
         deceased_characters = (
             Character.objects.deceased()
             .player_characters()
             .with_group_ordering()
             .filter(chronicle=chronicle)
+            .select_related("owner", "owner__profile")
         )
         npc_characters = (
-            Character.objects.active().npcs().with_group_ordering().filter(chronicle=chronicle)
+            Character.objects.active()
+            .npcs()
+            .with_group_ordering()
+            .filter(chronicle=chronicle)
+            .select_related("owner", "owner__profile")
         )
 
         # --- Items ---


### PR DESCRIPTION
Add select_related('owner', 'owner__profile') to all four character list queries (active, retired, deceased, NPC) to prevent N+1 queries when templates access character.owner.username and owner.profile.

Without this fix, accessing the chronicle detail page with 20 characters across 4 sections would trigger ~160 extra database queries. With this fix, the related user and profile data is fetched in a single JOIN.

Fixes #1353