### PR TITLE
Fix issue 1351

### DIFF
--- a/characters/forms/mage/practiceform.py
+++ b/characters/forms/mage/practiceform.py
@@ -22,7 +22,7 @@ class PracticeRatingForm(forms.ModelForm):
                 polymorphic_ctype__model="corruptedpractice"
             )
             spec = SpecializedPractice.objects.filter(faction=mage.faction)
-            if spec.count() > 0:
+            if spec.exists():
                 q = q.exclude(
                     id__in=[x.parent_practice.id for x in spec]
                 ) | Practice.objects.filter(id__in=spec)
@@ -47,7 +47,7 @@ class BasePracticeRatingFormSet(BaseInlineFormSet):
                 polymorphic_ctype__model="corruptedpractice"
             )
             spec = SpecializedPractice.objects.filter(faction=self.mage.faction)
-            if spec.count() > 0:
+            if spec.exists():
                 q = q.exclude(
                     id__in=[x.parent_practice.id for x in spec]
                 ) | Practice.objects.filter(id__in=spec)

--- a/characters/forms/mage/xp.py
+++ b/characters/forms/mage/xp.py
@@ -104,7 +104,7 @@ class MageXPForm(XPForm):
                     polymorphic_ctype__model="specializedpractice"
                 ).exclude(polymorphic_ctype__model="corruptedpractice")
                 spec = SpecializedPractice.objects.filter(faction=char.faction)
-                if spec.count() > 0:
+                if spec.exists():
                     examples = examples.exclude(
                         id__in=[x.parent_practice.id for x in spec]
                     ) | Practice.objects.filter(id__in=[x.id for x in spec])
@@ -159,7 +159,7 @@ class MageXPForm(XPForm):
             polymorphic_ctype__model="corruptedpractice"
         )
         spec = SpecializedPractice.objects.filter(faction=self.character.faction)
-        if spec.count() > 0:
+        if spec.exists():
             examples = examples.exclude(
                 id__in=[x.parent_practice.id for x in spec]
             ) | Practice.objects.filter(id__in=[x.id for x in spec])

--- a/characters/models/mage/cabal.py
+++ b/characters/models/mage/cabal.py
@@ -16,7 +16,7 @@ class Cabal(Group):
     def get_display_type(self):
         if self.leader is None:
             return "Cabal"
-        if Mage.objects.filter(pk=self.leader.pk).count() == 0:
+        if not Mage.objects.filter(pk=self.leader.pk).exists():
             return "Cabal"
         m = Mage.objects.get(pk=self.leader.pk)
         if m.affiliation == MageFaction.objects.get_or_create(name="Technocratic Union")[0]:

--- a/characters/models/mage/companion.py
+++ b/characters/models/mage/companion.py
@@ -24,14 +24,14 @@ class Advantage(Model):
         return reverse("characters:mage:advantage", kwargs={"pk": self.pk})
 
     def update_max_rating(self):
-        if self.ratings.all().count() == 0:
+        if not self.ratings.exists():
             self.max_rating = 0
         else:
             self.max_rating = max(self.ratings.all().values_list("value", flat=True))
         self.save()
 
     def update_min_rating(self):
-        if self.ratings.all().count() == 0:
+        if not self.ratings.exists():
             self.min_rating = 0
         else:
             self.min_rating = min(self.ratings.all().values_list("value", flat=True))

--- a/characters/models/mage/mage.py
+++ b/characters/models/mage/mage.py
@@ -343,7 +343,7 @@ class Mage(MtAHuman):
         if self.subfaction is not None:
             q |= self.subfaction.affinities.all()
         q = q.distinct()
-        if q.count() == 0:
+        if not q.exists():
             return Sphere.objects.all()
         return q
 
@@ -469,7 +469,7 @@ class Mage(MtAHuman):
     def has_specialties(self):
         output = super().has_specialties()
         for sphere in self.filter_spheres(minimum=4):
-            output = output and (self.specialties.filter(stat=sphere).count() > 0)
+            output = output and self.specialties.filter(stat=sphere).exists()
         return output
 
     def needs_specialties(self):

--- a/characters/models/mage/sorcerer.py
+++ b/characters/models/mage/sorcerer.py
@@ -155,7 +155,7 @@ class Sorcerer(MtAHuman):
 
     def path_rating(self, path):
         ratings = PathRating.objects.filter(path=path, character=self)
-        if ratings.count() == 0:
+        if not ratings.exists():
             return 0
         return ratings.first().rating
 

--- a/characters/models/werewolf/garou.py
+++ b/characters/models/werewolf/garou.py
@@ -211,7 +211,7 @@ class Werewolf(WtAHuman):
         return True
 
     def has_camp(self):
-        return self.camps.count() != 0
+        return self.camps.exists()
 
     def add_camp(self, camp):
         if camp is None:
@@ -249,9 +249,9 @@ class Werewolf(WtAHuman):
         else:
             b = False
 
-        b = b and self.gifts.filter(allowed=breed).count() > 0
-        b = b and self.gifts.filter(allowed=auspice).count() > 0
-        b = b and self.gifts.filter(allowed=tribe).count() > 0
+        b = b and self.gifts.filter(allowed=breed).exists()
+        b = b and self.gifts.filter(allowed=auspice).exists()
+        b = b and self.gifts.filter(allowed=tribe).exists()
 
         return b
 

--- a/characters/models/wraith/wraith.py
+++ b/characters/models/wraith/wraith.py
@@ -387,7 +387,7 @@ class Wraith(WtOHuman):
             triggers.append("zero_corpus")
 
         # Check for lost Fetters (this would need to be tracked separately)
-        if Fetter.objects.filter(wraith=self).count() == 0:
+        if not Fetter.objects.filter(wraith=self).exists():
             triggers.append("no_fetters")
 
         # Check permanent Angst

--- a/characters/views/mage/mage.py
+++ b/characters/views/mage/mage.py
@@ -197,7 +197,7 @@ class LoadXPExamplesView(View):
                 polymorphic_ctype__model="specializedpractice"
             ).exclude(polymorphic_ctype__model="corruptedpractice")
             spec = SpecializedPractice.objects.filter(faction=self.character.faction)
-            if spec.count() > 0:
+            if spec.exists():
                 examples = examples.exclude(
                     id__in=[x.parent_practice.id for x in spec]
                 ) | Practice.objects.filter(id__in=[x.id for x in spec])

--- a/characters/views/mage/sorcerer.py
+++ b/characters/views/mage/sorcerer.py
@@ -434,7 +434,7 @@ class SorcererRitualView(SpendFreebiesPermissionMixin, FormView):
                 "One ritual per path dot at this stage",
             )
             return self.form_invalid(form)
-        if r.level != 1 and sorcerer.rituals.filter(path=p, level=r.level - 1).count() == 0:
+        if r.level != 1 and not sorcerer.rituals.filter(path=p, level=r.level - 1).exists():
             form.add_error(
                 None,
                 "Must learn rituals in ascending level",

--- a/core/management/commands/generate_chronicle_summary.py
+++ b/core/management/commands/generate_chronicle_summary.py
@@ -103,9 +103,7 @@ class Command(BaseCommand):
         if approved_chars.exists():
             total_xp = sum(char.xp for char in approved_chars if hasattr(char, "xp"))
             stats["xp"]["total_awarded"] = total_xp
-            stats["xp"]["average_per_character"] = (
-                total_xp / approved_chars.count() if approved_chars.count() > 0 else 0
-            )
+            stats["xp"]["average_per_character"] = total_xp / approved_chars.count()
 
             # Count pending XP requests
             char_ids = approved_chars.values_list("id", flat=True)

--- a/core/management/commands/process_weekly_xp.py
+++ b/core/management/commands/process_weekly_xp.py
@@ -129,7 +129,7 @@ class Command(BaseCommand):
         self.stdout.write(f"Characters participating: {characters.count()}")
         self.stdout.write("=" * 70 + "\n")
 
-        if characters.count() == 0:
+        if not characters.exists():
             self.stdout.write(self.style.WARNING("No characters participated in scenes this week."))
             return
 

--- a/core/models.py
+++ b/core/models.py
@@ -344,7 +344,7 @@ class Model(PermissionMixin, PolymorphicModel):
         return True
 
     def has_source(self):
-        return self.sources.count() > 0
+        return self.sources.exists()
 
     def add_source(self, book_title, page_number):
         book = Book.objects.get_or_create(name=book_title)[0]

--- a/items/models/mage/grimoire.py
+++ b/items/models/mage/grimoire.py
@@ -68,7 +68,7 @@ class Grimoire(Wonder):
         return True
 
     def has_abilities(self):
-        return self.abilities.count() != 0
+        return self.abilities.exists()
 
     def set_date_written(self, date_written):
         self.date_written = date_written
@@ -91,7 +91,7 @@ class Grimoire(Wonder):
         return True
 
     def has_focus(self):
-        return self.practices.count() != 0 and self.instruments.count() != 0
+        return self.practices.exists() and self.instruments.exists()
 
     def set_language(self, language):
         self.language = language
@@ -155,7 +155,7 @@ class Grimoire(Wonder):
         return True
 
     def has_spheres(self):
-        return self.spheres.count() != 0
+        return self.spheres.exists()
 
     def set_is_primer(self, is_primer):
         self.is_primer = is_primer
@@ -218,7 +218,7 @@ class Grimoire(Wonder):
             raise ValueError("Faction must come before Practice")
         if practices is None:
             practices = self.faction.practices.all()
-            if practices.count() == 0:
+            if not practices.exists():
                 practices = Practice.objects.all()
             num_practices = 1
             while random.random() < 0.25 and num_practices < practices.distinct().count():
@@ -234,7 +234,7 @@ class Grimoire(Wonder):
                     instruments |= practice.instruments.all()
             else:
                 instruments = Instrument.objects.all()
-            if instruments.count() == 0:
+            if not instruments.exists():
                 instruments = Instrument.objects.all()
             num_instruments = 1
             while random.random() < 0.3 and num_instruments < instruments.distinct().count():
@@ -250,7 +250,7 @@ class Grimoire(Wonder):
     def random_language(self, language=None):
         if language is None:
             if self.faction is not None:
-                if self.faction.languages.count() > 0:
+                if self.faction.languages.exists():
                     languages = self.faction.languages.all()
                     language = weighted_choice({x: x.frequency for x in languages})
                 else:
@@ -281,7 +281,7 @@ class Grimoire(Wonder):
     def random_material(self, cover_material=None, inner_material=None):
         if cover_material is None:
             if self.faction is not None:
-                if self.faction.materials.count() > 0:
+                if self.faction.materials.exists():
                     cover_material = self.faction.materials.order_by("?").first()
                 else:
                     cover_material = Material.objects.order_by("?").first()
@@ -290,7 +290,7 @@ class Grimoire(Wonder):
         if inner_material is None:
             is_hard = random.random() <= 0.3
             if self.faction is not None:
-                if self.faction.materials.filter(is_hard=is_hard).count() > 0:
+                if self.faction.materials.filter(is_hard=is_hard).exists():
                     inner_material = (
                         self.faction.materials.filter(is_hard=is_hard).order_by("?").first()
                     )
@@ -303,7 +303,7 @@ class Grimoire(Wonder):
     def random_medium(self, medium=None):
         if medium is None:
             if self.faction is not None:
-                if self.faction.media.count() != 0:
+                if self.faction.media.exists():
                     medium = self.faction.media.order_by("?").first()
                 else:
                     medium = Medium.objects.order_by("?").first()
@@ -319,7 +319,7 @@ class Grimoire(Wonder):
         self.set_rank(rank)
 
     def random_rotes(self, rotes=None):
-        if self.spheres.count() == 0:
+        if not self.spheres.exists():
             raise ValueError("Spheres must be determiend before rotes")
         if rotes is None:
             effects = []

--- a/locations/forms/mage/chantry.py
+++ b/locations/forms/mage/chantry.py
@@ -55,7 +55,7 @@ class ChantryPointForm(ChainedSelectMixin, ConditionalFieldsMixin, forms.Form):
             ("Existing Background", "Existing Background"),
         ]
 
-        if self.object.backgrounds.count() == 0:
+        if not self.object.backgrounds.exists():
             category_choices = [
                 ("-----", "-----"),
                 ("Integrated Effects", "Integrated Effects"),


### PR DESCRIPTION
Replace inefficient .count() > 0, .count() == 0, and .count() != 0 patterns with .exists() and not .exists() across the codebase.

EXISTS terminates after finding the first matching row while COUNT(*) scans entire relations, making this a significant performance improvement for large tables.

Fixes #1351