### PR TITLE
Fix issue 1350

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -113,24 +113,27 @@ class Profile(models.Model):
 
         Returns:
             QuerySet[Character]: Characters owned by this user, ordered by name.
+            Includes polymorphic_ctype for subclass-specific method calls in templates.
         """
-        return Character.objects.owned_by(self.user)
+        return Character.objects.owned_by(self.user).with_polymorphic_ctype()
 
     def my_locations(self):
         """Get all locations owned by this user.
 
         Returns:
             QuerySet[LocationModel]: Locations owned by this user, ordered by name.
+            Includes polymorphic_ctype for subclass-specific method calls in templates.
         """
-        return LocationModel.objects.owned_by(self.user)
+        return LocationModel.objects.owned_by(self.user).with_polymorphic_ctype()
 
     def my_items(self):
         """Get all items owned by this user.
 
         Returns:
             QuerySet[ItemModel]: Items owned by this user, ordered by name.
+            Includes polymorphic_ctype for subclass-specific method calls in templates.
         """
-        return ItemModel.objects.owned_by(self.user)
+        return ItemModel.objects.owned_by(self.user).with_polymorphic_ctype()
 
     def xp_requests(self):
         """Get scenes awaiting XP awards for this user's chronicles.
@@ -229,24 +232,39 @@ class Profile(models.Model):
 
         Returns:
             QuerySet[Character]: Characters with images awaiting ST approval.
+            Includes polymorphic_ctype for subclass-specific method calls in templates.
         """
-        return Character.objects.with_pending_images().for_user_chronicles(self.user)
+        return (
+            Character.objects.with_pending_images()
+            .for_user_chronicles(self.user)
+            .with_polymorphic_ctype()
+        )
 
     def location_images_to_approve(self):
         """Get locations with pending image uploads for this user's chronicles.
 
         Returns:
             QuerySet[LocationModel]: Locations with images awaiting ST approval.
+            Includes polymorphic_ctype for subclass-specific method calls in templates.
         """
-        return LocationModel.objects.with_pending_images().for_user_chronicles(self.user)
+        return (
+            LocationModel.objects.with_pending_images()
+            .for_user_chronicles(self.user)
+            .with_polymorphic_ctype()
+        )
 
     def item_images_to_approve(self):
         """Get items with pending image uploads for this user's chronicles.
 
         Returns:
             QuerySet[ItemModel]: Items with images awaiting ST approval.
+            Includes polymorphic_ctype for subclass-specific method calls in templates.
         """
-        return ItemModel.objects.with_pending_images().for_user_chronicles(self.user)
+        return (
+            ItemModel.objects.with_pending_images()
+            .for_user_chronicles(self.user)
+            .with_polymorphic_ctype()
+        )
 
     @property
     def theme_list(self):

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -69,7 +69,10 @@ class ProfileView(LoginRequiredMixin, DetailView):
 
         # Optimize queries with select_related
         scenes = self.object.xp_requests().select_related("chronicle", "location")
-        characters = self.object.freebies_to_approve().select_related("owner", "chronicle")
+        # Include polymorphic_ctype for subclass-specific method calls in templates
+        characters = self.object.freebies_to_approve().select_related(
+            "polymorphic_ctype", "owner", "chronicle"
+        )
 
         context["scenexp_forms"] = [SceneXP(scene=s, prefix=f"scene_{s.pk}") for s in scenes]
         context["freebie_forms"] = [

--- a/characters/views/core/__init__.py
+++ b/characters/views/core/__init__.py
@@ -414,7 +414,12 @@ class CharacterIndexView(ListView):
             context["header"] = "wod_heading"
 
         # Optimize: fetch all visible characters in one query, then group by chronicle
-        all_characters = list(self.get_queryset().select_related("owner", "chronicle").visible())
+        # Include polymorphic_ctype for subclass-specific method calls in templates
+        all_characters = list(
+            self.get_queryset()
+            .select_related("polymorphic_ctype", "owner", "chronicle")
+            .visible()
+        )
 
         # Initialize chron_dict with all chronicles and None
         chronicles = list(Chronicle.objects.all()) + [None]

--- a/characters/views/core/character.py
+++ b/characters/views/core/character.py
@@ -94,7 +94,8 @@ class CharacterListView(VisibilityFilterMixin, ListView):
         """Get filtered queryset based on permissions."""
         qs = super().get_queryset()
         # Additional filtering can be added here (e.g., by status, chronicle, etc.)
-        return qs.select_related("owner", "chronicle").order_by("name")
+        # Include polymorphic_ctype for subclass-specific method calls in templates
+        return qs.select_related("polymorphic_ctype", "owner", "chronicle").order_by("name")
 
 
 class CharacterCreateView(LoginRequiredMixin, CreateView):

--- a/core/tests/models/test_model_manager.py
+++ b/core/tests/models/test_model_manager.py
@@ -1,0 +1,142 @@
+"""
+Tests for ModelManager and ModelQuerySet performance optimizations.
+
+Tests verify that:
+- ModelManager does NOT automatically add select_related('polymorphic_ctype')
+- with_polymorphic_ctype() method explicitly adds the optimization
+- pending_approval_for_user() includes polymorphic_ctype
+
+See issue #1350: Polymorphic select_related on every query adds 20-30% overhead
+"""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from characters.models.core.character import Character
+from characters.models.core.human import Human
+from game.models import Chronicle
+
+
+class ModelManagerTests(TestCase):
+    """Tests for ModelManager without automatic polymorphic_ctype."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="testuser", password="testpass")
+        cls.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        cls.human = Human.objects.create(
+            name="Test Character",
+            owner=cls.user,
+            chronicle=cls.chronicle,
+            status="Un",
+        )
+
+    def test_manager_does_not_auto_include_polymorphic_ctype(self):
+        """Test that ModelManager does NOT auto-include polymorphic_ctype."""
+        # Get a queryset without explicit with_polymorphic_ctype()
+        qs = Character.objects.all()
+
+        # Check the query does NOT include polymorphic_ctype in select_related
+        # This is the fix for issue #1350
+        query_str = str(qs.query)
+        # The query should be a simple SELECT without JOIN on content_type
+        # (unless with_polymorphic_ctype() is called)
+        self.assertNotIn("django_content_type", query_str.lower())
+
+    def test_with_polymorphic_ctype_method_exists(self):
+        """Test that with_polymorphic_ctype() method exists on queryset."""
+        qs = Character.objects.all()
+        self.assertTrue(hasattr(qs, "with_polymorphic_ctype"))
+
+    def test_with_polymorphic_ctype_returns_queryset(self):
+        """Test that with_polymorphic_ctype() returns a queryset."""
+        qs = Character.objects.all().with_polymorphic_ctype()
+        # Should be able to iterate
+        list(qs)
+        self.assertEqual(qs.count(), 1)
+
+    def test_with_polymorphic_ctype_includes_join(self):
+        """Test that with_polymorphic_ctype() includes polymorphic_ctype join."""
+        qs = Character.objects.all().with_polymorphic_ctype()
+        query_str = str(qs.query)
+        # The query SHOULD include JOIN on content_type
+        self.assertIn("django_content_type", query_str.lower())
+
+    def test_count_works_without_polymorphic_ctype(self):
+        """Test that .count() works efficiently without polymorphic dispatch."""
+        # This should NOT include the content_type join
+        count = Character.objects.filter(chronicle=self.chronicle).count()
+        self.assertEqual(count, 1)
+
+    def test_exists_works_without_polymorphic_ctype(self):
+        """Test that .exists() works efficiently without polymorphic dispatch."""
+        # This should NOT include the content_type join
+        exists = Character.objects.filter(chronicle=self.chronicle).exists()
+        self.assertTrue(exists)
+
+    def test_values_works_without_polymorphic_ctype(self):
+        """Test that .values() works efficiently without polymorphic dispatch."""
+        # This should NOT include the content_type join
+        values = list(Character.objects.filter(chronicle=self.chronicle).values("name"))
+        self.assertEqual(len(values), 1)
+        self.assertEqual(values[0]["name"], "Test Character")
+
+
+class ModelQuerySetMethodsTests(TestCase):
+    """Tests for ModelQuerySet methods that need polymorphic_ctype."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(username="testuser", password="testpass")
+        cls.chronicle = Chronicle.objects.create(name="Test Chronicle")
+        cls.chronicle.storytellers.add(cls.user)
+        cls.human = Human.objects.create(
+            name="Test Character",
+            owner=cls.user,
+            chronicle=cls.chronicle,
+            status="Un",  # Pending approval
+        )
+
+    def test_pending_approval_includes_polymorphic_ctype(self):
+        """Test that pending_approval_for_user() includes polymorphic_ctype."""
+        qs = Character.objects.pending_approval_for_user(self.user)
+        query_str = str(qs.query)
+        # Should include polymorphic_ctype join for template rendering
+        self.assertIn("django_content_type", query_str.lower())
+
+    def test_pending_approval_returns_characters(self):
+        """Test that pending_approval_for_user() returns pending characters."""
+        qs = Character.objects.pending_approval_for_user(self.user)
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first().name, "Test Character")
+
+    def test_visible_can_chain_with_polymorphic_ctype(self):
+        """Test that visible() can chain with with_polymorphic_ctype()."""
+        # Create a visible character
+        Human.objects.create(
+            name="Visible Character",
+            owner=self.user,
+            chronicle=self.chronicle,
+            display=True,
+        )
+        qs = Character.objects.visible().with_polymorphic_ctype()
+        # Should work and include the join
+        query_str = str(qs.query)
+        self.assertIn("django_content_type", query_str.lower())
+        self.assertGreaterEqual(qs.count(), 1)
+
+    def test_for_chronicle_can_chain_with_polymorphic_ctype(self):
+        """Test that for_chronicle() can chain with with_polymorphic_ctype()."""
+        qs = Character.objects.for_chronicle(self.chronicle).with_polymorphic_ctype()
+        # Should work and include the join
+        query_str = str(qs.query)
+        self.assertIn("django_content_type", query_str.lower())
+        self.assertEqual(qs.count(), 1)
+
+    def test_owned_by_can_chain_with_polymorphic_ctype(self):
+        """Test that owned_by() can chain with with_polymorphic_ctype()."""
+        qs = Character.objects.owned_by(self.user).with_polymorphic_ctype()
+        # Should work and include the join
+        query_str = str(qs.query)
+        self.assertIn("django_content_type", query_str.lower())
+        self.assertEqual(qs.count(), 1)

--- a/items/views/core/__init__.py
+++ b/items/views/core/__init__.py
@@ -218,8 +218,11 @@ class ItemIndexView(View):
                 c = ItemModel.objects.filter(chronicle=chron).order_by("name")
             items = [x for x in c if x.type in game_items_types]
 
-            c = ItemModel.objects.filter(id__in=[x.id for x in items], chronicle=chron).order_by(
-                "name"
+            # Include polymorphic_ctype for subclass-specific method calls in templates
+            c = (
+                ItemModel.objects.filter(id__in=[x.id for x in items], chronicle=chron)
+                .with_polymorphic_ctype()
+                .order_by("name")
             )
             chron_dict[chron] = c
 

--- a/locations/views/core/__init__.py
+++ b/locations/views/core/__init__.py
@@ -207,14 +207,13 @@ class LocationIndexView(View):
         }
         chron_dict = {}
         for chron in list(Chronicle.objects.all()) + [None]:
-            if chron:
-                chron_dict[chron] = (
-                    LocationModel.objects.top_level().filter(chronicle=chron).order_by("name")
-                )
-            else:
-                chron_dict[chron] = (
-                    LocationModel.objects.top_level().filter(chronicle=chron).order_by("name")
-                )
+            # Include polymorphic_ctype for subclass-specific method calls in templates
+            chron_dict[chron] = (
+                LocationModel.objects.top_level()
+                .filter(chronicle=chron)
+                .with_polymorphic_ctype()
+                .order_by("name")
+            )
         context["form"] = LocationCreationForm(user=self.request.user)
         context["chrondict"] = chron_dict
         if self.request.user.is_authenticated:


### PR DESCRIPTION
Removes the automatic select_related('polymorphic_ctype') from ModelManager that was adding 20-30% overhead to ALL queries, even those that don't need polymorphic dispatch (like .count(), .exists(), .values()).

Changes:
- Remove automatic select_related from ModelManager.get_queryset()
- Add with_polymorphic_ctype() method to ModelQuerySet for explicit use
- Update views and Profile methods that iterate over polymorphic querysets to explicitly include polymorphic_ctype where needed for template rendering

Fixes #1350