### PR TITLE
Display Fetters and Passions on Wraith character detail page

### DIFF
--- a/characters/templates/characters/wraith/wraith/detail.html
+++ b/characters/templates/characters/wraith/wraith/detail.html
@@ -100,6 +100,61 @@
         </div>
     {% endif %}
 {% endblock powers %}
+{% block passions %}
+    {% if passions %}
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="tg-card">
+                    <div class="tg-card-header">
+                        <h5 class="tg-card-title {{ object.get_heading }}">Passions</h5>
+                    </div>
+                    <div class="tg-card-body">
+                        <div class="row">
+                            {% for passion in passions %}
+                                <div class="col-md-6 mb-2">
+                                    <div class="row">
+                                        <div class="col-8">
+                                            <strong>{{ passion.emotion }}:</strong> {{ passion.description }}
+                                            {% if passion.is_dark_passion %}<span class="tg-badge badge-dec">Dark</span>{% endif %}
+                                        </div>
+                                        <div class="col-4 dots">{{ passion.rating|dots }}</div>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock passions %}
+{% block fetters %}
+    {% if fetters %}
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="tg-card">
+                    <div class="tg-card-header">
+                        <h5 class="tg-card-title {{ object.get_heading }}">Fetters</h5>
+                    </div>
+                    <div class="tg-card-body">
+                        <div class="row">
+                            {% for fetter in fetters %}
+                                <div class="col-md-6 mb-2">
+                                    <div class="row">
+                                        <div class="col-8">
+                                            <strong>{{ fetter.get_fetter_type_display }}:</strong> {{ fetter.description }}
+                                        </div>
+                                        <div class="col-4 dots">{{ fetter.rating|dots }}</div>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock fetters %}
 {% block advantages %}
     <div class="row mb-3">
         <div class="col-12">

--- a/characters/tests/views/wraith/test_wraith.py
+++ b/characters/tests/views/wraith/test_wraith.py
@@ -1,6 +1,8 @@
 """Tests for wraith views module."""
 
+from characters.models.wraith.fetter import Fetter
 from characters.models.wraith.guild import Guild
+from characters.models.wraith.passion import Passion
 from characters.models.wraith.wraith import Wraith
 from django.contrib.auth.models import User
 from django.test import Client, TestCase
@@ -70,6 +72,57 @@ class TestWraithDetailView(TestCase):
         self.client.login(username="owner", password="password")
         response = self.client.get(self.wraith.get_absolute_url())
         self.assertIn("dark_arcanoi", response.context)
+
+    def test_detail_view_has_fetters_in_context(self):
+        """Test that fetters are in the context."""
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.wraith.get_absolute_url())
+        self.assertIn("fetters", response.context)
+
+    def test_detail_view_has_passions_in_context(self):
+        """Test that passions are in the context."""
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.wraith.get_absolute_url())
+        self.assertIn("passions", response.context)
+
+    def test_detail_view_displays_fetters(self):
+        """Test that fetters are displayed in the template."""
+        Fetter.objects.create(
+            wraith=self.wraith,
+            fetter_type="person",
+            description="My beloved wife",
+            rating=3,
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.wraith.get_absolute_url())
+        self.assertContains(response, "My beloved wife")
+        self.assertContains(response, "Fetters")
+
+    def test_detail_view_displays_passions(self):
+        """Test that passions are displayed in the template."""
+        Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Rage",
+            description="Avenge my murder",
+            rating=4,
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.wraith.get_absolute_url())
+        self.assertContains(response, "Avenge my murder")
+        self.assertContains(response, "Passions")
+
+    def test_detail_view_displays_dark_passion_badge(self):
+        """Test that dark passions show the Dark badge."""
+        Passion.objects.create(
+            wraith=self.wraith,
+            emotion="Jealousy",
+            description="Destroy my rival",
+            rating=2,
+            is_dark_passion=True,
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.wraith.get_absolute_url())
+        self.assertContains(response, "Dark")
 
     def test_detail_view_unapproved_hidden_from_others(self):
         """Test that unapproved characters are hidden from non-owners."""

--- a/characters/views/wraith/wraith.py
+++ b/characters/views/wraith/wraith.py
@@ -16,6 +16,8 @@ class WraithDetailView(XPApprovalMixin, HumanDetailView):
         context = super().get_context_data(**kwargs)
         context["arcanoi"] = self.object.get_arcanoi()
         context["dark_arcanoi"] = self.object.get_dark_arcanoi()
+        context["fetters"] = self.object.fetters.all()
+        context["passions"] = self.object.passions.all()
         return context
 
 


### PR DESCRIPTION
Wraiths have Fetters (anchors to the mortal world) and Passions (emotional drives) as core mechanics. While these could be created during character generation, they were not displayed on the character sheet detail view.

- Add fetters and passions to WraithDetailView context
- Add display blocks for Fetters and Passions in detail template
- Include Dark Passion badge indicator
- Add tests for new display functionality

Fixes #1367