### PR TITLE
Fix pre-existing test issues

### DIFF
--- a/core/tests/mixins/test_mixins.py
+++ b/core/tests/mixins/test_mixins.py
@@ -1,5 +1,6 @@
 """Tests for mixins in core/mixins.py."""
 
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
@@ -1363,7 +1364,6 @@ class ApprovalMixinTest(TestCase):
         the post() method properly converts it to a user-facing error message
         and redirects. This catches bugs like using e.message instead of str(e).
         """
-        from unittest.mock import MagicMock
 
         from core.mixins import ApprovalMixin
 
@@ -1403,7 +1403,6 @@ class ApprovalMixinTest(TestCase):
         Tests the reject button path to ensure both approve and reject
         branches properly handle ValidationError without AttributeError.
         """
-        from unittest.mock import MagicMock
 
         from core.mixins import ApprovalMixin
 

--- a/game/apps.py
+++ b/game/apps.py
@@ -6,4 +6,4 @@ class GameConfig(AppConfig):
     name = "game"
 
     def ready(self):
-        pass
+        import game.signals  # noqa: F401 - Register signal handlers


### PR DESCRIPTION
## Summary
Fixes two pre-existing test failures discovered during the refactoring work:

### 1. Missing imports in test_mixins.py
- Added `MagicMock` and `patch` imports from `unittest.mock`
- The `ApprovalMixinTest` tests were using these without importing them

### 2. Signal registration in game app
- Import `game.signals` in `GameConfig.ready()` to register signal handlers
- The Journal creation signal wasn't firing because signals module was never imported
- Django signals must be imported to be registered

## Test plan
- [x] `test_post_approve_with_malformed_key_shows_error_message` - PASS
- [x] `test_post_reject_with_malformed_key_shows_error_message` - PASS
- [x] `test_journal_created_with_character` - PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)