### PR TITLE
Fix duplicate template tag name warning

### DIFF
--- a/characters/templatetags/get_specialty.py
+++ b/characters/templatetags/get_specialty.py
@@ -1,8 +1,0 @@
-from django import template
-
-register = template.Library()
-
-
-@register.filter(name="get_specialty")
-def get_specialty(character, stat):
-    return character.get_specialty(stat)

--- a/characters/tests/templatetags/test_get_specialty.py
+++ b/characters/tests/templatetags/test_get_specialty.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from django.template import Context, Template
 from django.test import TestCase
 
-from characters.templatetags.get_specialty import get_specialty
+from core.templatetags.get_specialty import get_specialty
 
 
 class GetSpecialtyFilterTest(TestCase):


### PR DESCRIPTION
Remove characters/templatetags/get_specialty.py which duplicated the identical template tag in core/templatetags/get_specialty.py. This resolves Django's templates.W003 warning about multiple template tag modules with the same name.

Updated the test import to use the core version.