### PR TITLE
Fix VampireCreationForm path_rating validation error

### DIFF
--- a/characters/forms/vampire/vampire.py
+++ b/characters/forms/vampire/vampire.py
@@ -60,9 +60,12 @@ class VampireCreationForm(forms.ModelForm):
         except ValidationError as e:
             self._update_errors(e)
 
-        # Set path_rating to 4 if a path is selected (before model validation)
-        if self.instance.path and self.instance.path_rating < 4:
-            self.instance.path_rating = 4
+        # Set path_rating to minimum if a path is selected (before model validation)
+        if (
+            self.instance.path
+            and self.instance.path_rating < Vampire.MIN_STARTING_PATH_RATING
+        ):
+            self.instance.path_rating = Vampire.MIN_STARTING_PATH_RATING
 
         try:
             self.instance.full_clean(exclude=exclude, validate_unique=False)

--- a/characters/models/vampire/vampire.py
+++ b/characters/models/vampire/vampire.py
@@ -22,6 +22,10 @@ class Vampire(VtMHuman):
     type = "vampire"
     freebie_step = 7
 
+    # Minimum starting values for morality traits (V20 rules)
+    MIN_STARTING_PATH_RATING = 4
+    MIN_STARTING_HUMANITY = 4
+
     allowed_backgrounds = [
         "contacts",
         "mentor",
@@ -234,14 +238,19 @@ class Vampire(VtMHuman):
         if self.status in [CharacterStatus.UNAPPROVED, CharacterStatus.SUBMITTED]:
             # Validate humanity (if on humanity, not a path)
             if not self.path:
-                if self.humanity < 4:
-                    errors["humanity"] = "Starting Humanity must be at least 4."
+                if self.humanity < self.MIN_STARTING_HUMANITY:
+                    errors["humanity"] = (
+                        f"Starting Humanity must be at least {self.MIN_STARTING_HUMANITY}."
+                    )
                 elif self.humanity > 10:
                     errors["humanity"] = "Starting Humanity cannot exceed 10."
             # Validate path_rating (if on a path)
             else:
-                if self.path_rating < 4:
-                    errors["path_rating"] = "Starting Path rating must be at least 4."
+                if self.path_rating < self.MIN_STARTING_PATH_RATING:
+                    errors["path_rating"] = (
+                        f"Starting Path rating must be at least "
+                        f"{self.MIN_STARTING_PATH_RATING}."
+                    )
                 elif self.path_rating > 10:
                     errors["path_rating"] = "Starting Path rating cannot exceed 10."
 

--- a/characters/tests/forms/vampire/test_vampire.py
+++ b/characters/tests/forms/vampire/test_vampire.py
@@ -315,7 +315,9 @@ class TestVampireCreationFormSave(VampireCreationFormTestCase):
         self.assertEqual(vampire.owner, self.user)
 
     def test_save_with_path_sets_path_rating(self):
-        """Saving form with a path sets path_rating to 4."""
+        """Saving form with a path sets path_rating to minimum."""
+        from characters.models.vampire.vampire import Vampire
+
         form = VampireCreationForm(
             data={
                 "name": "Test Vampire",
@@ -332,4 +334,23 @@ class TestVampireCreationFormSave(VampireCreationFormTestCase):
         self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
         vampire = form.save()
         self.assertEqual(vampire.path, self.path_of_caine)
-        self.assertEqual(vampire.path_rating, 4)
+        self.assertEqual(vampire.path_rating, Vampire.MIN_STARTING_PATH_RATING)
+
+    def test_save_without_path_leaves_path_rating_at_default(self):
+        """Saving form without a path does not modify path_rating."""
+        form = VampireCreationForm(
+            data={
+                "name": "Test Vampire",
+                "nature": str(self.survivor.pk),
+                "demeanor": str(self.bravo.pk),
+                "concept": "Warrior",
+                "clan": str(self.brujah.pk),
+                "sect": str(self.camarilla.pk),
+                "chronicle": str(self.chronicle.pk),
+            },
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        vampire = form.save()
+        self.assertIsNone(vampire.path)
+        self.assertEqual(vampire.path_rating, 0)  # Default, unchanged


### PR DESCRIPTION
Summary
Fixes ValueError: 'VampireCreationForm' has no field named 'path_rating' when creating a vampire with a path selected
Overrides _post_clean() to set path_rating=4 after instance is populated with form data but before model validation runs
Adds test case to verify path_rating is correctly set when a path is selected
Problem
When creating a vampire with a path selected, the model's clean() method validates that path_rating >= 4. Since path_rating is not a form field (defaults to 0), validation failed. Django then tried to attach the error to a non-existent path_rating form field, causing a ValueError.

Solution
Override _post_clean() to inject path_rating = 4 at the correct point in the form lifecycle:

After construct_instance() populates the instance with form data (including path)
Before full_clean() runs model validation
Test plan
 Run python manage.py test characters.tests.forms.vampire.test_vampire to verify form tests pass
 Test vampire creation with a path selected via the web UI
 Verify test_save_with_path_sets_path_rating passes
