### PR TITLE
Fix scene title fonts and render posts with safe HTML

### DIFF
--- a/core/templatetags/sanitize_text.py
+++ b/core/templatetags/sanitize_text.py
@@ -8,6 +8,25 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 
+def clean_html(value):
+    """Sanitize HTML with bleach, allowing only a safe subset of tags."""
+    allowed_tags = ["a", "b", "i", "em", "strong", "u", "p", "br", "strike", "ul", "li", "span"]
+    allowed_attributes = {
+        "a": ["href"],
+        "span": lambda tag, name, value: name == "class" and value == "quote",
+    }
+    # Only allow safe protocols in links
+    allowed_protocols = ["http", "https", "mailto"]
+
+    return bleach.clean(
+        value,
+        tags=allowed_tags,
+        attributes=allowed_attributes,
+        protocols=allowed_protocols,
+        strip=True,
+    )
+
+
 @register.filter
 def sanitize_html(value):
     # Handle None, empty strings, and non-string types
@@ -18,24 +37,7 @@ def sanitize_html(value):
     if not isinstance(value, str):
         value = str(value)
 
-    allowed_tags = ["a", "b", "i", "em", "strong", "u", "p", "br", "strike", "ul", "li", "span"]
-    allowed_attributes = {
-        "a": ["href"],
-        "span": lambda tag, name, value: name == "class" and value == "quote",
-    }
-    # Only allow safe protocols in links
-    allowed_protocols = ["http", "https", "mailto"]
-
-    # Clean the HTML
-    cleaned_text = bleach.clean(
-        value,
-        tags=allowed_tags,
-        attributes=allowed_attributes,
-        protocols=allowed_protocols,
-        strip=True,
-    )
-
-    return format_html(cleaned_text)
+    return format_html(clean_html(value))
 
 
 @register.filter
@@ -70,6 +72,42 @@ def quote_tag(value):
     result = "".join(parts)
     # Mark as safe since we've escaped user content and only added safe HTML tags
     return mark_safe(result)
+
+
+def render_post_html(value):
+    """Sanitize post HTML and wrap quoted dialogue in styled spans.
+
+    Unlike quote_tag, this preserves safe HTML tags (bold, italic, links,
+    etc.) instead of escaping them. Dangerous markup is stripped by bleach.
+    Returns a plain string; use safe_post for template rendering.
+    """
+    if value is None or value == "":
+        return ""
+
+    if not isinstance(value, str):
+        value = str(value)
+
+    cleaned = clean_html(value)
+
+    # Wrap quoted text in styled spans, but only in text between tags so
+    # that quotes inside attribute values (e.g. href="...") are untouched.
+    def wrap_quotes(segment):
+        return re.sub(r'"([^"]*)"', r'<span class="quote">"\1"</span>', segment)
+
+    parts = re.split(r"(<[^>]*>)", cleaned)
+    parts = [part if part.startswith("<") else wrap_quotes(part) for part in parts if part]
+    return "".join(parts)
+
+
+@register.filter
+def safe_post(value):
+    """Render a post's message as sanitized HTML with quote styling.
+
+    Allows users to write safe HTML in posts (bold, italic, links, etc.)
+    while stripping dangerous markup and preserving the quote-highlighting
+    behavior of quote_tag.
+    """
+    return mark_safe(render_post_html(value))
 
 
 @register.filter

--- a/core/templatetags/sanitize_text.py
+++ b/core/templatetags/sanitize_text.py
@@ -2,13 +2,13 @@ import re
 
 import bleach
 from django import template
-from django.utils.html import escape, format_html
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 register = template.Library()
 
 
-def clean_html(value):
+def _clean_html(value):
     """Sanitize HTML with bleach, allowing only a safe subset of tags."""
     allowed_tags = ["a", "b", "i", "em", "strong", "u", "p", "br", "strike", "ul", "li", "span"]
     allowed_attributes = {
@@ -37,7 +37,9 @@ def sanitize_html(value):
     if not isinstance(value, str):
         value = str(value)
 
-    return format_html(clean_html(value))
+    # mark_safe, not format_html: the cleaned text may contain literal
+    # braces, which format_html would treat as format placeholders
+    return mark_safe(_clean_html(value))
 
 
 @register.filter
@@ -87,10 +89,12 @@ def render_post_html(value):
     if not isinstance(value, str):
         value = str(value)
 
-    cleaned = clean_html(value)
+    cleaned = _clean_html(value)
 
     # Wrap quoted text in styled spans, but only in text between tags so
     # that quotes inside attribute values (e.g. href="...") are untouched.
+    # Known limitation: a quote pair that spans a tag boundary (e.g.
+    # "He said <em>hi</em>") is split across fragments and won't be wrapped.
     def wrap_quotes(segment):
         return re.sub(r'"([^"]*)"', r'<span class="quote">"\1"</span>', segment)
 

--- a/core/tests/templatetags/test_sanitize_text.py
+++ b/core/tests/templatetags/test_sanitize_text.py
@@ -113,6 +113,12 @@ class SanitizeHTMLFilterTest(TestCase):
         result = sanitize_html(text)
         self.assertEqual(result, text)
 
+    def test_handles_literal_braces(self):
+        """Text containing braces must not be treated as format placeholders."""
+        text = "CSS uses {braces} and {0} placeholders"
+        result = sanitize_html(text)
+        self.assertEqual(result, text)
+
 
 class QuoteTagFilterTest(TestCase):
     """Tests for quote_tag filter."""
@@ -501,6 +507,8 @@ class SafePostFilterTest(TestCase):
     def test_strips_javascript_protocol(self):
         result = safe_post('<a href="javascript:alert(1)">link</a>')
         self.assertNotIn("javascript:", result)
+        # The unsafe href is dropped entirely, leaving a bare anchor
+        self.assertEqual(result, "<a>link</a>")
 
     def test_wraps_quoted_text_in_span(self):
         result = safe_post('He said "hello there" loudly')

--- a/core/tests/templatetags/test_sanitize_text.py
+++ b/core/tests/templatetags/test_sanitize_text.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from core.templatetags.sanitize_text import (
     badge_text,
     quote_tag,
+    safe_post,
     sanitize_html,
     simple_markdown,
 )
@@ -472,3 +473,52 @@ class BadgeTextFilterTest(TestCase):
         text = "autumn_person"
         result = badge_text(text)
         self.assertEqual(result, "Autumn Person")
+
+
+class SafePostFilterTest(TestCase):
+    """Tests for safe_post filter (sanitized HTML + quote styling for posts)."""
+
+    def test_returns_empty_string_for_none(self):
+        self.assertEqual(safe_post(None), "")
+
+    def test_returns_empty_string_for_empty_string(self):
+        self.assertEqual(safe_post(""), "")
+
+    def test_preserves_allowed_html(self):
+        result = safe_post("Some <b>bold</b> and <em>italic</em> text")
+        self.assertEqual(result, "Some <b>bold</b> and <em>italic</em> text")
+
+    def test_removes_script_tags(self):
+        result = safe_post("Hello <script>alert('xss')</script> world")
+        self.assertNotIn("<script>", result)
+        self.assertNotIn("</script>", result)
+
+    def test_removes_onclick_attributes(self):
+        result = safe_post('<b onclick="alert(1)">text</b>')
+        self.assertNotIn("onclick", result)
+        self.assertIn("<b>text</b>", result)
+
+    def test_strips_javascript_protocol(self):
+        result = safe_post('<a href="javascript:alert(1)">link</a>')
+        self.assertNotIn("javascript:", result)
+
+    def test_wraps_quoted_text_in_span(self):
+        result = safe_post('He said "hello there" loudly')
+        self.assertIn('<span class="quote">"hello there"</span>', result)
+
+    def test_quote_wrapping_with_html(self):
+        result = safe_post('<b>He said</b> "hi"')
+        self.assertIn("<b>He said</b>", result)
+        self.assertIn('<span class="quote">"hi"</span>', result)
+
+    def test_href_quotes_not_wrapped(self):
+        result = safe_post('<a href="http://example.com">link</a>')
+        self.assertIn('href="http://example.com"', result)
+
+    def test_returns_safe_string(self):
+        from django.utils.safestring import SafeString
+
+        self.assertIsInstance(safe_post("text"), SafeString)
+
+    def test_plain_text_unchanged(self):
+        self.assertEqual(safe_post("Just plain text"), "Just plain text")

--- a/game/consumers.py
+++ b/game/consumers.py
@@ -9,6 +9,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 from characters.models.core import CharacterModel
+from core.templatetags.sanitize_text import render_post_html
 from game.models import Scene
 
 logger = logging.getLogger(__name__)
@@ -305,6 +306,7 @@ class SceneChatConsumer(AsyncWebsocketConsumer):
             "character_url": character.get_absolute_url(),
             "display_name": post.display_name,
             "message": post.message,
+            "message_html": render_post_html(post.message),
             "datetime_created": post.datetime_created.isoformat(),
             "owner_id": character.owner_id,
             "is_st": is_st,

--- a/game/templates/game/chronicle/display_includes/scene_gameline_tabs.html
+++ b/game/templates/game/chronicle/display_includes/scene_gameline_tabs.html
@@ -61,7 +61,7 @@
                                             {% for scene in scenes %}
                                                 <tr style="transition: var(--transition-fast);">
                                                     <td data-label="Title" style="padding: 16px;">
-                                                        <a href="{{ scene.get_absolute_url }}" class="{{ scene.gameline }}_heading" style="font-weight: 600;">
+                                                        <a href="{{ scene.get_absolute_url }}" class="{{ object.headings|default:'wod_heading' }}" style="font-weight: 600;">
                                                             {{ scene.name }}
                                                         </a>
                                                     </td>

--- a/game/templates/game/scene/detail.html
+++ b/game/templates/game/scene/detail.html
@@ -50,7 +50,7 @@
                         <p class="post mb-0" style="line-height: 1.6;">
                             <strong {% if post.character.owner.profile.is_st %}class="st"{% elif post.character.owner == request.user %}class="highlight"{% endif %}>
                                 <a href="{{ post.character.get_absolute_url }}" style="font-weight: 600;">{{ post.display_name }}</a>
-                            </strong>: {{ post.message|quote_tag }}
+                            </strong>: {{ post.message|safe_post }}
                         </p>
                     </div>
                 {% empty %}
@@ -324,12 +324,16 @@
                 highlightClass = 'class="highlight"';
             }
 
-            // Create HTML with all user content escaped
+            // Message HTML is sanitized server-side (message_html); fall back
+            // to escaping the raw message if it's missing.
+            const messageHtml = post.message_html !== undefined
+                ? post.message_html
+                : escapeHtml(post.message);
             postDiv.innerHTML = `
                 <p class="post mb-0" style="line-height: 1.6;">
                     <strong ${highlightClass}>
                         <a href="${escapeHtml(post.character_url)}" style="font-weight: 600;">${escapeHtml(post.display_name)}</a>
-                    </strong>: ${escapeHtml(post.message)}
+                    </strong>: ${messageHtml}
                 </p>
             `;
 


### PR DESCRIPTION
Resolves two display bugs:

## #1436 — Scene titles not displaying using Chronicle header font
Scene title links on the chronicle scene tab used `{{ scene.gameline }}_heading`, which is almost always the `wod` default, so titles always rendered with `wod_heading`. They now use the chronicle's configured `headings` style (falling back to `wod_heading` when unset), matching the rest of the chronicle detail page.

## #1437 — HTML in posts is all escaped
Posts rendered through `quote_tag`, which escapes everything. They now render through a new `safe_post` filter that:
- sanitizes HTML with the existing bleach allowlist (bold, italic, links, lists, etc. — scripts/event handlers/javascript: URLs stripped)
- preserves the quote-highlighting behavior, applied only to text between tags so quotes in attributes (e.g. `href="..."`) are untouched

The WebSocket consumer now broadcasts a server-sanitized `message_html` alongside the raw message, and the live-append JS inserts it directly (falling back to escaping the raw message if absent), so live posts render identically to page loads.

## Testing
- 11 new tests for `safe_post` (XSS payloads, quote wrapping, href handling)
- `core.tests.templatetags`, `game.tests.views`, `game.tests.templates`, `game.tests.consumers`: pass. One pre-existing, unrelated failure (`TestXPSpendingRequestViews.test_create_view_requires_login` expects 403 but the auth middleware returns 401) reproduces on branches that don't touch `game` at all.

Closes #1436, closes #1437

https://claude.ai/code/session_01L51YqDgXSKKhJaYiMkorHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01L51YqDgXSKKhJaYiMkorHW)_