### PR TITLE
Chargen: client-side JS validation (Tasks 13–16)

### DIFF
--- a/characters/templates/characters/changeling/ctdhuman/ability_block_form.html
+++ b/characters/templates/characters/changeling/ctdhuman/ability_block_form.html
@@ -91,3 +91,4 @@
     <div class="col-sm">Technology</div>
     <div class="col-sm dots">{{ form.technology }}</div>
 </div>
+{% include "characters/core/ability_block/validation.html" %}

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -53,11 +53,14 @@
         // (HumanAbilityView.form_valid and variants) rejects values below 0 or
         // above 3, and IntegerField rejects fractions, so checking only the
         // category totals would let an out-of-range value pass the client.
+        // Detection only — the client never clamps/mutates the input value.
         function anyOutOfRange() {
             return groups.some(function(group) {
                 return group.some(function(field) {
+                    // The ModelForm field is required, so a cleared input is
+                    // invalid even if other ratings offset the category total.
                     var raw = field.value.trim();
-                    if (raw === '') return false;
+                    if (raw === '') return true;
                     var value = Number(raw);
                     var isInt = isFinite(value) && Math.floor(value) === value;
                     return !isInt || value < 0 || value > MAX_RATING;
@@ -78,6 +81,8 @@
                 message = 'Distribute {{ primary }}/{{ secondary }}/{{ tertiary }} dots across categories (currently ' + totals.slice().reverse().join('/') + ')';
             }
             TG.validation.setStatus(statusEl, valid, message);
+            // Abilities block submit until the distribution is valid; the
+            // backgrounds/virtues counters are status-only by design.
             TG.validation.setSubmitEnabled(form, valid);
         }
 

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -9,8 +9,8 @@
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         'use strict';
-        var form = document.querySelector('form');
         var statusEl = document.getElementById('abilities-validation-status');
+        var form = statusEl && statusEl.closest('form');
         if (!form || !statusEl || !window.TG || !TG.validation) return;
 
         var TARGETS = [{{ tertiary }}, {{ secondary }}, {{ primary }}].sort(function(a, b) { return a - b; });

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -34,6 +34,11 @@
         });
         if (!groups[0].length) return;
 
+        // Each ability is capped at 3 dots in chargen (HumanAbilityView
+        // form_valid rejects ratings above 3), but the rendered inputs allow
+        // higher values, so the client must enforce the cap too.
+        var MAX_RATING = 3;
+
         function groupTotal(group) {
             var total = 0;
             group.forEach(function(field) {
@@ -43,16 +48,28 @@
             return total;
         }
 
+        function anyOverCap() {
+            return groups.some(function(group) {
+                return group.some(function(field) {
+                    var value = parseInt(field.value, 10);
+                    return !isNaN(value) && value > MAX_RATING;
+                });
+            });
+        }
+
         function validate() {
             var totals = groups.map(groupTotal).sort(function(a, b) { return a - b; });
-            var valid = JSON.stringify(totals) === JSON.stringify(TARGETS);
-            TG.validation.setStatus(
-                statusEl,
-                valid,
-                valid
-                    ? 'Valid ({{ primary }}/{{ secondary }}/{{ tertiary }})'
-                    : 'Distribute {{ primary }}/{{ secondary }}/{{ tertiary }} dots across categories (currently ' + totals.slice().reverse().join('/') + ')'
-            );
+            var overCap = anyOverCap();
+            var valid = !overCap && JSON.stringify(totals) === JSON.stringify(TARGETS);
+            var message;
+            if (valid) {
+                message = 'Valid ({{ primary }}/{{ secondary }}/{{ tertiary }})';
+            } else if (overCap) {
+                message = 'No ability may exceed ' + MAX_RATING + ' dots in creation';
+            } else {
+                message = 'Distribute {{ primary }}/{{ secondary }}/{{ tertiary }} dots across categories (currently ' + totals.slice().reverse().join('/') + ')';
+            }
+            TG.validation.setStatus(statusEl, valid, message);
             TG.validation.setSubmitEnabled(form, valid);
         }
 

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -40,6 +40,8 @@
         // higher values, so the client must enforce the cap too.
         var MAX_RATING = 3;
 
+        // Parallel to TG.validation.sumFields but takes a pre-grouped array of
+        // inputs (not a selector), so it can't delegate to that helper.
         function groupTotal(group) {
             var total = 0;
             group.forEach(function(field) {

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -1,5 +1,8 @@
 {# Client-side validation for ability distribution forms. #}
 {# Expects primary/secondary/tertiary in context and rows of three .dots cells (Talents/Skills/Knowledges). #}
+{# Truthiness (not is-not-None) is deliberate: when this block is included
+   without the target context vars (plain edit forms), they resolve to ''
+   which must suppress the script. No gameline uses a 0 target (min is 3). #}
 {% if primary and secondary and tertiary %}
     <div class="row">
         <div class="col-sm">

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -71,7 +71,8 @@
         function validate() {
             var totals = groups.map(groupTotal).sort(function(a, b) { return a - b; });
             var outOfRange = anyOutOfRange();
-            var valid = !outOfRange && JSON.stringify(totals) === JSON.stringify(TARGETS);
+            var totalsMatch = totals.every(function(t, i) { return t === TARGETS[i]; });
+            var valid = !outOfRange && totalsMatch;
             var message;
             if (valid) {
                 message = 'Valid ({{ primary }}/{{ secondary }}/{{ tertiary }})';

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -3,7 +3,7 @@
 {% if primary and secondary and tertiary %}
     <div class="row">
         <div class="col-sm">
-            <div id="abilities-validation-status" style="font-weight: 600; margin-top: 8px;"></div>
+            <div id="abilities-validation-status" role="status" style="font-weight: 600; margin-top: 8px;"></div>
         </div>
     </div>
     <script>

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -1,0 +1,58 @@
+{# Client-side validation for ability distribution forms. #}
+{# Expects primary/secondary/tertiary in context and rows of three .dots cells (Talents/Skills/Knowledges). #}
+{% if primary and secondary and tertiary %}
+    <div class="row">
+        <div class="col-sm">
+            <div id="abilities-validation-status" style="font-weight: 600; margin-top: 8px;"></div>
+        </div>
+    </div>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        'use strict';
+        var form = document.querySelector('form');
+        var statusEl = document.getElementById('abilities-validation-status');
+        if (!form || !statusEl || !window.TG || !TG.validation) return;
+
+        var TARGETS = [{{ tertiary }}, {{ secondary }}, {{ primary }}].sort(function(a, b) { return a - b; });
+
+        // Ability rows lay out three .dots cells per row: Talents, Skills,
+        // Knowledges. Group the inputs by column position.
+        var groups = [[], [], []];
+        Array.prototype.forEach.call(form.querySelectorAll('.row'), function(row) {
+            var cells = row.querySelectorAll(':scope > .dots');
+            if (cells.length !== 3) return;
+            for (var i = 0; i < 3; i++) {
+                var input = cells[i].querySelector('input, select');
+                if (input) groups[i].push(input);
+            }
+        });
+        if (!groups[0].length) return;
+
+        function groupTotal(group) {
+            var total = 0;
+            group.forEach(function(field) {
+                var value = parseInt(field.value, 10);
+                if (!isNaN(value)) total += value;
+            });
+            return total;
+        }
+
+        function validate() {
+            var totals = groups.map(groupTotal).sort(function(a, b) { return a - b; });
+            var valid = JSON.stringify(totals) === JSON.stringify(TARGETS);
+            TG.validation.setStatus(
+                statusEl,
+                valid,
+                valid
+                    ? 'Valid ({{ primary }}/{{ secondary }}/{{ tertiary }})'
+                    : 'Distribute {{ primary }}/{{ secondary }}/{{ tertiary }} dots across categories (currently ' + totals.slice().reverse().join('/') + ')'
+            );
+            TG.validation.setSubmitEnabled(form, valid);
+        }
+
+        form.addEventListener('change', validate);
+        form.addEventListener('input', validate);
+        validate();
+    });
+    </script>
+{% endif %}

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -48,24 +48,31 @@
             return total;
         }
 
-        function anyOverCap() {
+        // Every ability must be a whole number in 0..MAX_RATING. The server
+        // (HumanAbilityView.form_valid and variants) rejects values below 0 or
+        // above 3, and IntegerField rejects fractions, so checking only the
+        // category totals would let an out-of-range value pass the client.
+        function anyOutOfRange() {
             return groups.some(function(group) {
                 return group.some(function(field) {
-                    var value = parseInt(field.value, 10);
-                    return !isNaN(value) && value > MAX_RATING;
+                    var raw = field.value.trim();
+                    if (raw === '') return false;
+                    var value = Number(raw);
+                    var isInt = isFinite(value) && Math.floor(value) === value;
+                    return !isInt || value < 0 || value > MAX_RATING;
                 });
             });
         }
 
         function validate() {
             var totals = groups.map(groupTotal).sort(function(a, b) { return a - b; });
-            var overCap = anyOverCap();
-            var valid = !overCap && JSON.stringify(totals) === JSON.stringify(TARGETS);
+            var outOfRange = anyOutOfRange();
+            var valid = !outOfRange && JSON.stringify(totals) === JSON.stringify(TARGETS);
             var message;
             if (valid) {
                 message = 'Valid ({{ primary }}/{{ secondary }}/{{ tertiary }})';
-            } else if (overCap) {
-                message = 'No ability may exceed ' + MAX_RATING + ' dots in creation';
+            } else if (outOfRange) {
+                message = 'Each ability must be a whole number from 0 to ' + MAX_RATING;
             } else {
                 message = 'Distribute {{ primary }}/{{ secondary }}/{{ tertiary }} dots across categories (currently ' + totals.slice().reverse().join('/') + ')';
             }

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -19,7 +19,8 @@
         var TARGETS = [{{ tertiary }}, {{ secondary }}, {{ primary }}].sort(function(a, b) { return a - b; });
 
         // Ability rows lay out three .dots cells per row: Talents, Skills,
-        // Knowledges. Group the inputs by column position. The length-3
+        // Knowledges. The grid is static, so grouping the inputs once here
+        // (not re-querying on each validate) is intentional. Group by column. The length-3
         // guard is sufficient because this include renders only on the
         // ability step, where the attribute block shows as a display (no
         // inputs) — input-bearing three-cell rows are the ability grid.

--- a/characters/templates/characters/core/ability_block/validation.html
+++ b/characters/templates/characters/core/ability_block/validation.html
@@ -19,7 +19,10 @@
         var TARGETS = [{{ tertiary }}, {{ secondary }}, {{ primary }}].sort(function(a, b) { return a - b; });
 
         // Ability rows lay out three .dots cells per row: Talents, Skills,
-        // Knowledges. Group the inputs by column position.
+        // Knowledges. Group the inputs by column position. The length-3
+        // guard is sufficient because this include renders only on the
+        // ability step, where the attribute block shows as a display (no
+        // inputs) — input-bearing three-cell rows are the ability grid.
         var groups = [[], [], []];
         Array.prototype.forEach.call(form.querySelectorAll('.row'), function(row) {
             var cells = row.querySelectorAll(':scope > .dots');

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -103,6 +103,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // formset:removed on document without an input/change event, so the
     // counter would otherwise keep the removed row's dots in the total.
     // (Dispatched on `document` by widgets/widgets/formset_manager.py.)
+    // Assumes the backgrounds step renders a single formset; re-validating
+    // on any formset removal is harmless since validate() rescans bg rows.
     document.addEventListener('formset:removed', validate);
     validate();
 });

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -40,6 +40,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // background's pk to its multiplier — not just the allowed subset —
     // because the formset add-row can select any background. pk and
     // multiplier are both integers, so rendering them into JS is safe.
+    {# |safe is XSS-safe only because the view json.dumps a dict of integer
+       pk->multiplier pairs. Do not reuse this with any string values. #}
     var MULTIPLIERS = {{ background_multipliers_json|safe }};
     if (Object.keys(MULTIPLIERS).length === 0) {
         console.warn('Background multiplier map is empty; all costs fall back to 1 per dot.');

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -44,7 +44,9 @@ document.addEventListener('DOMContentLoaded', function() {
        pk->multiplier pairs. Do not reuse this with any string values. #}
     // Built from all backgrounds; only empty on an unseeded table, in which
     // case costs fall back to 1/dot (the server still enforces the budget).
-    var MULTIPLIERS = {{ background_multipliers_json|safe }};
+    {# default:"{}" guards against an empty render (var absent from context)
+       producing `var MULTIPLIERS = ;` — a syntax error that breaks the script. #}
+    var MULTIPLIERS = {{ background_multipliers_json|default:"{}"|safe }};
 
     // BackgroundRatingForm's rating is an IntegerField clamped to 0..5, so a
     // negative or fractional rating is rejected server-side; the counter must

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -42,10 +42,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // multiplier are both integers, so rendering them into JS is safe.
     {# |safe is XSS-safe only because the view json.dumps a dict of integer
        pk->multiplier pairs. Do not reuse this with any string values. #}
+    // Built from all backgrounds; only empty on an unseeded table, in which
+    // case costs fall back to 1/dot (the server still enforces the budget).
     var MULTIPLIERS = {{ background_multipliers_json|safe }};
-    if (Object.keys(MULTIPLIERS).length === 0) {
-        console.warn('Background multiplier map is empty; all costs fall back to 1 per dot.');
-    }
 
     // BackgroundRatingForm's rating is an IntegerField clamped to 0..5, so a
     // negative or fractional rating is rejected server-side; the counter must

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -35,8 +35,10 @@ document.addEventListener('DOMContentLoaded', function() {
     // Some backgrounds (Enhancements, Sanctum, Totem...) cost more per dot.
     // empty_form comes from the view context with bg.queryset filtered to the
     // character's allowed backgrounds; this reads Background.multiplier off
-    // that queryset. If the field or model attribute is renamed this renders
-    // an empty map and every cost silently falls back to 1.
+    // that queryset. pk and multiplier are both integers (AutoField /
+    // IntegerField), so rendering them into JS directly is safe. If the
+    // field or model attribute is renamed this renders an empty map and
+    // every cost silently falls back to 1.
     var MULTIPLIERS = {
         {% for bg in empty_form.bg.field.queryset %}"{{ bg.pk }}": {{ bg.multiplier }}{% if not forloop.last %},{% endif %}{% endfor %}
     };

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -19,3 +19,52 @@
         {% for error in f.non_field_errors %}<p class="alert centertext">{{ error }}</p>{% endfor %}
     {% endif %}
 {% endfor %}
+<div class="row">
+    <div class="col-sm">
+        <div id="backgrounds-validation-status" style="font-weight: 600; margin-top: 8px;"></div>
+    </div>
+</div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    'use strict';
+    var form = document.querySelector('form');
+    var statusEl = document.getElementById('backgrounds-validation-status');
+    if (!form || !statusEl || !window.TG || !TG.validation) return;
+
+    var BUDGET = {{ object.background_points }};
+    // Some backgrounds (Enhancements, Sanctum, Totem...) cost more per dot
+    var MULTIPLIERS = {
+        {% for bg in form.empty_form.bg.field.queryset %}"{{ bg.pk }}": {{ bg.multiplier }}{% if not forloop.last %},{% endif %}{% endfor %}
+    };
+
+    function validate() {
+        var total = 0;
+        Array.prototype.forEach.call(form.querySelectorAll('select[name$="-bg"]'), function(select) {
+            if (select.name.indexOf('__prefix__') !== -1) return;  // hidden empty-form template
+            var prefix = select.name.slice(0, -'-bg'.length);
+            var deleteBox = form.querySelector('input[name="' + prefix + '-DELETE"]');
+            if (deleteBox && deleteBox.checked) return;
+            var ratingInput = form.querySelector('input[name="' + prefix + '-rating"]');
+            if (!ratingInput) return;
+            var rating = parseInt(ratingInput.value, 10);
+            if (isNaN(rating)) return;
+            var multiplier = MULTIPLIERS[select.value] || 1;
+            total += rating * multiplier;
+        });
+        var valid = (total === BUDGET);
+        var message;
+        if (valid) {
+            message = 'Valid (' + total + '/' + BUDGET + ' points)';
+        } else if (total > BUDGET) {
+            message = (total - BUDGET) + ' point(s) over budget (' + total + '/' + BUDGET + ')';
+        } else {
+            message = (BUDGET - total) + ' point(s) remaining (' + total + '/' + BUDGET + ')';
+        }
+        TG.validation.setStatus(statusEl, valid, message);
+    }
+
+    form.addEventListener('change', validate);
+    form.addEventListener('input', validate);
+    validate();
+});
+</script>

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -66,7 +66,12 @@ document.addEventListener('DOMContentLoaded', function() {
             var ratingInput = form.querySelector('input[name="' + prefix + '-rating"]');
             if (!ratingInput) return;
             var raw = ratingInput.value.trim();
-            if (raw === '') return;
+            if (raw === '') {
+                // A selected background requires a rating (form field is
+                // required); a blank rating can't save, so mark invalid.
+                outOfRange = true;
+                return;
+            }
             var rating = Number(raw);
             var isInt = isFinite(rating) && Math.floor(rating) === rating;
             if (!isInt || rating < RATING_MIN || rating > RATING_MAX) {

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -49,7 +49,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // BackgroundRatingForm's rating is an IntegerField clamped to 0..5, so a
     // negative or fractional rating is rejected server-side; the counter must
     // treat such a row as invalid rather than folding it into the total.
-    var RATING_MIN = 0, RATING_MAX = 5;
+    var RATING_MIN = 0;
+    var RATING_MAX = 5;
 
     function validate() {
         var total = 0;

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -85,6 +85,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // The dynamic formset's Remove button deletes the row and fires
     // formset:removed on document without an input/change event, so the
     // counter would otherwise keep the removed row's dots in the total.
+    // (Dispatched on `document` by widgets/widgets/formset_manager.py.)
     document.addEventListener('formset:removed', validate);
     validate();
 });

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -19,6 +19,9 @@
         {% for error in f.non_field_errors %}<p class="alert centertext">{{ error }}</p>{% endfor %}
     {% endif %}
 {% endfor %}
+{# Guard mirrors the abilities include: only render the counter where the
+   character actually has a background budget in context. #}
+{% if object.background_points %}
 <div class="row">
     <div class="col-sm">
         <div id="backgrounds-validation-status" role="status" style="font-weight: 600; margin-top: 8px;"></div>
@@ -79,3 +82,4 @@ document.addEventListener('DOMContentLoaded', function() {
     validate();
 });
 </script>
+{% endif %}

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -36,14 +36,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
     var BUDGET = {{ object.background_points }};
     // Some backgrounds (Enhancements, Sanctum, Totem...) cost more per dot.
-    // empty_form comes from the view context with bg.queryset filtered to the
-    // character's allowed backgrounds; this reads Background.multiplier off
-    // that queryset. pk and multiplier are both integers (AutoField /
-    // IntegerField), so rendering them into JS directly is safe. If the
-    // field or model attribute is renamed this renders an empty map and
-    // every cost silently falls back to 1.
+    // background_multipliers (from the view) maps every selectable
+    // background's pk to its multiplier — not just the allowed subset —
+    // because the formset add-row can select any background. pk and
+    // multiplier are both integers, so rendering them into JS is safe.
     var MULTIPLIERS = {
-        {% for bg in empty_form.bg.field.queryset %}"{{ bg.pk }}": {{ bg.multiplier }}{% if not forloop.last %},{% endif %}{% endfor %}
+        {% for pk, mult in background_multipliers.items %}"{{ pk }}": {{ mult }}{% if not forloop.last %},{% endif %}{% endfor %}
     };
     if (Object.keys(MULTIPLIERS).length === 0) {
         console.warn('Background multiplier map is empty; all costs fall back to 1 per dot.');

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -40,9 +40,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // background's pk to its multiplier — not just the allowed subset —
     // because the formset add-row can select any background. pk and
     // multiplier are both integers, so rendering them into JS is safe.
-    var MULTIPLIERS = {
-        {% for pk, mult in background_multipliers.items %}"{{ pk }}": {{ mult }}{% if not forloop.last %},{% endif %}{% endfor %}
-    };
+    var MULTIPLIERS = {{ background_multipliers_json|safe }};
     if (Object.keys(MULTIPLIERS).length === 0) {
         console.warn('Background multiplier map is empty; all costs fall back to 1 per dot.');
     }

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -40,6 +40,9 @@ document.addEventListener('DOMContentLoaded', function() {
     var MULTIPLIERS = {
         {% for bg in empty_form.bg.field.queryset %}"{{ bg.pk }}": {{ bg.multiplier }}{% if not forloop.last %},{% endif %}{% endfor %}
     };
+    if (Object.keys(MULTIPLIERS).length === 0) {
+        console.warn('Background multiplier map is empty; all costs fall back to 1 per dot.');
+    }
 
     function validate() {
         var total = 0;

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -53,6 +53,9 @@ document.addEventListener('DOMContentLoaded', function() {
         var total = 0;
         Array.prototype.forEach.call(form.querySelectorAll('select[name$="-bg"]'), function(select) {
             if (select.name.indexOf('__prefix__') !== -1) return;  // hidden empty-form template
+            // A rating with no background chosen can't be saved (bg is
+            // required), so it must not count toward the total.
+            if (!select.value) return;
             var prefix = select.name.replace(/-bg$/, '');
             var deleteBox = form.querySelector('input[name="' + prefix + '-DELETE"]');
             if (deleteBox && deleteBox.checked) return;
@@ -79,6 +82,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     form.addEventListener('change', validate);
     form.addEventListener('input', validate);
+    // The dynamic formset's Remove button deletes the row and fires
+    // formset:removed on document without an input/change event, so the
+    // counter would otherwise keep the removed row's dots in the total.
+    document.addEventListener('formset:removed', validate);
     validate();
 });
 </script>

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -27,8 +27,8 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     'use strict';
-    var form = document.querySelector('form');
     var statusEl = document.getElementById('backgrounds-validation-status');
+    var form = statusEl && statusEl.closest('form');
     if (!form || !statusEl || !window.TG || !TG.validation) return;
 
     var BUDGET = {{ object.background_points }};

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -47,8 +47,14 @@ document.addEventListener('DOMContentLoaded', function() {
         console.warn('Background multiplier map is empty; all costs fall back to 1 per dot.');
     }
 
+    // BackgroundRatingForm's rating is an IntegerField clamped to 0..5, so a
+    // negative or fractional rating is rejected server-side; the counter must
+    // treat such a row as invalid rather than folding it into the total.
+    var RATING_MIN = 0, RATING_MAX = 5;
+
     function validate() {
         var total = 0;
+        var outOfRange = false;
         Array.prototype.forEach.call(form.querySelectorAll('select[name$="-bg"]'), function(select) {
             if (select.name.indexOf('__prefix__') !== -1) return;  // hidden empty-form template
             // A rating with no background chosen can't be saved (bg is
@@ -59,16 +65,24 @@ document.addEventListener('DOMContentLoaded', function() {
             if (deleteBox && deleteBox.checked) return;
             var ratingInput = form.querySelector('input[name="' + prefix + '-rating"]');
             if (!ratingInput) return;
-            var rating = parseInt(ratingInput.value, 10);
-            if (isNaN(rating)) return;
+            var raw = ratingInput.value.trim();
+            if (raw === '') return;
+            var rating = Number(raw);
+            var isInt = isFinite(rating) && Math.floor(rating) === rating;
+            if (!isInt || rating < RATING_MIN || rating > RATING_MAX) {
+                outOfRange = true;
+                return;
+            }
             var multiplier = MULTIPLIERS[select.value] || 1;
             total += rating * multiplier;
         });
         // Counter only — submit stays enabled (unlike abilities) so players
         // can save partial progress; the server still enforces the budget.
-        var valid = (total === BUDGET);
+        var valid = !outOfRange && (total === BUDGET);
         var message;
-        if (valid) {
+        if (outOfRange) {
+            message = 'Each rating must be a whole number from ' + RATING_MIN + ' to ' + RATING_MAX;
+        } else if (valid) {
             message = 'Valid (' + total + '/' + BUDGET + ' points)';
         } else if (total > BUDGET) {
             message = (total - BUDGET) + ' point(s) over budget (' + total + '/' + BUDGET + ')';

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var total = 0;
         Array.prototype.forEach.call(form.querySelectorAll('select[name$="-bg"]'), function(select) {
             if (select.name.indexOf('__prefix__') !== -1) return;  // hidden empty-form template
-            var prefix = select.name.slice(0, -'-bg'.length);
+            var prefix = select.name.slice(0, -3);  // strip the trailing '-bg'
             var deleteBox = form.querySelector('input[name="' + prefix + '-DELETE"]');
             if (deleteBox && deleteBox.checked) return;
             var ratingInput = form.querySelector('input[name="' + prefix + '-rating"]');

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
         var total = 0;
         Array.prototype.forEach.call(form.querySelectorAll('select[name$="-bg"]'), function(select) {
             if (select.name.indexOf('__prefix__') !== -1) return;  // hidden empty-form template
-            var prefix = select.name.slice(0, -3);  // strip the trailing '-bg'
+            var prefix = select.name.replace(/-bg$/, '');
             var deleteBox = form.querySelector('input[name="' + prefix + '-DELETE"]');
             if (deleteBox && deleteBox.checked) return;
             var ratingInput = form.querySelector('input[name="' + prefix + '-rating"]');

--- a/characters/templates/characters/core/background_block/form.html
+++ b/characters/templates/characters/core/background_block/form.html
@@ -21,7 +21,7 @@
 {% endfor %}
 <div class="row">
     <div class="col-sm">
-        <div id="backgrounds-validation-status" style="font-weight: 600; margin-top: 8px;"></div>
+        <div id="backgrounds-validation-status" role="status" style="font-weight: 600; margin-top: 8px;"></div>
     </div>
 </div>
 <script>
@@ -32,9 +32,13 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!form || !statusEl || !window.TG || !TG.validation) return;
 
     var BUDGET = {{ object.background_points }};
-    // Some backgrounds (Enhancements, Sanctum, Totem...) cost more per dot
+    // Some backgrounds (Enhancements, Sanctum, Totem...) cost more per dot.
+    // empty_form comes from the view context with bg.queryset filtered to the
+    // character's allowed backgrounds; this reads Background.multiplier off
+    // that queryset. If the field or model attribute is renamed this renders
+    // an empty map and every cost silently falls back to 1.
     var MULTIPLIERS = {
-        {% for bg in form.empty_form.bg.field.queryset %}"{{ bg.pk }}": {{ bg.multiplier }}{% if not forloop.last %},{% endif %}{% endfor %}
+        {% for bg in empty_form.bg.field.queryset %}"{{ bg.pk }}": {{ bg.multiplier }}{% if not forloop.last %},{% endif %}{% endfor %}
     };
 
     function validate() {
@@ -51,6 +55,8 @@ document.addEventListener('DOMContentLoaded', function() {
             var multiplier = MULTIPLIERS[select.value] || 1;
             total += rating * multiplier;
         });
+        // Counter only — submit stays enabled (unlike abilities) so players
+        // can save partial progress; the server still enforces the budget.
         var valid = (total === BUDGET);
         var message;
         if (valid) {

--- a/characters/templates/characters/mage/mtahuman/ability_block_form.html
+++ b/characters/templates/characters/mage/mtahuman/ability_block_form.html
@@ -99,3 +99,4 @@
     <div class="col-sm">Science</div>
     <div class="col-sm dots">{{ form.science }}</div>
 </div>
+{% include "characters/core/ability_block/validation.html" %}

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -121,7 +121,7 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
-                                <div id="virtues-validation-status" role="status" style="font-weight: 600;"></div>
+                                <div id="virtues-validation-status" role="status" style="font-weight: 600; margin-top: 8px;"></div>
                                 <script>
                                 document.addEventListener('DOMContentLoaded', function() {
                                     'use strict';

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -85,6 +85,36 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
+                                <div id="virtues-validation-status" style="font-weight: 600;"></div>
+                                <script>
+                                document.addEventListener('DOMContentLoaded', function() {
+                                    'use strict';
+                                    var form = document.querySelector('form');
+                                    var statusEl = document.getElementById('virtues-validation-status');
+                                    if (!form || !statusEl || !window.TG || !TG.validation) return;
+
+                                    var TARGET = 7;
+                                    // Inactive virtues render as hidden inputs and don't count
+                                    var SELECTOR = [
+                                        '#id_conscience', '#id_conviction',
+                                        '#id_self_control', '#id_instinct',
+                                        '#id_courage'
+                                    ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
+
+                                    function validate() {
+                                        var total = TG.validation.sumFields(form, SELECTOR);
+                                        var valid = (total === TARGET);
+                                        TG.validation.setStatus(
+                                            statusEl, valid,
+                                            valid ? 'Valid (' + total + '/7)' : total + '/7 dots'
+                                        );
+                                    }
+
+                                    form.addEventListener('change', validate);
+                                    form.addEventListener('input', validate);
+                                    validate();
+                                });
+                                </script>
                             </div>
                         </div>
                     </div>
@@ -121,6 +151,36 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
+                                <div id="virtues-validation-status" style="font-weight: 600;"></div>
+                                <script>
+                                document.addEventListener('DOMContentLoaded', function() {
+                                    'use strict';
+                                    var form = document.querySelector('form');
+                                    var statusEl = document.getElementById('virtues-validation-status');
+                                    if (!form || !statusEl || !window.TG || !TG.validation) return;
+
+                                    var TARGET = 7;
+                                    // Inactive virtues render as hidden inputs and don't count
+                                    var SELECTOR = [
+                                        '#id_conscience', '#id_conviction',
+                                        '#id_self_control', '#id_instinct',
+                                        '#id_courage'
+                                    ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
+
+                                    function validate() {
+                                        var total = TG.validation.sumFields(form, SELECTOR);
+                                        var valid = (total === TARGET);
+                                        TG.validation.setStatus(
+                                            statusEl, valid,
+                                            valid ? 'Valid (' + total + '/7)' : total + '/7 dots'
+                                        );
+                                    }
+
+                                    form.addEventListener('change', validate);
+                                    form.addEventListener('input', validate);
+                                    validate();
+                                });
+                                </script>
                             </div>
                         </div>
                     </div>
@@ -153,6 +213,36 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
+                                <div id="virtues-validation-status" style="font-weight: 600;"></div>
+                                <script>
+                                document.addEventListener('DOMContentLoaded', function() {
+                                    'use strict';
+                                    var form = document.querySelector('form');
+                                    var statusEl = document.getElementById('virtues-validation-status');
+                                    if (!form || !statusEl || !window.TG || !TG.validation) return;
+
+                                    var TARGET = 7;
+                                    // Inactive virtues render as hidden inputs and don't count
+                                    var SELECTOR = [
+                                        '#id_conscience', '#id_conviction',
+                                        '#id_self_control', '#id_instinct',
+                                        '#id_courage'
+                                    ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
+
+                                    function validate() {
+                                        var total = TG.validation.sumFields(form, SELECTOR);
+                                        var valid = (total === TARGET);
+                                        TG.validation.setStatus(
+                                            statusEl, valid,
+                                            valid ? 'Valid (' + total + '/7)' : total + '/7 dots'
+                                        );
+                                    }
+
+                                    form.addEventListener('change', validate);
+                                    form.addEventListener('input', validate);
+                                    validate();
+                                });
+                                </script>
                             </div>
                         </div>
                     </div>

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -131,6 +131,8 @@
 
                                     // Status only — submit stays enabled; the
                                     // server enforces the 7-dot total.
+                                    // Vampire only; Demon's total is 6 — make this
+                                    // context-driven when Demon chargen exists.
                                     var TARGET = 7;
                                     // Inactive virtues render as hidden inputs and don't count
                                     var SELECTOR = [

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -146,7 +146,7 @@
                                         var valid = (total === TARGET);
                                         TG.validation.setStatus(
                                             statusEl, valid,
-                                            valid ? 'Valid (' + total + '/7)' : total + '/7 dots'
+                                            valid ? 'Valid (' + total + '/' + TARGET + ')' : total + '/' + TARGET + ' dots'
                                         );
                                     }
 

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -141,13 +141,30 @@
                                         '#id_courage'
                                     ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
 
+                                    function activeBelowMin() {
+                                        // Each active virtue (Courage + the two
+                                        // chosen pair members) must be >= 1, per
+                                        // Vampire.clean(). The selector already
+                                        // matches only the active (visible) inputs.
+                                        var fields = form.querySelectorAll(SELECTOR);
+                                        return Array.prototype.some.call(fields, function(f) {
+                                            return (parseInt(f.value, 10) || 0) < 1;
+                                        });
+                                    }
+
                                     function validate() {
                                         var total = TG.validation.sumFields(form, SELECTOR);
-                                        var valid = (total === TARGET);
-                                        TG.validation.setStatus(
-                                            statusEl, valid,
-                                            valid ? 'Valid (' + total + '/' + TARGET + ')' : total + '/' + TARGET + ' dots'
-                                        );
+                                        var belowMin = activeBelowMin();
+                                        var valid = (total === TARGET) && !belowMin;
+                                        var message;
+                                        if (valid) {
+                                            message = 'Valid (' + total + '/' + TARGET + ')';
+                                        } else if (belowMin && total === TARGET) {
+                                            message = 'Each virtue must be at least 1';
+                                        } else {
+                                            message = total + '/' + TARGET + ' dots';
+                                        }
+                                        TG.validation.setStatus(statusEl, valid, message);
                                     }
 
                                     form.addEventListener('change', validate);

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -159,8 +159,8 @@
                                         var message;
                                         if (valid) {
                                             message = 'Valid (' + total + '/' + TARGET + ')';
-                                        } else if (belowMin && total === TARGET) {
-                                            message = 'Each virtue must be at least 1';
+                                        } else if (belowMin) {
+                                            message = 'Each virtue must be at least 1 (' + total + '/' + TARGET + ')';
                                         } else {
                                             message = total + '/' + TARGET + ' dots';
                                         }

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -141,26 +141,30 @@
                                         '#id_courage'
                                     ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
 
-                                    function activeBelowMin() {
+                                    function activeInvalid() {
                                         // Each active virtue (Courage + the two
-                                        // chosen pair members) must be >= 1, per
-                                        // Vampire.clean(). The selector already
-                                        // matches only the active (visible) inputs.
+                                        // chosen pair members) must be a whole
+                                        // number >= 1, per Vampire.clean() and
+                                        // IntegerField. parseInt would truncate a
+                                        // fractional value the server then rejects,
+                                        // so check the raw value is an integer too.
                                         var fields = form.querySelectorAll(SELECTOR);
                                         return Array.prototype.some.call(fields, function(f) {
-                                            return (parseInt(f.value, 10) || 0) < 1;
+                                            var value = Number(f.value);
+                                            var isInt = isFinite(value) && Math.floor(value) === value;
+                                            return !isInt || value < 1;
                                         });
                                     }
 
                                     function validate() {
                                         var total = TG.validation.sumFields(form, SELECTOR);
-                                        var belowMin = activeBelowMin();
-                                        var valid = (total === TARGET) && !belowMin;
+                                        var invalid = activeInvalid();
+                                        var valid = (total === TARGET) && !invalid;
                                         var message;
                                         if (valid) {
                                             message = 'Valid (' + total + '/' + TARGET + ')';
-                                        } else if (belowMin) {
-                                            message = 'Each virtue must be at least 1 (' + total + '/' + TARGET + ')';
+                                        } else if (invalid) {
+                                            message = 'Each virtue must be a whole number of at least 1 (' + total + '/' + TARGET + ')';
                                         } else {
                                             message = total + '/' + TARGET + ' dots';
                                         }

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -125,8 +125,8 @@
                                 <script>
                                 document.addEventListener('DOMContentLoaded', function() {
                                     'use strict';
-                                    var form = document.querySelector('form');
                                     var statusEl = document.getElementById('virtues-validation-status');
+                                    var form = statusEl && statusEl.closest('form');
                                     if (!form || !statusEl || !window.TG || !TG.validation) return;
 
                                     // Status only — submit stays enabled; the

--- a/characters/templates/characters/vampire/vampire/chargen.html
+++ b/characters/templates/characters/vampire/vampire/chargen.html
@@ -85,36 +85,6 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
-                                <div id="virtues-validation-status" style="font-weight: 600;"></div>
-                                <script>
-                                document.addEventListener('DOMContentLoaded', function() {
-                                    'use strict';
-                                    var form = document.querySelector('form');
-                                    var statusEl = document.getElementById('virtues-validation-status');
-                                    if (!form || !statusEl || !window.TG || !TG.validation) return;
-
-                                    var TARGET = 7;
-                                    // Inactive virtues render as hidden inputs and don't count
-                                    var SELECTOR = [
-                                        '#id_conscience', '#id_conviction',
-                                        '#id_self_control', '#id_instinct',
-                                        '#id_courage'
-                                    ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
-
-                                    function validate() {
-                                        var total = TG.validation.sumFields(form, SELECTOR);
-                                        var valid = (total === TARGET);
-                                        TG.validation.setStatus(
-                                            statusEl, valid,
-                                            valid ? 'Valid (' + total + '/7)' : total + '/7 dots'
-                                        );
-                                    }
-
-                                    form.addEventListener('change', validate);
-                                    form.addEventListener('input', validate);
-                                    validate();
-                                });
-                                </script>
                             </div>
                         </div>
                     </div>
@@ -151,7 +121,7 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
-                                <div id="virtues-validation-status" style="font-weight: 600;"></div>
+                                <div id="virtues-validation-status" role="status" style="font-weight: 600;"></div>
                                 <script>
                                 document.addEventListener('DOMContentLoaded', function() {
                                     'use strict';
@@ -159,6 +129,8 @@
                                     var statusEl = document.getElementById('virtues-validation-status');
                                     if (!form || !statusEl || !window.TG || !TG.validation) return;
 
+                                    // Status only — submit stays enabled; the
+                                    // server enforces the 7-dot total.
                                     var TARGET = 7;
                                     // Inactive virtues render as hidden inputs and don't count
                                     var SELECTOR = [
@@ -213,36 +185,6 @@
                             <div class="tg-card-body">
                                 {% csrf_token %}
                                 {{ form.as_p }}
-                                <div id="virtues-validation-status" style="font-weight: 600;"></div>
-                                <script>
-                                document.addEventListener('DOMContentLoaded', function() {
-                                    'use strict';
-                                    var form = document.querySelector('form');
-                                    var statusEl = document.getElementById('virtues-validation-status');
-                                    if (!form || !statusEl || !window.TG || !TG.validation) return;
-
-                                    var TARGET = 7;
-                                    // Inactive virtues render as hidden inputs and don't count
-                                    var SELECTOR = [
-                                        '#id_conscience', '#id_conviction',
-                                        '#id_self_control', '#id_instinct',
-                                        '#id_courage'
-                                    ].map(function(id) { return id + ':not([type="hidden"])'; }).join(', ');
-
-                                    function validate() {
-                                        var total = TG.validation.sumFields(form, SELECTOR);
-                                        var valid = (total === TARGET);
-                                        TG.validation.setStatus(
-                                            statusEl, valid,
-                                            valid ? 'Valid (' + total + '/7)' : total + '/7 dots'
-                                        );
-                                    }
-
-                                    form.addEventListener('change', validate);
-                                    form.addEventListener('input', validate);
-                                    validate();
-                                });
-                                </script>
                             </div>
                         </div>
                     </div>

--- a/characters/templates/characters/vampire/vtmhuman/ability_block_form.html
+++ b/characters/templates/characters/vampire/vtmhuman/ability_block_form.html
@@ -91,3 +91,4 @@
     <div class="col-sm">Technology</div>
     <div class="col-sm dots">{{ form.technology }}</div>
 </div>
+{% include "characters/core/ability_block/validation.html" %}

--- a/characters/templates/characters/werewolf/wtahuman/ability_block_form.html
+++ b/characters/templates/characters/werewolf/wtahuman/ability_block_form.html
@@ -91,3 +91,4 @@
     <div class="col-sm">Technology</div>
     <div class="col-sm dots">{{ form.technology }}</div>
 </div>
+{% include "characters/core/ability_block/validation.html" %}

--- a/characters/templates/characters/wraith/wtohuman/ability_block_form.html
+++ b/characters/templates/characters/wraith/wtohuman/ability_block_form.html
@@ -91,3 +91,4 @@
     <div class="col-sm">Technology</div>
     <div class="col-sm dots">{{ form.technology }}</div>
 </div>
+{% include "characters/core/ability_block/validation.html" %}

--- a/characters/tests/views/core/test_backgrounds.py
+++ b/characters/tests/views/core/test_backgrounds.py
@@ -377,3 +377,24 @@ class TestHumanBackgroundsViewMultiplier(TestCase):
         # Total = 4 + 1 = 5, should be valid
         if response.status_code == 302:
             self.assertEqual(self.human.creation_status, initial_status + 1)
+
+
+class TestHumanBackgroundsViewContext(TestCase):
+    """Tests for HumanBackgroundsView context data."""
+
+    def setUp(self):
+        human_setup()
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.human = Human.objects.create(
+            name="Test Human",
+            owner=self.owner,
+            creation_status=3,
+        )
+
+    def test_empty_form_in_context(self):
+        """empty_form must be in context: the points-counter JS builds its
+        multiplier map from empty_form.bg.field.queryset."""
+        self.client.login(username="owner", password="password")
+        response = self.client.get(self.human.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("empty_form", response.context)

--- a/characters/tests/views/core/test_backgrounds.py
+++ b/characters/tests/views/core/test_backgrounds.py
@@ -392,9 +392,10 @@ class TestHumanBackgroundsViewContext(TestCase):
         )
 
     def test_empty_form_in_context(self):
-        """empty_form must be in context: the points-counter JS builds its
-        multiplier map from empty_form.bg.field.queryset."""
+        """empty_form and the multiplier-map JSON must be in context: the
+        points-counter JS depends on both."""
         self.client.login(username="owner", password="password")
         response = self.client.get(self.human.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertIn("empty_form", response.context)
+        self.assertIn("background_multipliers_json", response.context)

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -61,3 +61,21 @@ class TestChargenValidationRendering(TestCase):
         ).first()
         self.assertIsNotNone(bg)
         self.assertContains(response, f'"{bg.pk}": {bg.multiplier}')
+
+    def test_virtues_step_renders_validation(self):
+        from django.urls import reverse
+
+        from characters.models.vampire.vampire import Vampire
+
+        char = Vampire.objects.create(
+            name="Virtue Vampire", owner=self.owner, creation_status=5
+        )
+        self.client.login(username="owner", password="password")
+        # Vampire.get_absolute_url targets the plain detail view; chargen is
+        # reached through the generic character dispatcher.
+        response = self.client.get(
+            reverse("characters:character", kwargs={"pk": char.pk})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "virtues-validation-status")
+        self.assertContains(response, "TG.validation")

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -125,8 +125,8 @@ class TestChargenValidationRendering(TestCase):
 
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no
-        # backgrounds block (pre-existing gap), so exercise a flow whose
-        # template includes background_block/form.html: the Wraith human.
+        # backgrounds block (pre-existing gap, tracked in #1459), so exercise a
+        # flow whose template includes background_block/form.html: Wraith human.
         char = WtOHuman.objects.create(
             name="Background Human", owner=self.owner, creation_status=3
         )

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -69,6 +69,21 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation = {")
 
+    def test_staff_non_owner_sees_ability_validation(self):
+        """A staff user who is not the owner keeps is_approved_user via the
+        middleware flag, so they still see the form (not the not-owner
+        fallback) — the per-view flag must combine staff OR special-user."""
+        char = MtAHuman.objects.create(
+            name="Mage Ability Human", owner=self.owner, creation_status=2
+        )
+        staff = User.objects.create_user(
+            username="staff", password="password", is_staff=True
+        )
+        self.client.login(username="staff", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "abilities-validation-status")
+
     def test_abilities_validation_absent_before_ability_step(self):
         """The ability validation include must not render outside the
         ability step (here, step 1), so it can never disable submit on a

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -43,6 +43,18 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation")
 
+    def test_abilities_step_renders_validation_third_gameline(self):
+        from characters.models.werewolf.wtahuman import WtAHuman
+
+        char = WtAHuman.objects.create(
+            name="Werewolf Ability Human", owner=self.owner, creation_status=2
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "abilities-validation-status")
+        self.assertContains(response, "TG.validation")
+
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no
         # backgrounds block (pre-existing gap), so exercise a flow whose

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -38,3 +38,11 @@ class TestChargenValidationRendering(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "backgrounds-validation-status")
         self.assertContains(response, "TG.validation")
+        # The multiplier map must render with real data, not fall back empty
+        from characters.models.core.background_block import Background
+
+        bg = Background.objects.filter(
+            property_name__in=char.allowed_backgrounds
+        ).first()
+        self.assertIsNotNone(bg)
+        self.assertContains(response, f'"{bg.pk}": {bg.multiplier}')

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -3,7 +3,9 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
 
+from characters.models.core.background_block import Background
 from characters.models.core.human import Human
+from characters.models.wraith.wtohuman import WtOHuman
 from characters.tests.utils import human_setup
 
 
@@ -28,8 +30,6 @@ class TestChargenValidationRendering(TestCase):
         # The plain-Human step 3 template (core/human/chargen.html) has no
         # backgrounds block (pre-existing gap), so exercise a flow whose
         # template includes background_block/form.html: the Wraith human.
-        from characters.models.wraith.wtohuman import WtOHuman
-
         char = WtOHuman.objects.create(
             name="Background Human", owner=self.owner, creation_status=3
         )
@@ -39,8 +39,6 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "backgrounds-validation-status")
         self.assertContains(response, "TG.validation")
         # The multiplier map must render with real data, not fall back empty
-        from characters.models.core.background_block import Background
-
         bg = Background.objects.filter(
             property_name__in=char.allowed_backgrounds
         ).first()

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -26,6 +26,23 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation")
 
+    def test_abilities_step_renders_validation_other_gameline(self):
+        # The shared include covers five gamelines; exercise a second flow
+        # whose view sets the target context vars independently. (Not
+        # WtOHuman: its ability view never sets is_approved_user, so that
+        # step renders the not-owner fallback even for owners — pre-existing
+        # bug noted on issue #1459.)
+        from characters.models.vampire.vtmhuman import VtMHuman
+
+        char = VtMHuman.objects.create(
+            name="Vampire Ability Human", owner=self.owner, creation_status=2
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "abilities-validation-status")
+        self.assertContains(response, "TG.validation")
+
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no
         # backgrounds block (pre-existing gap), so exercise a flow whose

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -39,7 +39,7 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation = {")
 
-    def test_abilities_step_renders_validation_other_gameline(self):
+    def test_abilities_step_renders_validation_vtmhuman(self):
         char = VtMHuman.objects.create(
             name="Vampire Ability Human", owner=self.owner, creation_status=2
         )
@@ -49,7 +49,7 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation = {")
 
-    def test_abilities_step_renders_validation_third_gameline(self):
+    def test_abilities_step_renders_validation_wtahuman(self):
         char = WtAHuman.objects.create(
             name="Werewolf Ability Human", owner=self.owner, creation_status=2
         )
@@ -59,7 +59,7 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation = {")
 
-    def test_abilities_step_renders_validation_fourth_gameline(self):
+    def test_abilities_step_renders_validation_ctdhuman(self):
         char = CtDHuman.objects.create(
             name="Changeling Ability Human", owner=self.owner, creation_status=2
         )
@@ -68,6 +68,18 @@ class TestChargenValidationRendering(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation = {")
+
+    def test_abilities_validation_absent_before_ability_step(self):
+        """The ability validation include must not render outside the
+        ability step (here, step 1), so it can never disable submit on a
+        non-distribution form."""
+        char = WtOHuman.objects.create(
+            name="Pre-ability Human", owner=self.owner, creation_status=1
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "abilities-validation-status")
 
     def test_abilities_step_renders_validation_all_gamelines(self):
         """WtOHuman and MtAHuman work now that their ability views set

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -55,6 +55,20 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation")
 
+    def test_abilities_step_renders_validation_fourth_gameline(self):
+        # Changeling human; MtAHuman is excluded for the same reason as
+        # WtOHuman — its ability view never sets is_approved_user (#1459).
+        from characters.models.changeling.ctdhuman import CtDHuman
+
+        char = CtDHuman.objects.create(
+            name="Changeling Ability Human", owner=self.owner, creation_status=2
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "abilities-validation-status")
+        self.assertContains(response, "TG.validation")
+
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no
         # backgrounds block (pre-existing gap), so exercise a flow whose

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -17,7 +17,13 @@ from characters.tests.utils import human_setup
 
 
 class TestChargenValidationRendering(TestCase):
-    """The validation include and shared utilities must reach the page."""
+    """The validation include and shared utilities must reach the page.
+
+    Gameline note: VtMHuman/WtAHuman/CtDHuman ability views inherit
+    HumanAbilityView (whose permission mixin sets is_approved_user);
+    the WtOHuman/MtAHuman views are SpecialUserMixin-based and needed
+    the explicit flag fix carried in this PR (#1459).
+    """
 
     def setUp(self):
         human_setup()
@@ -31,7 +37,7 @@ class TestChargenValidationRendering(TestCase):
         response = self.client.get(char.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
-        self.assertContains(response, "TG.validation")
+        self.assertContains(response, "TG.validation = {")
 
     def test_abilities_step_renders_validation_other_gameline(self):
         char = VtMHuman.objects.create(
@@ -41,7 +47,7 @@ class TestChargenValidationRendering(TestCase):
         response = self.client.get(char.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
-        self.assertContains(response, "TG.validation")
+        self.assertContains(response, "TG.validation = {")
 
     def test_abilities_step_renders_validation_third_gameline(self):
         char = WtAHuman.objects.create(
@@ -51,7 +57,7 @@ class TestChargenValidationRendering(TestCase):
         response = self.client.get(char.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
-        self.assertContains(response, "TG.validation")
+        self.assertContains(response, "TG.validation = {")
 
     def test_abilities_step_renders_validation_fourth_gameline(self):
         char = CtDHuman.objects.create(
@@ -61,7 +67,7 @@ class TestChargenValidationRendering(TestCase):
         response = self.client.get(char.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
-        self.assertContains(response, "TG.validation")
+        self.assertContains(response, "TG.validation = {")
 
     def test_abilities_step_renders_validation_all_gamelines(self):
         """WtOHuman and MtAHuman work now that their ability views set
@@ -74,7 +80,7 @@ class TestChargenValidationRendering(TestCase):
             response = self.client.get(char.get_absolute_url())
             self.assertEqual(response.status_code, 200)
             self.assertContains(response, "abilities-validation-status")
-            self.assertContains(response, "TG.validation")
+            self.assertContains(response, "TG.validation = {")
 
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no
@@ -87,7 +93,7 @@ class TestChargenValidationRendering(TestCase):
         response = self.client.get(char.get_absolute_url())
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "backgrounds-validation-status")
-        self.assertContains(response, "TG.validation")
+        self.assertContains(response, "TG.validation = {")
         # The multiplier map must render with real data, not fall back empty
         bg = Background.objects.filter(
             property_name__in=char.allowed_backgrounds
@@ -107,4 +113,4 @@ class TestChargenValidationRendering(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "virtues-validation-status")
-        self.assertContains(response, "TG.validation")
+        self.assertContains(response, "TG.validation = {")

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -1,0 +1,40 @@
+"""Tests that chargen pages render the client-side validation hooks."""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from characters.models.core.human import Human
+from characters.tests.utils import human_setup
+
+
+class TestChargenValidationRendering(TestCase):
+    """The validation include and shared utilities must reach the page."""
+
+    def setUp(self):
+        human_setup()
+        self.owner = User.objects.create_user(username="owner", password="password")
+
+    def test_abilities_step_renders_validation(self):
+        char = Human.objects.create(
+            name="Ability Human", owner=self.owner, creation_status=2
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "abilities-validation-status")
+        self.assertContains(response, "TG.validation")
+
+    def test_backgrounds_step_renders_validation(self):
+        # The plain-Human step 3 template (core/human/chargen.html) has no
+        # backgrounds block (pre-existing gap), so exercise a flow whose
+        # template includes background_block/form.html: the Wraith human.
+        from characters.models.wraith.wtohuman import WtOHuman
+
+        char = WtOHuman.objects.create(
+            name="Background Human", owner=self.owner, creation_status=3
+        )
+        self.client.login(username="owner", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "backgrounds-validation-status")
+        self.assertContains(response, "TG.validation")

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -143,6 +143,7 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, f'"{bg.pk}": {bg.multiplier}')
 
     def test_virtues_step_renders_validation(self):
+        # creation_status 5 is the Vampire virtues step (VampireVirtuesView).
         char = Vampire.objects.create(
             name="Virtue Vampire", owner=self.owner, creation_status=5
         )

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -84,6 +84,19 @@ class TestChargenValidationRendering(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
 
+    def test_non_owner_non_staff_does_not_see_ability_form(self):
+        """The is_approved_user fix combines staff OR special-user; confirm it
+        did not widen access — a plain non-owner (not staff, not ST) still
+        gets the not-owner fallback, not the validation form."""
+        char = MtAHuman.objects.create(
+            name="Mage Ability Human", owner=self.owner, creation_status=2
+        )
+        other = User.objects.create_user(username="stranger", password="password")
+        self.client.login(username="stranger", password="password")
+        response = self.client.get(char.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "abilities-validation-status")
+
     def test_abilities_validation_absent_before_ability_step(self):
         """The ability validation include must not render outside the
         ability step (here, step 1), so it can never disable submit on a

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -100,14 +100,15 @@ class TestChargenValidationRendering(TestCase):
         """WtOHuman and MtAHuman work now that their ability views set
         is_approved_user (two #1459 instances fixed in this PR)."""
         for model, name in [(WtOHuman, "Wraith"), (MtAHuman, "Mage")]:
-            char = model.objects.create(
-                name=f"{name} Ability Human", owner=self.owner, creation_status=2
-            )
-            self.client.login(username="owner", password="password")
-            response = self.client.get(char.get_absolute_url())
-            self.assertEqual(response.status_code, 200)
-            self.assertContains(response, "abilities-validation-status")
-            self.assertContains(response, "TG.validation = {")
+            with self.subTest(gameline=name):
+                char = model.objects.create(
+                    name=f"{name} Ability Human", owner=self.owner, creation_status=2
+                )
+                self.client.login(username="owner", password="password")
+                response = self.client.get(char.get_absolute_url())
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, "abilities-validation-status")
+                self.assertContains(response, "TG.validation = {")
 
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no

--- a/characters/tests/views/core/test_chargen_validation.py
+++ b/characters/tests/views/core/test_chargen_validation.py
@@ -3,8 +3,15 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
 
+from django.urls import reverse
+
+from characters.models.changeling.ctdhuman import CtDHuman
 from characters.models.core.background_block import Background
 from characters.models.core.human import Human
+from characters.models.mage.mtahuman import MtAHuman
+from characters.models.vampire.vampire import Vampire
+from characters.models.vampire.vtmhuman import VtMHuman
+from characters.models.werewolf.wtahuman import WtAHuman
 from characters.models.wraith.wtohuman import WtOHuman
 from characters.tests.utils import human_setup
 
@@ -27,13 +34,6 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "TG.validation")
 
     def test_abilities_step_renders_validation_other_gameline(self):
-        # The shared include covers five gamelines; exercise a second flow
-        # whose view sets the target context vars independently. (Not
-        # WtOHuman: its ability view never sets is_approved_user, so that
-        # step renders the not-owner fallback even for owners — pre-existing
-        # bug noted on issue #1459.)
-        from characters.models.vampire.vtmhuman import VtMHuman
-
         char = VtMHuman.objects.create(
             name="Vampire Ability Human", owner=self.owner, creation_status=2
         )
@@ -44,8 +44,6 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "TG.validation")
 
     def test_abilities_step_renders_validation_third_gameline(self):
-        from characters.models.werewolf.wtahuman import WtAHuman
-
         char = WtAHuman.objects.create(
             name="Werewolf Ability Human", owner=self.owner, creation_status=2
         )
@@ -56,10 +54,6 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, "TG.validation")
 
     def test_abilities_step_renders_validation_fourth_gameline(self):
-        # Changeling human; MtAHuman is excluded for the same reason as
-        # WtOHuman — its ability view never sets is_approved_user (#1459).
-        from characters.models.changeling.ctdhuman import CtDHuman
-
         char = CtDHuman.objects.create(
             name="Changeling Ability Human", owner=self.owner, creation_status=2
         )
@@ -68,6 +62,19 @@ class TestChargenValidationRendering(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "abilities-validation-status")
         self.assertContains(response, "TG.validation")
+
+    def test_abilities_step_renders_validation_all_gamelines(self):
+        """WtOHuman and MtAHuman work now that their ability views set
+        is_approved_user (two #1459 instances fixed in this PR)."""
+        for model, name in [(WtOHuman, "Wraith"), (MtAHuman, "Mage")]:
+            char = model.objects.create(
+                name=f"{name} Ability Human", owner=self.owner, creation_status=2
+            )
+            self.client.login(username="owner", password="password")
+            response = self.client.get(char.get_absolute_url())
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, "abilities-validation-status")
+            self.assertContains(response, "TG.validation")
 
     def test_backgrounds_step_renders_validation(self):
         # The plain-Human step 3 template (core/human/chargen.html) has no
@@ -89,10 +96,6 @@ class TestChargenValidationRendering(TestCase):
         self.assertContains(response, f'"{bg.pk}": {bg.multiplier}')
 
     def test_virtues_step_renders_validation(self):
-        from django.urls import reverse
-
-        from characters.models.vampire.vampire import Vampire
-
         char = Vampire.objects.create(
             name="Virtue Vampire", owner=self.owner, creation_status=5
         )

--- a/characters/views/core/backgrounds.py
+++ b/characters/views/core/backgrounds.py
@@ -70,4 +70,13 @@ class HumanBackgroundsView(SpendFreebiesPermissionMixin, FormView):
             property_name__in=self.object.allowed_backgrounds
         )
         context["empty_form"] = empty_form
+        # Multiplier map for the client points counter. It must cover EVERY
+        # selectable background, not just the allowed set: the formset's
+        # add-row rebuilds empty_form with add_fields(), which resets the bg
+        # queryset to all backgrounds, so a dynamically added row can select
+        # one outside allowed_backgrounds and the server still applies its
+        # real multiplier. pk and multiplier are both integers.
+        context["background_multipliers"] = dict(
+            Background.objects.values_list("pk", "multiplier")
+        )
         return context

--- a/characters/views/core/backgrounds.py
+++ b/characters/views/core/backgrounds.py
@@ -1,3 +1,5 @@
+import json
+
 from django.shortcuts import get_object_or_404
 from django.views.generic import FormView
 
@@ -70,13 +72,14 @@ class HumanBackgroundsView(SpendFreebiesPermissionMixin, FormView):
             property_name__in=self.object.allowed_backgrounds
         )
         context["empty_form"] = empty_form
-        # Multiplier map for the client points counter. It must cover EVERY
-        # selectable background, not just the allowed set: the formset's
-        # add-row rebuilds empty_form with add_fields(), which resets the bg
-        # queryset to all backgrounds, so a dynamically added row can select
-        # one outside allowed_backgrounds and the server still applies its
-        # real multiplier. pk and multiplier are both integers.
-        context["background_multipliers"] = dict(
-            Background.objects.values_list("pk", "multiplier")
+        # Multiplier map (pk -> cost multiplier) for the client points counter.
+        # It must cover EVERY selectable background, not just the allowed set:
+        # the formset's add-row rebuilds empty_form with add_fields(), which
+        # resets the bg queryset to all backgrounds, so a dynamically added row
+        # can select one outside allowed_backgrounds and the server still
+        # applies its real multiplier. Rendered via json.dumps to avoid a
+        # hand-built template loop; pk/multiplier are integers (no XSS).
+        context["background_multipliers_json"] = json.dumps(
+            dict(Background.objects.values_list("pk", "multiplier"))
         )
         return context

--- a/characters/views/mage/mtahuman.py
+++ b/characters/views/mage/mtahuman.py
@@ -348,6 +348,7 @@ class MtAHumanAbilityView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff (see #1459), so without this the
         # owner sees the not-owner fallback instead of the ability form.
+        # TODO(#1459): consolidate into SpecialUserMixin.get_context_data
         context["is_approved_user"] = (
             getattr(self.request, "is_approved_user", False)
             or self.check_if_special_user(self.object, self.request.user)

--- a/characters/views/mage/mtahuman.py
+++ b/characters/views/mage/mtahuman.py
@@ -348,11 +348,7 @@ class MtAHumanAbilityView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff (see #1459), so without this the
         # owner sees the not-owner fallback instead of the ability form.
-        # TODO(#1459): consolidate into SpecialUserMixin.get_context_data
-        context["is_approved_user"] = (
-            getattr(self.request, "is_approved_user", False)
-            or self.check_if_special_user(self.object, self.request.user)
-        )
+        context["is_approved_user"] = self.get_is_approved_user(self.object)
         return context
 
     def form_valid(self, form):

--- a/characters/views/mage/mtahuman.py
+++ b/characters/views/mage/mtahuman.py
@@ -345,6 +345,12 @@ class MtAHumanAbilityView(SpecialUserMixin, UpdateView):
         context["primary"] = self.primary
         context["secondary"] = self.secondary
         context["tertiary"] = self.tertiary
+        # The chargen template gates on is_approved_user; the global context
+        # processor only sets it for staff (see #1459), so without this the
+        # owner sees the not-owner fallback instead of the ability form.
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
         return context
 
     def form_valid(self, form):

--- a/characters/views/mage/mtahuman.py
+++ b/characters/views/mage/mtahuman.py
@@ -348,8 +348,9 @@ class MtAHumanAbilityView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff (see #1459), so without this the
         # owner sees the not-owner fallback instead of the ability form.
-        context["is_approved_user"] = self.check_if_special_user(
-            self.object, self.request.user
+        context["is_approved_user"] = (
+            getattr(self.request, "is_approved_user", False)
+            or self.check_if_special_user(self.object, self.request.user)
         )
         return context
 

--- a/characters/views/vampire/vampire_chargen.py
+++ b/characters/views/vampire/vampire_chargen.py
@@ -215,11 +215,7 @@ class VampireVirtuesView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff, so without this the owner sees
         # the not-owner fallback instead of the virtues form.
-        # TODO(#1459): consolidate into SpecialUserMixin.get_context_data
-        context["is_approved_user"] = (
-            getattr(self.request, "is_approved_user", False)
-            or self.check_if_special_user(self.object, self.request.user)
-        )
+        context["is_approved_user"] = self.get_is_approved_user(self.object)
         return context
 
     def form_valid(self, form):

--- a/characters/views/vampire/vampire_chargen.py
+++ b/characters/views/vampire/vampire_chargen.py
@@ -215,8 +215,9 @@ class VampireVirtuesView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff, so without this the owner sees
         # the not-owner fallback instead of the virtues form.
-        context["is_approved_user"] = self.check_if_special_user(
-            self.object, self.request.user
+        context["is_approved_user"] = (
+            getattr(self.request, "is_approved_user", False)
+            or self.check_if_special_user(self.object, self.request.user)
         )
         return context
 

--- a/characters/views/vampire/vampire_chargen.py
+++ b/characters/views/vampire/vampire_chargen.py
@@ -212,6 +212,12 @@ class VampireVirtuesView(SpecialUserMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["uses_path"] = bool(self.object.path)
+        # The chargen template gates on is_approved_user; the global context
+        # processor only sets it for staff, so without this the owner sees
+        # the not-owner fallback instead of the virtues form.
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
         return context
 
     def form_valid(self, form):

--- a/characters/views/vampire/vampire_chargen.py
+++ b/characters/views/vampire/vampire_chargen.py
@@ -215,6 +215,7 @@ class VampireVirtuesView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff, so without this the owner sees
         # the not-owner fallback instead of the virtues form.
+        # TODO(#1459): consolidate into SpecialUserMixin.get_context_data
         context["is_approved_user"] = (
             getattr(self.request, "is_approved_user", False)
             or self.check_if_special_user(self.object, self.request.user)

--- a/characters/views/wraith/wtohuman.py
+++ b/characters/views/wraith/wtohuman.py
@@ -306,8 +306,9 @@ class WtOHumanAbilityView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff (see #1459), so without this the
         # owner sees the not-owner fallback instead of the ability form.
-        context["is_approved_user"] = self.check_if_special_user(
-            self.object, self.request.user
+        context["is_approved_user"] = (
+            getattr(self.request, "is_approved_user", False)
+            or self.check_if_special_user(self.object, self.request.user)
         )
         return context
 

--- a/characters/views/wraith/wtohuman.py
+++ b/characters/views/wraith/wtohuman.py
@@ -306,11 +306,7 @@ class WtOHumanAbilityView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff (see #1459), so without this the
         # owner sees the not-owner fallback instead of the ability form.
-        # TODO(#1459): consolidate into SpecialUserMixin.get_context_data
-        context["is_approved_user"] = (
-            getattr(self.request, "is_approved_user", False)
-            or self.check_if_special_user(self.object, self.request.user)
-        )
+        context["is_approved_user"] = self.get_is_approved_user(self.object)
         return context
 
     def form_valid(self, form):

--- a/characters/views/wraith/wtohuman.py
+++ b/characters/views/wraith/wtohuman.py
@@ -306,6 +306,7 @@ class WtOHumanAbilityView(SpecialUserMixin, UpdateView):
         # The chargen template gates on is_approved_user; the global context
         # processor only sets it for staff (see #1459), so without this the
         # owner sees the not-owner fallback instead of the ability form.
+        # TODO(#1459): consolidate into SpecialUserMixin.get_context_data
         context["is_approved_user"] = (
             getattr(self.request, "is_approved_user", False)
             or self.check_if_special_user(self.object, self.request.user)

--- a/characters/views/wraith/wtohuman.py
+++ b/characters/views/wraith/wtohuman.py
@@ -303,6 +303,12 @@ class WtOHumanAbilityView(SpecialUserMixin, UpdateView):
         context["primary"] = self.primary
         context["secondary"] = self.secondary
         context["tertiary"] = self.tertiary
+        # The chargen template gates on is_approved_user; the global context
+        # processor only sets it for staff (see #1459), so without this the
+        # owner sees the not-owner fallback instead of the ability form.
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
         return context
 
     def form_valid(self, form):

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -272,28 +272,8 @@ class SpecialUserMixin:
     - Any authenticated storyteller (ST)
     - Anyone if the object has no owner
 
-    Usage:
-        class MyView(SpecialUserMixin, DetailView):
-            def get_context_data(self, **kwargs):
-                context = super().get_context_data(**kwargs)
-                context['is_special'] = self.check_if_special_user(self.object, self.request.user)
-                return context
-
-    IMPORTANT: this mixin does NOT set ``is_approved_user`` in context.
-    The global context processor only sets that flag for staff, so any view
-    whose template gates on ``{% if is_approved_user %}`` must set it itself.
-    Combine the staff flag with the special-user check so neither audience is
-    excluded (a plain assignment of check_if_special_user would overwrite the
-    staff True with False for a staff user who is not the owner/ST):
-
-        context["is_approved_user"] = (
-            getattr(self.request, "is_approved_user", False)
-            or self.check_if_special_user(self.object, self.request.user)
-        )
-
-    Omitting this makes the template render the not-owner fallback even for
-    the owner. A base-class fix that sets the flag for all SpecialUserMixin
-    views is tracked in issue #1459.
+    Does not set ``is_approved_user`` (templates gating on it need staff OR
+    check_if_special_user); base-class fix tracked in #1459.
     """
 
     def check_if_special_user(self, obj, user):

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -278,6 +278,18 @@ class SpecialUserMixin:
                 context = super().get_context_data(**kwargs)
                 context['is_special'] = self.check_if_special_user(self.object, self.request.user)
                 return context
+
+    IMPORTANT: this mixin does NOT set ``is_approved_user`` in context.
+    The global context processor only sets that flag for staff, so any view
+    whose template gates on ``{% if is_approved_user %}`` must set it itself:
+
+        context["is_approved_user"] = self.check_if_special_user(
+            self.object, self.request.user
+        )
+
+    Omitting this makes the template render the not-owner fallback even for
+    the owner. A base-class fix that sets the flag for all SpecialUserMixin
+    views is tracked in issue #1459.
     """
 
     def check_if_special_user(self, obj, user):

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -272,9 +272,19 @@ class SpecialUserMixin:
     - Any authenticated storyteller (ST)
     - Anyone if the object has no owner
 
-    Does not set ``is_approved_user`` (templates gating on it need staff OR
-    check_if_special_user); base-class fix tracked in #1459.
+    Templates gating on ``is_approved_user`` should set it via
+    get_is_approved_user(); auto-setting it for all such views is in #1459.
     """
+
+    def get_is_approved_user(self, obj):
+        """is_approved_user value for templates: staff OR special-user access.
+
+        Combines the middleware/context-processor staff flag with the
+        per-object special-user check so neither audience is excluded.
+        """
+        return getattr(self.request, "is_approved_user", False) or (
+            self.check_if_special_user(obj, self.request.user)
+        )
 
     def check_if_special_user(self, obj, user):
         """

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -281,10 +281,14 @@ class SpecialUserMixin:
 
     IMPORTANT: this mixin does NOT set ``is_approved_user`` in context.
     The global context processor only sets that flag for staff, so any view
-    whose template gates on ``{% if is_approved_user %}`` must set it itself:
+    whose template gates on ``{% if is_approved_user %}`` must set it itself.
+    Combine the staff flag with the special-user check so neither audience is
+    excluded (a plain assignment of check_if_special_user would overwrite the
+    staff True with False for a staff user who is not the owner/ST):
 
-        context["is_approved_user"] = self.check_if_special_user(
-            self.object, self.request.user
+        context["is_approved_user"] = (
+            getattr(self.request, "is_approved_user", False)
+            or self.check_if_special_user(self.object, self.request.user)
         )
 
     Omitting this makes the template render the not-owner fallback even for

--- a/core/templates/core/form.html
+++ b/core/templates/core/form.html
@@ -137,7 +137,10 @@
                             btn.disabled = !enabled;
                         });
                     },
-                    /* Sum integer values of inputs/selects matching selector. */
+                    /* Sum integer values of inputs/selects matching selector.
+                       Status display only: parseInt truncates fractionals, so
+                       callers gating validity must reject non-integers
+                       separately rather than trust this total. */
                     sumFields: function(form, selector) {
                         if (!form) return 0;
                         var total = 0;

--- a/core/templates/core/form.html
+++ b/core/templates/core/form.html
@@ -121,7 +121,7 @@
                     setStatus: function(el, valid, message) {
                         if (!el) return;
                         el.textContent = message;
-                        el.style.color = valid ? '#28a745' : '#dc3545';
+                        el.style.color = valid ? 'var(--color-success, #28a745)' : 'var(--color-danger, #dc3545)';
                     },
                     /* Enable/disable the form's main submit button (not Back/Cancel). */
                     setSubmitEnabled: function(form, enabled) {

--- a/core/templates/core/form.html
+++ b/core/templates/core/form.html
@@ -114,6 +114,10 @@
             {% endblock buttons %}
 
             {% block form_scripts %}
+                {# Must stay inside the form, after the content blocks: step
+                   scripts render earlier in the document and reference
+                   TG.validation from DOMContentLoaded handlers, which fire
+                   after this block has been parsed. #}
                 <script>
                 window.TG = window.TG || {};
                 TG.validation = {

--- a/core/templates/core/form.html
+++ b/core/templates/core/form.html
@@ -112,6 +112,51 @@
                     </div>
                 </div>
             {% endblock buttons %}
+
+            {% block form_scripts %}
+                <script>
+                window.TG = window.TG || {};
+                TG.validation = {
+                    /* Set text and color (green/red) on a status element. */
+                    setStatus: function(el, valid, message) {
+                        if (!el) return;
+                        el.textContent = message;
+                        el.style.color = valid ? '#28a745' : '#dc3545';
+                    },
+                    /* Enable/disable the form's main submit button (not Back/Cancel). */
+                    setSubmitEnabled: function(form, enabled) {
+                        if (!form) return;
+                        var buttons = form.querySelectorAll(
+                            'button[type="submit"]:not([formaction]), input[type="submit"]:not([formaction])'
+                        );
+                        Array.prototype.forEach.call(buttons, function(btn) {
+                            btn.disabled = !enabled;
+                        });
+                    },
+                    /* Sum integer values of inputs/selects matching selector. */
+                    sumFields: function(form, selector) {
+                        if (!form) return 0;
+                        var total = 0;
+                        Array.prototype.forEach.call(form.querySelectorAll(selector), function(field) {
+                            var value = parseInt(field.value, 10);
+                            if (!isNaN(value)) total += value;
+                        });
+                        return total;
+                    },
+                    /* Count checked checkboxes matching selector.
+                       Not used yet; part of the shared API for upcoming
+                       chargen step validations (e.g. merit/flaw pickers). */
+                    countChecked: function(form, selector) {
+                        if (!form) return 0;
+                        var count = 0;
+                        Array.prototype.forEach.call(form.querySelectorAll(selector), function(box) {
+                            if (box.checked) count += 1;
+                        });
+                        return count;
+                    }
+                };
+                </script>
+            {% endblock form_scripts %}
         </form>
     </div>
 {% endblock content %}


### PR DESCRIPTION
Workstream B part 2: instant client-side feedback on chargen forms, Tasks 13–16.

**Stacked on #1456** (both touch `core/templates/core/form.html`); base is `claude/tender-clarke-85l81o-chargen-nav`. Re-target to `main` after #1456 merges.

## What changed
- **`TG.validation` shared utilities** (#1450) — vanilla-JS `setStatus`, `setSubmitEnabled`, `sumFields`, `countChecked` in a `{% block form_scripts %}` in the base form template. `setSubmitEnabled` skips buttons with a `formaction` attribute so disabling submit never locks out the chargen Back button from #1456. Step scripts initialize on `DOMContentLoaded` since they render earlier in the document than the utilities block.
- **Abilities validation** (#1451) — discovery found five structurally identical `ability_block_form.html` templates (vampire/werewolf/mage/wraith/changeling humans), all laying out rows of three `.dots` cells (Talents/Skills/Knowledges) with `primary`/`secondary`/`tertiary` in context. One shared include (`characters/core/ability_block/validation.html`) groups inputs by column, live-checks the sorted totals against the sorted targets (any order, matching the server rule), shows current distribution, and disables submit until valid. Applied to all five.
- **Backgrounds points counter** (#1452) — live remaining/over-budget status against `object.background_points`. Accounts for per-background cost multipliers (Enhancements, Sanctum, Totem cost 2/dot) via a pk→multiplier map rendered from the formset queryset; ignores deleted rows and the hidden `__prefix__` empty-form template. Counter only — submit stays enabled, matching the issue spec.
- **Virtues validation** (#1453) — Vampire chargen virtues step gets a live "X/7 dots" status summing only the *active* virtue inputs (inactive Conscience/Conviction and Self-Control/Instinct render as hidden inputs and are excluded, matching `VampireVirtuesView.form_valid`). **Demon:** `DemonVirtuesView` points at `characters/demon/demon/chargen.html`, which does not exist in the repo (the Demon chargen flow is incomplete upstream), so there is nothing to attach the script to — and its target is 6 dots, not 7 as the issue assumed. Left for when that template is created.

## Testing
Client-side JS, so primarily template-rendering regression coverage: full `characters.tests.views` suite passes (OK, 20 pre-existing skips), including the vampire and core chargen page renders.

Closes #1450, closes #1451, closes #1452, closes #1453

https://claude.ai/code/session_01L51YqDgXSKKhJaYiMkorHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01L51YqDgXSKKhJaYiMkorHW)_